### PR TITLE
feat: add Oh My Pi support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,18 +42,9 @@ Please also:
 
 ## New Provider Policy
 
-Pull requests that add a new provider are not accepted.
+Provider additions must include focused tests and a clear explanation of the runtime, permission, history, and settings behavior they introduce.
 
-This is a maintenance and product-quality boundary:
-
-1. I am the sole maintainer of this project and remain responsible for every integration after it is merged. If I do not use a provider myself, I cannot test and maintain its integration responsibly over time.
-2. Integrated providers must offer a broadly consistent feature set and user experience. Past attempts have shown that partial integrations are difficult to bring to parity and keep reliable.
-3. Some provider CLIs do not currently expose the capabilities required for a complete integration. For example, Antigravity CLI does not expose ACP or a comparable integration protocol, and Cursor CLI does not allow the system prompt to be customized fully.
-4. Integrating a separate CLI from every model vendor is not sustainable. OpenCode and Pi already support multiple model vendors through API configuration. Codex and Claude Code can also use alternative model endpoints through configuration. Inside an Obsidian vault, switching the underlying harness usually provides limited additional value compared with the ongoing integration and maintenance cost.
-
-You may open an issue to describe an unmet provider-related use case, but please do not submit a new-provider implementation. An issue does not imply that the provider will be added.
-
-Contributions that improve an existing provider are welcome when they follow the focused pull request requirements above and preserve the expected cross-provider experience.
+Provider contributions should preserve provider isolation, use provider-native behavior where possible, and document any capabilities that are intentionally unavailable. Changes that improve an existing provider should follow the same focused pull request requirements.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@
 
 An Obsidian plugin that embeds AI coding agents (Claude Code, Codex, Grok, Opencode, Pi, and more to come) in your vault. Your vault becomes the agent's working directory — file read/write, search, bash, and multi-step workflows all work out of the box.
 
+> This repository is a fork of [YishenTu/claudian](https://github.com/YishenTu/claudian), maintained as an OMP-focused variant. It keeps the upstream providers and adds first-class Oh My Pi support through ACP.
+
+## What This Fork Adds
+
+- **OMP ACP provider** — Run Oh My Pi (OMP) directly in the Claudian chat sidebar, with OMP-native model discovery and selection.
+- **OMP-aware context** — The current note and editor selection are included with each OMP request; image attachments are supported as well.
+- **Useful session feedback** — OMP streams plan/thinking output, reports live context-window usage, and restores the context meter after restarting Obsidian.
+- **Simple OMP permissions** — The shared **Safe / YOLO** control determines whether OMP tool operations ask for confirmation; OMP does not add a separate Plan mode.
+- **OMP visual identity** — OMP has its own cyan accent color instead of inheriting Claude's styling.
+
 ## Features & Usage
 
 Open the chat sidebar from the ribbon icon or command palette. Select text and use the hotkey for inline edit. Everything works like your familiar coding agent, Claude Code, Codex, Grok, Opencode, and Pi — talk to the agent, and it reads, writes, edits, and searches files in your vault.
@@ -42,6 +52,7 @@ Open the chat sidebar from the ribbon icon or command palette. Select text and u
   - [Codex CLI](https://github.com/openai/codex)
   - [Grok Build](https://github.com/xai-org/grok-build)
   - [OpenCode](https://github.com/anomalyco/opencode)
+  - Oh My Pi (OMP, via ACP)
   - [Pi](https://github.com/earendil-works/pi)
 - A compatible subscription or API provider, such as [OpenRouter](https://openrouter.ai/docs/guides/guides/claude-code-integration), [Kimi](https://platform.kimi.ai/docs/guide/claude-code-kimi), [GLM](https://docs.z.ai/devpack/tool/claude), or [DeepSeek](https://api-docs.deepseek.com/quick_start/agent_integrations/claude_code).
 - Obsidian v1.7.2+
@@ -62,7 +73,7 @@ Or install directly from the [community plugin page](https://community.obsidian.
 1. Clone this repository into your vault's plugins folder:
    ```bash
    cd /path/to/vault/.obsidian/plugins
-   git clone https://github.com/YishenTu/claudian.git
+   git clone https://github.com/lee259/claudian.git
    cd claudian
    ```
 
@@ -148,6 +159,7 @@ src/
 │   ├── codex/                   # Codex app-server adaptor, JSON-RPC transport, JSONL history
 │   ├── grok/                    # Grok Build ACP adaptor, native history, models, and tools
 │   ├── opencode/                # Opencode adaptor
+│   ├── omp/                     # Oh My Pi ACP adaptor, model discovery, and history
 │   ├── pi/                      # Pi RPC adaptor, model discovery, JSONL history
 │   └── acp/                     # Agent Client Protocol shared transport
 ├── features/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Claudian is an Obsidian plugin that embeds coding agents in your vault. Agents c
   - [Codex CLI](https://github.com/openai/codex)
   - [Grok Build](https://github.com/xai-org/grok-build)
   - [OpenCode](https://github.com/anomalyco/opencode)
-  - Oh My Pi (OMP, via ACP)
+  - [Oh My Pi (OMP)](https://github.com/can1357/oh-my-pi) via ACP
   - [Pi](https://github.com/earendil-works/pi)
 - A compatible subscription or API provider.
 - Obsidian v1.7.2+ on macOS, Linux, or Windows.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Claudian is an Obsidian plugin that embeds coding agents in your vault. Agents c
   - [Codex CLI](https://github.com/openai/codex)
   - [Grok Build](https://github.com/xai-org/grok-build)
   - [OpenCode](https://github.com/anomalyco/opencode)
-  - [Oh My Pi (OMP)](https://github.com/can1357/oh-my-pi) via ACP
+  - [Oh My Pi (OMP)](https://github.com/can1357/oh-my-pi)
   - [Pi](https://github.com/earendil-works/pi)
 - A compatible subscription or API provider.
 - Obsidian v1.7.2+ on macOS, Linux, or Windows.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Claudian
+# Oh My Claudian
 
 ![Preview](assets/Preview.png)
 
-Claudian is an Obsidian plugin that embeds coding agents in your vault. Agents can read, write, search, run commands, and carry out multi-step workflows in the vault working directory.
+Oh My Claudian is an Obsidian plugin that embeds coding agents in your vault. Agents can read, write, search, run commands, and carry out multi-step workflows in the vault working directory.
 
 > This repository is based on [YishenTu/claudian](https://github.com/YishenTu/claudian) and adds Oh My Pi (OMP) support through ACP.
 
@@ -34,8 +34,8 @@ Claudian is an Obsidian plugin that embeds coding agents in your vault. Agents c
 
 ```bash
 cd /path/to/vault/.obsidian/plugins
-git clone https://github.com/lee259/claudian.git
-cd claudian
+git clone https://github.com/lee259/oh-my-claudian.git
+cd oh-my-claudian
 npm install
 npm run build
 ```
@@ -54,11 +54,11 @@ npm run test
 
 ## Privacy
 
-Your input, attachments, and tool results are sent only to the provider you select: Claude, Codex, Grok, OMP, OpenCode, Pi, or their configured model providers. Claudian does not send telemetry. Network activity is limited to explicit provider work and configured MCP endpoints.
+Your input, attachments, and tool results are sent only to the provider you select: Claude, Codex, Grok, OMP, OpenCode, Pi, or their configured model providers. Oh My Claudian does not send telemetry. Network activity is limited to explicit provider work and configured MCP endpoints.
 
 ## Troubleshooting
 
-If a provider CLI is not found, first leave its configured path blank so Claudian can auto-detect it. If detection fails, set the executable path in the provider settings and ensure its runtime is available to Obsidian's `PATH`.
+If a provider CLI is not found, first leave its configured path blank so Oh My Claudian can auto-detect it. If detection fails, set the executable path in the provider settings and ensure its runtime is available to Obsidian's `PATH`.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -17,15 +17,11 @@
 
 An Obsidian plugin that embeds AI coding agents (Claude Code, Codex, Grok, Opencode, Pi, and more to come) in your vault. Your vault becomes the agent's working directory — file read/write, search, bash, and multi-step workflows all work out of the box.
 
-> This repository is a fork of [YishenTu/claudian](https://github.com/YishenTu/claudian), maintained as an OMP-focused variant. It keeps the upstream providers and adds first-class Oh My Pi support through ACP.
+> This repository is a fork of [YishenTu/claudian](https://github.com/YishenTu/claudian). In addition to the upstream providers, it adds Oh My Pi (OMP) support through ACP.
 
 ## What This Fork Adds
 
-- **OMP ACP provider** — Run Oh My Pi (OMP) directly in the Claudian chat sidebar, with OMP-native model discovery and selection.
-- **OMP-aware context** — The current note and editor selection are included with each OMP request; image attachments are supported as well.
-- **Useful session feedback** — OMP streams plan/thinking output, reports live context-window usage, and restores the context meter after restarting Obsidian.
-- **Simple OMP permissions** — The shared **Safe / YOLO** control determines whether OMP tool operations ask for confirmation; OMP does not add a separate Plan mode.
-- **OMP visual identity** — OMP has its own cyan accent color instead of inheriting Claude's styling.
+- **Oh My Pi (OMP)** — Adds an ACP-backed OMP provider to the chat sidebar, including model discovery and selection.
 
 ## Features & Usage
 

--- a/README.md
+++ b/README.md
@@ -1,200 +1,80 @@
 # Claudian
 
-<p>
-  <a href="https://trendshift.io/repositories/21115?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-21115">
-    <img align="right" src="https://trendshift.io/api/badge/repositories/21115" alt="Claudian on Trendshift" width="180">
-  </a>
-  <img src="https://img.shields.io/github/stars/YishenTu/claudian" alt="GitHub stars" vspace="10">
-  <a href="https://community.obsidian.md/plugins/realclaudian">
-    <img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fobsidianmd%2Fobsidian-releases%2Fmaster%2Fcommunity-plugin-stats.json&amp;query=%24%5B%22realclaudian%22%5D.downloads&amp;label=downloads&amp;logo=obsidian&amp;color=7C3AED" alt="Obsidian downloads" vspace="10">
-  </a>
-  <img src="https://img.shields.io/github/v/release/YishenTu/claudian" alt="GitHub release" vspace="10">
-  <img src="https://img.shields.io/github/license/YishenTu/claudian" alt="License" vspace="10">
-  <br clear="both">
-</p>
-
 ![Preview](assets/Preview.png)
 
-An Obsidian plugin that embeds AI coding agents (Claude Code, Codex, Grok, Opencode, Pi, and more to come) in your vault. Your vault becomes the agent's working directory — file read/write, search, bash, and multi-step workflows all work out of the box.
+Claudian is an Obsidian plugin that embeds coding agents in your vault. Agents can read, write, search, run commands, and carry out multi-step workflows in the vault working directory.
 
-> This repository is a fork of [YishenTu/claudian](https://github.com/YishenTu/claudian). In addition to the upstream providers, it adds Oh My Pi (OMP) support through ACP.
+> This repository is based on [YishenTu/claudian](https://github.com/YishenTu/claudian) and adds Oh My Pi (OMP) support through ACP.
 
-## What This Fork Adds
+## Added in This Repository
 
-- **Oh My Pi (OMP)** — Adds an ACP-backed OMP provider to the chat sidebar, including model discovery and selection.
+- **Oh My Pi (OMP)** — An ACP-backed OMP provider with model discovery and selection in the chat sidebar.
 
-## Features & Usage
+## Features
 
-Open the chat sidebar from the ribbon icon or command palette. Select text and use the hotkey for inline edit. Everything works like your familiar coding agent, Claude Code, Codex, Grok, Opencode, and Pi — talk to the agent, and it reads, writes, edits, and searches files in your vault.
-
-**Inline Edit** — Select text or start at the cursor position + hotkey to edit directly in notes with word-level diff preview.
-
-**Slash Commands & Skills** — Type `/` or `$` for reusable prompt templates or Skills from user- and vault-level scopes.
-
-**`@mention`** - Type `@` to mention anything you want the agent to work with, vault files, subagents, MCP servers, or files in external directories.
-
-**Plan Mode** — Toggle via `Shift+Tab`. The agent explores and designs before implementing, then presents a plan for approval.
-
-**Instruction Mode (`#`)** — Refined custom instructions added from the chat input.
-
-**MCP Servers** — Connect external tools via Model Context Protocol (stdio, SSE, HTTP). Claude manages vault MCP in-app; Codex uses its own CLI-managed MCP configuration.
-
-**Multi-Tab & Conversations** — Multiple chat tabs, conversation history, fork, resume, and compact.
+- Sidebar chat, multiple tabs, conversation history, fork, resume, and compact.
+- Inline edits with word-level diff preview.
+- Slash commands, skills, `@` mentions, and instruction mode.
+- Provider-specific planning, permissions, reasoning controls, and model selection.
+- MCP support where available from the selected provider.
 
 ## Requirements
 
-- At least one of the following harnesses:
+- At least one supported harness:
   - [Claude Code CLI](https://code.claude.com/docs/en/overview)
   - [Codex CLI](https://github.com/openai/codex)
   - [Grok Build](https://github.com/xai-org/grok-build)
   - [OpenCode](https://github.com/anomalyco/opencode)
   - Oh My Pi (OMP, via ACP)
   - [Pi](https://github.com/earendil-works/pi)
-- A compatible subscription or API provider, such as [OpenRouter](https://openrouter.ai/docs/guides/guides/claude-code-integration), [Kimi](https://platform.kimi.ai/docs/guide/claude-code-kimi), [GLM](https://docs.z.ai/devpack/tool/claude), or [DeepSeek](https://api-docs.deepseek.com/quick_start/agent_integrations/claude_code).
-- Obsidian v1.7.2+
-- Desktop only (macOS, Linux, Windows)
+- A compatible subscription or API provider.
+- Obsidian v1.7.2+ on macOS, Linux, or Windows.
 
-## Installation
-
-### From Obsidian Community Plugins (recommended)
-
-1. Open Obsidian → Settings → Community plugins → Browse
-2. Search for "Claudian" and click Install
-3. Enable the plugin
-
-Or install directly from the [community plugin page](https://community.obsidian.md/plugins/realclaudian).
-
-### From source (development)
-
-1. Clone this repository into your vault's plugins folder:
-   ```bash
-   cd /path/to/vault/.obsidian/plugins
-   git clone https://github.com/lee259/claudian.git
-   cd claudian
-   ```
-
-2. Install dependencies and build:
-   ```bash
-   npm install
-   npm run build
-   ```
-
-3. Enable the plugin in Obsidian:
-   - Settings → Community plugins → Enable "Claudian"
-
-### Development
+## Installation from Source
 
 ```bash
-# Watch mode
-npm run dev
-
-# Production build
+cd /path/to/vault/.obsidian/plugins
+git clone https://github.com/lee259/claudian.git
+cd claudian
+npm install
 npm run build
 ```
 
-## Privacy & Data Use
+Then enable the plugin in Obsidian under **Settings → Community plugins**.
 
-- **Sent to API**: Your input, attached files, images, and tool call outputs. Depending on the selected provider, data is sent to Anthropic (Claude), OpenAI (Codex), xAI (Grok), or the providers configured in OpenCode or Pi. The destination can be configured through provider settings and environment variables.
-- **No telemetry or unsolicited background activity**: Claudian does not run telemetry beacons. UI polling timers read local Obsidian/editor selection state only. Network activity is limited to explicit provider runtime work, configured MCP endpoints, and provider SDK/CLI calls needed to answer your requests.
+## Development
+
+```bash
+npm run dev
+npm run build
+npm run typecheck
+npm run lint
+npm run test
+```
+
+## Privacy
+
+Your input, attachments, and tool results are sent only to the provider you select: Claude, Codex, Grok, OMP, OpenCode, Pi, or their configured model providers. Claudian does not send telemetry. Network activity is limited to explicit provider work and configured MCP endpoints.
 
 ## Troubleshooting
 
-The following sections use Claude Code as an example.
-
-### Provider CLI not found
-
-If Claudian cannot auto-detect a provider CLI, verify that the CLI is installed and available to GUI applications through PATH. Typical errors include `spawn claude ENOENT` and `Claude CLI not found`. This issue is common with Node version managers (nvm, fnm, volta).
-
-Leave the CLI path setting empty first so Claudian can auto-detect the CLI. If auto-detection fails, find the executable path and set it in Settings → Advanced → Claude CLI path.
-
-| Platform | Command | Example Path |
-|----------|---------|--------------|
-| macOS/Linux | `which claude` | `/Users/you/.volta/bin/claude` |
-| Windows (native) | `where.exe claude` | `C:\Users\you\AppData\Local\Claude\claude.exe` |
-| Windows (npm) | `npm root -g` | `{root}\@anthropic-ai\claude-code\cli-wrapper.cjs` |
-
-> **Note**: On Windows, avoid `.cmd` and `.ps1` wrappers. Use `claude.exe` for native installs, or `cli-wrapper.cjs` for package-manager installs. `cli.js` is only a legacy fallback for older Claude Code npm packages.
-
-**Alternative**: Add your Node.js bin directory to PATH in Settings → Environment → Custom variables.
-
-### npm CLI and Node.js not in the same directory
-
-When using an npm-installed provider CLI, make sure its executable and Node.js are available from the same environment. Check their paths:
-
-```bash
-dirname $(which claude)
-dirname $(which node)
-```
-
-If the paths differ, GUI apps like Obsidian may not find Node.js.
-
-Either:
-
-1. Install the native binary (recommended).
-2. Add the Node.js path in Settings → Environment: `PATH=/path/to/node/bin`.
-
-### More help
-
-For provider-specific installation and configuration guidance, refer to the provider documentation linked in the [Requirements](#requirements) section. If you have a feature request or run into a bug, please [submit a GitHub issue](https://github.com/YishenTu/claudian/issues).
+If a provider CLI is not found, first leave its configured path blank so Claudian can auto-detect it. If detection fails, set the executable path in the provider settings and ensure its runtime is available to Obsidian's `PATH`.
 
 ## Architecture
 
-```
+```text
 src/
-├── main.ts                      # Plugin entry point
-├── app/                         # Shared defaults and plugin-level storage
-├── core/                        # Provider-neutral runtime, registry, and type contracts
-│   ├── runtime/                 # ChatRuntime interface and approval types
-│   ├── providers/               # Provider registry and workspace services
-│   ├── auxiliary/               # Shared provider auxiliary services
-│   ├── bootstrap/               # Plugin bootstrap wiring
-│   ├── security/                # Approval utilities
-│   └── ...                      # commands, mcp, prompt, storage, tools, types
-├── providers/
-│   ├── claude/                  # Claude SDK adaptor, prompt encoding, storage, MCP, plugins
-│   ├── codex/                   # Codex app-server adaptor, JSON-RPC transport, JSONL history
-│   ├── grok/                    # Grok Build ACP adaptor, native history, models, and tools
-│   ├── opencode/                # Opencode adaptor
-│   ├── omp/                     # Oh My Pi ACP adaptor, model discovery, and history
-│   ├── pi/                      # Pi RPC adaptor, model discovery, JSONL history
-│   └── acp/                     # Agent Client Protocol shared transport
-├── features/
-│   ├── chat/                    # Sidebar chat: tabs, controllers, renderers
-│   ├── inline-edit/             # Inline edit modal and provider-backed edit services
-│   └── settings/                # Settings shell with provider tabs
-├── shared/                      # Reusable UI components and modals
-├── i18n/                        # Internationalization (10 locales)
-├── types/                       # Shared ambient types
-├── utils/                       # Cross-cutting utilities
-└── style/                       # Modular CSS
+├── app/          # Application services and persistence
+├── core/         # Provider-neutral contracts and runtime
+├── providers/    # Provider adaptors, including ACP and OMP
+├── features/     # Chat, inline edit, and settings UI
+├── shared/       # Reusable UI components
+└── style/        # Modular CSS
 ```
-
-## Star History
-
-<a href="https://www.star-history.com/?repos=YishenTu%2Fclaudian&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=YishenTu/claudian&type=date&theme=dark&legend=top-left&sealed_token=UAS9n3qO4GyhCCkOr9kcAl7msVtDEz-DoQTkpFuPrAELxMEK9PQWj9zG566afbx0CkF5OoIbLRkxiDIoMRCK5Q-HXbLUiimg1lT8wKDdcc_eP48_EodHFrR6UtY8jS7Mzik4lLd_sY8oVj2I42lISFB1tSlr4gnXwOCNwtTn6iQakbru7yKPIO3uVYpP" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=YishenTu/claudian&type=date&legend=top-left&sealed_token=UAS9n3qO4GyhCCkOr9kcAl7msVtDEz-DoQTkpFuPrAELxMEK9PQWj9zG566afbx0CkF5OoIbLRkxiDIoMRCK5Q-HXbLUiimg1lT8wKDdcc_eP48_EodHFrR6UtY8jS7Mzik4lLd_sY8oVj2I42lISFB1tSlr4gnXwOCNwtTn6iQakbru7yKPIO3uVYpP" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=YishenTu/claudian&type=date&legend=top-left&sealed_token=UAS9n3qO4GyhCCkOr9kcAl7msVtDEz-DoQTkpFuPrAELxMEK9PQWj9zG566afbx0CkF5OoIbLRkxiDIoMRCK5Q-HXbLUiimg1lT8wKDdcc_eP48_EodHFrR6UtY8jS7Mzik4lLd_sY8oVj2I42lISFB1tSlr4gnXwOCNwtTn6iQakbru7yKPIO3uVYpP" />
- </picture>
-</a>
-
-## Sponsorship
-
-### Ke Holdings Inc. (BEIKE)
-
-<img src="assets/sponsors/MOMA.png" alt="MOMA" width="90%">
-
-Claudian is proudly sponsored by Ke Holdings Inc. (BEIKE) and the MOMA team. Their support helps Claudian continue to
-improve through ongoing development and maintenance.
-
-> Want to support Claudian or appear here? Contact me: [tysk01213@gmail.com](mailto:tysk01213@gmail.com).
 
 ## Contributing
 
-Issues and focused pull requests are welcome. Issues are the preferred starting point: describe the problem, reproduction steps, and environment clearly so it can be investigated.
-
-Before opening a pull request, please read the [contribution guide](CONTRIBUTING.md). Pull requests must explain the problem, the proposed solution, why the approach is appropriate, and how the change was validated. Pull requests that add a new provider are not accepted; the guide explains this maintenance and product-quality boundary in detail.
+Issues and focused pull requests are welcome. Please describe the problem, reproduction steps, proposed solution, and validation.
 
 ## License
 

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -11,6 +11,7 @@ import {
   rmSync,
 } from 'fs';
 import rendererSafeUnrefHelpers from './scripts/rendererSafeUnref.js';
+import { resolveObsidianPluginPath } from './scripts/obsidianPluginPath.mjs';
 
 const {
   findUnsafeTimerUnrefSites,
@@ -131,8 +132,9 @@ function createPatchRendererUnsafeUnref(outputPaths) {
 
 // Obsidian plugin folder path (set via OBSIDIAN_VAULT env var or .env.local)
 const OBSIDIAN_VAULT = process.env.OBSIDIAN_VAULT;
+const PLUGIN_MANIFEST = JSON.parse(readFileSync('manifest.json', 'utf-8'));
 const OBSIDIAN_PLUGIN_PATH = OBSIDIAN_VAULT && existsSync(OBSIDIAN_VAULT)
-  ? path.join(OBSIDIAN_VAULT, '.obsidian', 'plugins', 'claudian')
+  ? resolveObsidianPluginPath(OBSIDIAN_VAULT, PLUGIN_MANIFEST)
   : null;
 
 // Plugin to copy built files to Obsidian plugin folder

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
-  "id": "realclaudian",
-  "name": "Claudian",
+  "id": "oh-my-claudian",
+  "name": "Oh My Claudian",
   "version": "2.0.44",
   "minAppVersion": "1.7.2",
-  "description": "Embeds Claude Code, Codex, and other coding agents as AI collaborators in your vault. Your vault becomes their working directory, giving them capabilities for file reads and writes, search, bash commands, and multi-step workflows.",
-  "author": "Yishen Tu",
-  "authorUrl": "https://github.com/YishenTu",
+  "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
+  "author": "Lee",
+  "authorUrl": "https://github.com/lee259",
   "isDesktopOnly": true
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.0.44",
+  "version": "2.1.0",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "claudian",
+  "name": "oh-my-claudian",
   "version": "2.0.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "claudian",
+      "name": "oh-my-claudian",
       "version": "2.0.44",
       "hasInstallScript": true,
       "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-claudian",
-  "version": "2.0.44",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-claudian",
-      "version": "2.0.44",
+      "version": "2.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claudian",
-  "version": "2.0.44",
+  "version": "2.1.0",
   "description": "Coding agents embedded in an Obsidian sidebar, including Oh My Pi support",
   "main": "main.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "claudian",
+  "name": "oh-my-claudian",
   "version": "2.0.44",
-  "description": "Claudian - Claude Code embedded in Obsidian sidebar",
+  "description": "Coding agents embedded in an Obsidian sidebar, including Oh My Pi support",
   "main": "main.js",
   "engines": {
     "node": ">=24 <25"
@@ -30,7 +30,7 @@
     "productivity",
     "ide"
   ],
-  "author": "Yishen Tu",
+  "author": "Lee",
   "license": "MIT",
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/scripts/obsidianPluginPath.mjs
+++ b/scripts/obsidianPluginPath.mjs
@@ -1,0 +1,7 @@
+import path from 'node:path';
+
+export function resolveObsidianPluginPath(vaultPath, manifest) {
+  const pluginId = typeof manifest?.id === 'string' ? manifest.id.trim() : '';
+  if (!vaultPath || !pluginId) return null;
+  return path.join(vaultPath, '.obsidian', 'plugins', pluginId);
+}

--- a/scripts/obsidianPluginPath.test.mjs
+++ b/scripts/obsidianPluginPath.test.mjs
@@ -5,7 +5,7 @@ import { resolveObsidianPluginPath } from './obsidianPluginPath.mjs';
 
 test('resolves the development plugin folder from the manifest id', () => {
   assert.equal(
-    resolveObsidianPluginPath('/vault', { id: 'realclaudian' }),
-    '/vault/.obsidian/plugins/realclaudian',
+    resolveObsidianPluginPath('/vault', { id: 'oh-my-claudian' }),
+    '/vault/.obsidian/plugins/oh-my-claudian',
   );
 });

--- a/scripts/obsidianPluginPath.test.mjs
+++ b/scripts/obsidianPluginPath.test.mjs
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { resolveObsidianPluginPath } from './obsidianPluginPath.mjs';
+
+test('resolves the development plugin folder from the manifest id', () => {
+  assert.equal(
+    resolveObsidianPluginPath('/vault', { id: 'realclaudian' }),
+    '/vault/.obsidian/plugins/realclaudian',
+  );
+});

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -18,6 +18,7 @@ import type {
   SlashCommand,
   SubagentInfo,
   ToolCallInfo,
+  UsageInfo,
 } from '../types';
 import type { ProviderId } from '../types/provider';
 import type { ProviderCommandCatalog } from './commands/ProviderCommandCatalog';
@@ -288,6 +289,9 @@ export interface ProviderChatUIConfig {
 
   /** Default reasoning value for the model. */
   getDefaultReasoningValue(model: string, settings: Record<string, unknown>): string;
+
+  /** Optional provider-owned context snapshot for a restored conversation without usage data. */
+  getInitialUsage?(model: string, settings: Record<string, unknown>): UsageInfo | null;
 
   /** Context window size in tokens. */
   getContextWindowSize(

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -5,7 +5,7 @@ import type {
   ChatRewindMode,
 } from '../../../core/execution';
 import type { TitleGenerationService } from '../../../core/providers/types';
-import type { ChatMessage, Conversation, ProviderId } from '../../../core/types';
+import type { ChatMessage, Conversation, ProviderId, UsageInfo } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
 import { confirm } from '../../../shared/modals/ConfirmModal';
 import { extractUserDisplayContent } from '../../../utils/context';
@@ -71,6 +71,7 @@ export interface ConversationControllerDeps {
   ensureExecutionInitialized?: () => Promise<boolean>;
   getProviderId?: () => ProviderId;
   getSelectedModel?: () => string | null;
+  getInitialUsage?: (providerId: ProviderId, model: string) => UsageInfo | null;
   ensureExecutionForConversation?: (conversation: Conversation | null) => Promise<void>;
   dismissPendingInlinePrompts?: () => void;
   awaitBackgroundWork?: () => Promise<void>;
@@ -586,7 +587,12 @@ export class ConversationController {
 
     state.currentConversationId = conversation.id;
     state.messages = [...conversation.messages];
-    state.usage = conversation.usage ?? null;
+    const providerId = conversation.providerId ?? this.deps.getProviderId?.();
+    const model = conversation.selectedModel ?? this.deps.getSelectedModel?.() ?? '';
+    state.usage = conversation.usage
+      ?? (providerId
+        ? this.deps.getInitialUsage?.(providerId, model) ?? null
+        : null);
     state.autoScrollEnabled = plugin.settings.enableAutoScroll ?? true;
     state.hasPendingConversationSave = false;
 

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -1858,6 +1858,9 @@ export function initializeTabControllers(
       ensureExecutionInitialized,
       getProviderId: () => getTabProviderId(tab, plugin),
       getSelectedModel: () => getTabSelectedModel(tab, plugin),
+      getInitialUsage: (providerId, model) => ProviderRegistry
+        .getChatUIConfig(providerId)
+        .getInitialUsage?.(model, plugin.settings) ?? null,
       dismissPendingInlinePrompts: () => tab.controllers.inputController?.dismissPendingApproval(),
       awaitBackgroundWork: () => tab.session.awaitBackgroundWork(),
       isDisposed: () => tab.lifecycleState === 'closing',

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -1471,6 +1471,7 @@ export function initializeTabUI(
     onTodosChanged: (todos) => tab.ui.statusPanel?.updateTodos(todos),
     onAutoScrollChanged: () => tab.ui.navigationSidebar?.updateVisibility(),
   };
+  tab.ui.contextUsageMeter?.update(state.usage);
 
   // ResizeObserver to detect overflow changes (e.g., content growth)
   const resizeObserver = new ResizeObserver(() => {

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -1227,7 +1227,7 @@ export class ContextUsageMeter {
   }
 
   update(usage: UsageInfo | null): void {
-    if (!usage || usage.contextTokens <= 0) {
+    if (!usage || usage.contextWindow <= 0) {
       this.container.addClass('claudian-hidden');
       return;
     }

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -457,7 +457,6 @@ export class PermissionToggle {
     const canShowPlan = Boolean(planValue) && capabilities.supportsPlanMode;
 
     if (canShowPlan && planValue && mode === planValue) {
-      this.toggleEl.addClass('claudian-hidden');
       this.labelEl.setText(planLabel);
       this.labelEl.addClass('plan-active');
     } else {
@@ -478,9 +477,13 @@ export class PermissionToggle {
     if (!toggleConfig) return;
 
     const current = this.callbacks.getSettings().permissionMode;
-    const newMode = current === toggleConfig.activeValue
-      ? toggleConfig.inactiveValue
-      : toggleConfig.activeValue;
+    const canCyclePlan = Boolean(toggleConfig.planValue)
+      && this.callbacks.getCapabilities().supportsPlanMode;
+    const newMode = current === toggleConfig.inactiveValue
+      ? toggleConfig.activeValue
+      : current === toggleConfig.activeValue && canCyclePlan
+        ? toggleConfig.planValue!
+        : toggleConfig.inactiveValue;
     await this.callbacks.onPermissionModeChange(newMode);
     this.updateDisplay();
   }

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -451,7 +451,7 @@ export class PermissionToggle {
     }
 
     this.container.removeClass('claudian-hidden');
-    const mode = this.callbacks.getSettings().permissionMode;
+    const mode = this.getCurrentMode();
     const planValue = toggleConfig.planValue;
     const planLabel = toggleConfig.planLabel ?? 'PLAN';
     const canShowPlan = Boolean(planValue) && capabilities.supportsPlanMode;
@@ -476,7 +476,7 @@ export class PermissionToggle {
     const toggleConfig = this.getToggleConfig();
     if (!toggleConfig) return;
 
-    const current = this.callbacks.getSettings().permissionMode;
+    const current = this.getCurrentMode();
     const canCyclePlan = Boolean(toggleConfig.planValue)
       && this.callbacks.getCapabilities().supportsPlanMode;
     const newMode = current === toggleConfig.inactiveValue
@@ -486,6 +486,12 @@ export class PermissionToggle {
         : toggleConfig.inactiveValue;
     await this.callbacks.onPermissionModeChange(newMode);
     this.updateDisplay();
+  }
+
+  private getCurrentMode(): string {
+    const settings = this.callbacks.getSettings();
+    return this.callbacks.getUIConfig().resolvePermissionMode?.(settings)
+      ?? settings.permissionMode;
   }
 }
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -72,7 +72,7 @@
     }
   },
   "settings": {
-    "title": "Claudian Einstellungen",
+    "title": "Oh My Claudian Einstellungen",
     "tabs": {
       "general": "Allgemein",
       "claude": "Claude",
@@ -86,7 +86,7 @@
     "models": "Modelle",
     "experimental": "Experimentell",
     "userName": {
-      "name": "Wie soll Claudian dich nennen?",
+      "name": "Wie soll Oh My Claudian dich nennen?",
       "desc": "Dein Name für personalisierte Begrüßungen (leer lassen für allgemeine Begrüßungen)"
     },
     "excludedTags": {
@@ -165,7 +165,7 @@
     },
     "hiddenSlashCommands": {
       "name": "Ausgeblendete Befehle und Fähigkeiten",
-      "desc": "Bestimmte Befehle und Fähigkeiten aus dem Dropdown ausblenden. Nützlich, um Claude Code-Einträge auszublenden, die für Claudian nicht relevant sind. Gib Namen ohne führenden Schrägstrich ein, einen pro Zeile.",
+      "desc": "Bestimmte Befehle und Fähigkeiten aus dem Dropdown ausblenden. Nützlich, um Claude Code-Einträge auszublenden, die für Oh My Claudian nicht relevant sind. Gib Namen ohne führenden Schrägstrich ein, einen pro Zeile.",
       "placeholder": "commit\nbuild\ntest"
     },
     "mcpServers": {
@@ -297,7 +297,7 @@
       "desc": "Write- und Edit-Diffs beim ersten Erscheinen ausgeklappt anzeigen."
     },
     "chatViewPlacement": {
-      "name": "Claudian öffnen in",
+      "name": "Oh My Claudian öffnen in",
       "desc": "Wählen Sie, wo das Chat-Panel beim Erstellen geöffnet wird",
       "rightSidebar": "Rechte Seitenleiste",
       "leftSidebar": "Linke Seitenleiste",
@@ -320,13 +320,13 @@
     "providerEnablement": {
       "name": "{provider} aktivieren",
       "desc": "Aktivierte {provider}-Modelle für neue Unterhaltungen verfügbar machen. Bestehende Sitzungen bleiben beim Deaktivieren erhalten.",
-      "lastProviderWarning": "Damit Claudian funktioniert, muss mindestens ein Anbieter aktiviert bleiben.",
+      "lastProviderWarning": "Damit Oh My Claudian funktioniert, muss mindestens ein Anbieter aktiviert bleiben.",
       "noModelsWarning": "Keine {provider}-Modelle sind aktiviert. Aktivieren Sie unten unter „Modelle“ mindestens ein Modell."
     },
     "codex": {
       "installationMethod": {
         "name": "Installationsmethode",
-        "desc": "Wie Claudian Codex unter Windows starten soll. Native Windows verwendet einen Windows-Programmpfad. WSL startet die Linux-CLI in einer ausgewählten Distribution.",
+        "desc": "Wie Oh My Claudian Codex unter Windows starten soll. Native Windows verwendet einen Windows-Programmpfad. WSL startet die Linux-CLI in einer ausgewählten Distribution.",
         "nativeWindows": "Natives Windows",
         "wsl": "WSL"
       },
@@ -377,7 +377,7 @@
       },
       "mcp": {
         "descBeforeCommand": "Codex verwaltet MCP-Server über seine eigene CLI. Konfiguriere mit ",
-        "descAfterCommand": ", dann sind sie in Claudian verfügbar. ",
+        "descAfterCommand": ", dann sind sie in Oh My Claudian verfügbar. ",
         "learnMore": "Mehr erfahren"
       },
       "environment": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -72,7 +72,7 @@
     }
   },
   "settings": {
-    "title": "Claudian Settings",
+    "title": "Oh My Claudian Settings",
     "tabs": {
       "general": "General",
       "claude": "Claude",
@@ -86,7 +86,7 @@
     "models": "Models",
     "experimental": "Experimental",
     "userName": {
-      "name": "What should Claudian call you?",
+      "name": "What should Oh My Claudian call you?",
       "desc": "Your name for personalized greetings (leave empty for generic greetings)"
     },
     "excludedTags": {
@@ -165,7 +165,7 @@
     },
     "hiddenSlashCommands": {
       "name": "Hidden Commands and Skills",
-      "desc": "Hide specific commands and skills from the dropdown. Useful for hiding Claude Code entries that are not relevant to Claudian. Enter names without the leading slash, one per line.",
+      "desc": "Hide specific commands and skills from the dropdown. Useful for hiding Claude Code entries that are not relevant to Oh My Claudian. Enter names without the leading slash, one per line.",
       "placeholder": "commit\nbuild\ntest"
     },
     "mcpServers": {
@@ -297,7 +297,7 @@
       "desc": "Show Write and Edit diffs expanded when they first appear."
     },
     "chatViewPlacement": {
-      "name": "Open Claudian in",
+      "name": "Open Oh My Claudian in",
       "desc": "Choose where the chat panel opens when it is created",
       "rightSidebar": "Right sidebar",
       "leftSidebar": "Left sidebar",
@@ -320,13 +320,13 @@
     "providerEnablement": {
       "name": "Enable {provider}",
       "desc": "Make enabled {provider} models available for new conversations. Existing sessions are preserved when disabled.",
-      "lastProviderWarning": "At least one provider must remain enabled for Claudian to work.",
+      "lastProviderWarning": "At least one provider must remain enabled for Oh My Claudian to work.",
       "noModelsWarning": "No {provider} models are enabled. Go to Models below and enable at least one model."
     },
     "codex": {
       "installationMethod": {
         "name": "Installation method",
-        "desc": "How Claudian should launch Codex on Windows. Native Windows uses a Windows executable path. WSL launches the Linux CLI inside a selected distro.",
+        "desc": "How Oh My Claudian should launch Codex on Windows. Native Windows uses a Windows executable path. WSL launches the Linux CLI inside a selected distro.",
         "nativeWindows": "Native Windows",
         "wsl": "WSL"
       },
@@ -377,7 +377,7 @@
       },
       "mcp": {
         "descBeforeCommand": "Codex manages MCP servers via its own CLI. Configure with ",
-        "descAfterCommand": " and they will be available in Claudian. ",
+        "descAfterCommand": " and they will be available in Oh My Claudian. ",
         "learnMore": "Learn more"
       },
       "environment": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -72,7 +72,7 @@
     }
   },
   "settings": {
-    "title": "Configuración de Claudian",
+    "title": "Configuración de Oh My Claudian",
     "tabs": {
       "general": "General",
       "claude": "Claude",
@@ -86,7 +86,7 @@
     "models": "Modelos",
     "experimental": "Experimental",
     "userName": {
-      "name": "¿Cómo debería Claudian llamarte?",
+      "name": "¿Cómo debería Oh My Claudian llamarte?",
       "desc": "Tu nombre para saludos personalizados (dejar vacío para saludos genéricos)"
     },
     "excludedTags": {
@@ -165,7 +165,7 @@
     },
     "hiddenSlashCommands": {
       "name": "Comandos y habilidades ocultos",
-      "desc": "Oculta comandos y habilidades específicos del menú desplegable. Útil para ocultar entradas de Claude Code que no son relevantes para Claudian. Ingresa los nombres sin la barra inicial, uno por línea.",
+      "desc": "Oculta comandos y habilidades específicos del menú desplegable. Útil para ocultar entradas de Claude Code que no son relevantes para Oh My Claudian. Ingresa los nombres sin la barra inicial, uno por línea.",
       "placeholder": "commit\nbuild\ntest"
     },
     "mcpServers": {
@@ -297,7 +297,7 @@
       "desc": "Mostrar los diffs de Write y Edit expandidos cuando aparecen por primera vez."
     },
     "chatViewPlacement": {
-      "name": "Abrir Claudian en",
+      "name": "Abrir Oh My Claudian en",
       "desc": "Elige dónde se abre el panel de chat cuando se crea",
       "rightSidebar": "Barra lateral derecha",
       "leftSidebar": "Barra lateral izquierda",
@@ -320,13 +320,13 @@
     "providerEnablement": {
       "name": "Activar {provider}",
       "desc": "Hacer que los modelos de {provider} activados estén disponibles para conversaciones nuevas. Las sesiones existentes se conservan al desactivar el proveedor.",
-      "lastProviderWarning": "Debe haber al menos un proveedor habilitado para que Claudian funcione.",
+      "lastProviderWarning": "Debe haber al menos un proveedor habilitado para que Oh My Claudian funcione.",
       "noModelsWarning": "No hay modelos de {provider} activados. Ve a Modelos más abajo y activa al menos uno."
     },
     "codex": {
       "installationMethod": {
         "name": "Método de instalación",
-        "desc": "Cómo debe iniciar Claudian Codex en Windows. Windows nativo usa una ruta de ejecutable de Windows. WSL inicia la CLI de Linux dentro de una distribución seleccionada.",
+        "desc": "Cómo debe iniciar Oh My Claudian Codex en Windows. Windows nativo usa una ruta de ejecutable de Windows. WSL inicia la CLI de Linux dentro de una distribución seleccionada.",
         "nativeWindows": "Windows nativo",
         "wsl": "WSL"
       },
@@ -377,7 +377,7 @@
       },
       "mcp": {
         "descBeforeCommand": "Codex gestiona servidores MCP mediante su propia CLI. Configúralos con ",
-        "descAfterCommand": " y estarán disponibles en Claudian. ",
+        "descAfterCommand": " y estarán disponibles en Oh My Claudian. ",
         "learnMore": "Más información"
       },
       "environment": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -72,7 +72,7 @@
     }
   },
   "settings": {
-    "title": "Paramètres Claudian",
+    "title": "Paramètres Oh My Claudian",
     "tabs": {
       "general": "Général",
       "claude": "Claude",
@@ -86,7 +86,7 @@
     "models": "Modèles",
     "experimental": "Expérimental",
     "userName": {
-      "name": "Comment Claudian doit-il vous appeler ?",
+      "name": "Comment Oh My Claudian doit-il vous appeler ?",
       "desc": "Votre nom pour les salutations personnalisées (laisser vide pour les salutations génériques)"
     },
     "excludedTags": {
@@ -165,7 +165,7 @@
     },
     "hiddenSlashCommands": {
       "name": "Commandes et compétences masquées",
-      "desc": "Masquez des commandes et compétences spécifiques du menu déroulant. Utile pour masquer les entrées Claude Code qui ne sont pas pertinentes pour Claudian. Saisissez les noms sans le slash initial, un par ligne.",
+      "desc": "Masquez des commandes et compétences spécifiques du menu déroulant. Utile pour masquer les entrées Claude Code qui ne sont pas pertinentes pour Oh My Claudian. Saisissez les noms sans le slash initial, un par ligne.",
       "placeholder": "commit\nbuild\ntest"
     },
     "mcpServers": {
@@ -297,7 +297,7 @@
       "desc": "Afficher les diffs Write et Edit développés lors de leur première apparition."
     },
     "chatViewPlacement": {
-      "name": "Ouvrir Claudian dans",
+      "name": "Ouvrir Oh My Claudian dans",
       "desc": "Choisissez où le panneau de chat s'ouvre lors de sa création",
       "rightSidebar": "Barre latérale droite",
       "leftSidebar": "Barre latérale gauche",
@@ -320,13 +320,13 @@
     "providerEnablement": {
       "name": "Activer {provider}",
       "desc": "Rendre les modèles {provider} activés disponibles pour les nouvelles conversations. Les sessions existantes sont conservées après la désactivation.",
-      "lastProviderWarning": "Au moins un fournisseur doit rester activé pour que Claudian fonctionne.",
+      "lastProviderWarning": "Au moins un fournisseur doit rester activé pour que Oh My Claudian fonctionne.",
       "noModelsWarning": "Aucun modèle {provider} n’est activé. Dans la section Modèles ci-dessous, activez au moins un modèle."
     },
     "codex": {
       "installationMethod": {
         "name": "Méthode d’installation",
-        "desc": "Comment Claudian doit lancer Codex sous Windows. Windows natif utilise un chemin d’exécutable Windows. WSL lance la CLI Linux dans une distribution choisie.",
+        "desc": "Comment Oh My Claudian doit lancer Codex sous Windows. Windows natif utilise un chemin d’exécutable Windows. WSL lance la CLI Linux dans une distribution choisie.",
         "nativeWindows": "Windows natif",
         "wsl": "WSL"
       },
@@ -377,7 +377,7 @@
       },
       "mcp": {
         "descBeforeCommand": "Codex gère les serveurs MCP via sa propre CLI. Configurez avec ",
-        "descAfterCommand": " et ils seront disponibles dans Claudian. ",
+        "descAfterCommand": " et ils seront disponibles dans Oh My Claudian. ",
         "learnMore": "En savoir plus"
       },
       "environment": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -72,7 +72,7 @@
     }
   },
   "settings": {
-    "title": "Claudian 設定",
+    "title": "Oh My Claudian 設定",
     "tabs": {
       "general": "一般",
       "claude": "Claude",
@@ -86,7 +86,7 @@
     "models": "モデル",
     "experimental": "実験的機能",
     "userName": {
-      "name": "Claudian はどのように呼びますか？",
+      "name": "Oh My Claudian はどのように呼びますか？",
       "desc": "パーソナライズされた挨拶に使用する名前（空欄で一般の挨拶）"
     },
     "excludedTags": {
@@ -165,7 +165,7 @@
     },
     "hiddenSlashCommands": {
       "name": "非表示のコマンドとスキル",
-      "desc": "ドロップダウンから特定のコマンドとスキルを非表示にします。Claudian に関係のない Claude Code の項目を隠すのに便利です。先頭のスラッシュなしで名前を1行に1つ入力してください。",
+      "desc": "ドロップダウンから特定のコマンドとスキルを非表示にします。Oh My Claudian に関係のない Claude Code の項目を隠すのに便利です。先頭のスラッシュなしで名前を1行に1つ入力してください。",
       "placeholder": "commit\nbuild\ntest"
     },
     "mcpServers": {
@@ -297,7 +297,7 @@
       "desc": "Write と Edit の diff が最初に表示されるとき、展開した状態で表示します。"
     },
     "chatViewPlacement": {
-      "name": "Claudian を開く場所",
+      "name": "Oh My Claudian を開く場所",
       "desc": "チャットパネルを作成するときに開く場所を選択します",
       "rightSidebar": "右サイドバー",
       "leftSidebar": "左サイドバー",
@@ -320,13 +320,13 @@
     "providerEnablement": {
       "name": "{provider} を有効化",
       "desc": "有効にした {provider} モデルを新しい会話で使用できるようにします。無効にしても既存のセッションは保持されます。",
-      "lastProviderWarning": "Claudian を使用するには、少なくとも 1 つのプロバイダーを有効にする必要があります。",
+      "lastProviderWarning": "Oh My Claudian を使用するには、少なくとも 1 つのプロバイダーを有効にする必要があります。",
       "noModelsWarning": "有効な {provider} モデルがありません。下の「モデル」で少なくとも1つのモデルを有効にしてください。"
     },
     "codex": {
       "installationMethod": {
         "name": "インストール方式",
-        "desc": "Windows で Claudian が Codex を起動する方法。ネイティブ Windows は Windows 実行ファイルパスを使い、WSL は選択したディストリビューション内で Linux CLI を起動します。",
+        "desc": "Windows で Oh My Claudian が Codex を起動する方法。ネイティブ Windows は Windows 実行ファイルパスを使い、WSL は選択したディストリビューション内で Linux CLI を起動します。",
         "nativeWindows": "ネイティブ Windows",
         "wsl": "WSL"
       },
@@ -377,7 +377,7 @@
       },
       "mcp": {
         "descBeforeCommand": "Codex は独自の CLI で MCP サーバーを管理します。",
-        "descAfterCommand": " で設定すると Claudian で利用できます。",
+        "descAfterCommand": " で設定すると Oh My Claudian で利用できます。",
         "learnMore": "詳しく見る"
       },
       "environment": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -72,7 +72,7 @@
     }
   },
   "settings": {
-    "title": "Claudian 설정",
+    "title": "Oh My Claudian 설정",
     "tabs": {
       "general": "일반",
       "claude": "Claude",
@@ -86,7 +86,7 @@
     "models": "모델",
     "experimental": "실험적 기능",
     "userName": {
-      "name": "Claudian이 당신을 어떻게 불러야 합니까?",
+      "name": "Oh My Claudian이 당신을 어떻게 불러야 합니까?",
       "desc": "개인화된 인사에 사용할 이름 (비워두면 일반 인사)"
     },
     "excludedTags": {
@@ -165,7 +165,7 @@
     },
     "hiddenSlashCommands": {
       "name": "숨겨진 명령어와 스킬",
-      "desc": "드롭다운에서 특정 명령어와 스킬을 숨깁니다. Claudian과 관련 없는 Claude Code 항목을 숨기는 데 유용합니다. 앞의 슬래시 없이 이름을 한 줄에 하나씩 입력하세요.",
+      "desc": "드롭다운에서 특정 명령어와 스킬을 숨깁니다. Oh My Claudian과 관련 없는 Claude Code 항목을 숨기는 데 유용합니다. 앞의 슬래시 없이 이름을 한 줄에 하나씩 입력하세요.",
       "placeholder": "commit\nbuild\ntest"
     },
     "mcpServers": {
@@ -297,7 +297,7 @@
       "desc": "Write 및 Edit diff가 처음 표시될 때 펼친 상태로 보여줍니다."
     },
     "chatViewPlacement": {
-      "name": "Claudian 열 위치",
+      "name": "Oh My Claudian 열 위치",
       "desc": "채팅 패널이 생성될 때 열릴 위치를 선택합니다",
       "rightSidebar": "오른쪽 사이드바",
       "leftSidebar": "왼쪽 사이드바",
@@ -320,13 +320,13 @@
     "providerEnablement": {
       "name": "{provider} 활성화",
       "desc": "활성화된 {provider} 모델을 새 대화에서 사용할 수 있게 합니다. 비활성화해도 기존 세션은 유지됩니다.",
-      "lastProviderWarning": "Claudian을 사용하려면 하나 이상의 제공자를 활성화해야 합니다.",
+      "lastProviderWarning": "Oh My Claudian을 사용하려면 하나 이상의 제공자를 활성화해야 합니다.",
       "noModelsWarning": "활성화된 {provider} 모델이 없습니다. 아래 모델 섹션에서 하나 이상의 모델을 활성화하세요."
     },
     "codex": {
       "installationMethod": {
         "name": "설치 방식",
-        "desc": "Windows에서 Claudian이 Codex를 실행하는 방식입니다. 네이티브 Windows는 Windows 실행 파일 경로를 사용하고, WSL은 선택한 배포판 안에서 Linux CLI를 실행합니다.",
+        "desc": "Windows에서 Oh My Claudian이 Codex를 실행하는 방식입니다. 네이티브 Windows는 Windows 실행 파일 경로를 사용하고, WSL은 선택한 배포판 안에서 Linux CLI를 실행합니다.",
         "nativeWindows": "네이티브 Windows",
         "wsl": "WSL"
       },
@@ -377,7 +377,7 @@
       },
       "mcp": {
         "descBeforeCommand": "Codex는 자체 CLI로 MCP 서버를 관리합니다. ",
-        "descAfterCommand": " 명령으로 구성하면 Claudian에서 사용할 수 있습니다. ",
+        "descAfterCommand": " 명령으로 구성하면 Oh My Claudian에서 사용할 수 있습니다. ",
         "learnMore": "자세히 알아보기"
       },
       "environment": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -72,7 +72,7 @@
     }
   },
   "settings": {
-    "title": "Configurações do Claudian",
+    "title": "Configurações do Oh My Claudian",
     "tabs": {
       "general": "Geral",
       "claude": "Claude",
@@ -86,7 +86,7 @@
     "models": "Modelos",
     "experimental": "Experimental",
     "userName": {
-      "name": "Como o Claudian deve chamá-lo?",
+      "name": "Como o Oh My Claudian deve chamá-lo?",
       "desc": "Seu nome para saudações personalizadas (deixe vazio para saudações genéricas)"
     },
     "excludedTags": {
@@ -165,7 +165,7 @@
     },
     "hiddenSlashCommands": {
       "name": "Comandos e habilidades ocultos",
-      "desc": "Oculta comandos e habilidades específicos do menu suspenso. Útil para ocultar entradas do Claude Code que não são relevantes para o Claudian. Digite os nomes sem a barra inicial, um por linha.",
+      "desc": "Oculta comandos e habilidades específicos do menu suspenso. Útil para ocultar entradas do Claude Code que não são relevantes para o Oh My Claudian. Digite os nomes sem a barra inicial, um por linha.",
       "placeholder": "commit\nbuild\ntest"
     },
     "mcpServers": {
@@ -297,7 +297,7 @@
       "desc": "Mostrar os diffs de Write e Edit expandidos quando aparecerem pela primeira vez."
     },
     "chatViewPlacement": {
-      "name": "Abrir Claudian em",
+      "name": "Abrir Oh My Claudian em",
       "desc": "Escolha onde o painel de chat abre quando é criado",
       "rightSidebar": "Barra lateral direita",
       "leftSidebar": "Barra lateral esquerda",
@@ -320,13 +320,13 @@
     "providerEnablement": {
       "name": "Ativar {provider}",
       "desc": "Disponibilizar os modelos {provider} ativados para novas conversas. As sessões existentes são preservadas quando o provedor é desativado.",
-      "lastProviderWarning": "Pelo menos um provedor deve permanecer habilitado para o Claudian funcionar.",
+      "lastProviderWarning": "Pelo menos um provedor deve permanecer habilitado para o Oh My Claudian funcionar.",
       "noModelsWarning": "Nenhum modelo {provider} está ativado. Vá para Modelos abaixo e ative pelo menos um modelo."
     },
     "codex": {
       "installationMethod": {
         "name": "Método de instalação",
-        "desc": "Como o Claudian deve iniciar o Codex no Windows. Windows nativo usa um caminho de executável do Windows. WSL inicia a CLI Linux dentro de uma distro selecionada.",
+        "desc": "Como o Oh My Claudian deve iniciar o Codex no Windows. Windows nativo usa um caminho de executável do Windows. WSL inicia a CLI Linux dentro de uma distro selecionada.",
         "nativeWindows": "Windows nativo",
         "wsl": "WSL"
       },
@@ -377,7 +377,7 @@
       },
       "mcp": {
         "descBeforeCommand": "O Codex gerencia servidores MCP por sua própria CLI. Configure com ",
-        "descAfterCommand": " e eles ficarão disponíveis no Claudian. ",
+        "descAfterCommand": " e eles ficarão disponíveis no Oh My Claudian. ",
         "learnMore": "Saiba mais"
       },
       "environment": {

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -72,7 +72,7 @@
     }
   },
   "settings": {
-    "title": "Настройки Claudian",
+    "title": "Настройки Oh My Claudian",
     "tabs": {
       "general": "Общие",
       "claude": "Claude",
@@ -86,7 +86,7 @@
     "models": "Модели",
     "experimental": "Экспериментальное",
     "userName": {
-      "name": "Как Claudian должен обращаться к вам?",
+      "name": "Как Oh My Claudian должен обращаться к вам?",
       "desc": "Ваше имя для персонализированных приветствий (оставьте пустым для общих приветствий)"
     },
     "excludedTags": {
@@ -165,7 +165,7 @@
     },
     "hiddenSlashCommands": {
       "name": "Скрытые команды и навыки",
-      "desc": "Скрыть определённые команды и навыки из выпадающего списка. Полезно для скрытия записей Claude Code, которые не актуальны для Claudian. Вводите имена без начального слэша, по одному на строку.",
+      "desc": "Скрыть определённые команды и навыки из выпадающего списка. Полезно для скрытия записей Claude Code, которые не актуальны для Oh My Claudian. Вводите имена без начального слэша, по одному на строку.",
       "placeholder": "commit\nbuild\ntest"
     },
     "mcpServers": {
@@ -297,7 +297,7 @@
       "desc": "Показывать diff для Write и Edit раскрытым при первом появлении."
     },
     "chatViewPlacement": {
-      "name": "Открывать Claudian в",
+      "name": "Открывать Oh My Claudian в",
       "desc": "Выберите, где открывается панель чата при создании",
       "rightSidebar": "Правая боковая панель",
       "leftSidebar": "Левая боковая панель",
@@ -320,13 +320,13 @@
     "providerEnablement": {
       "name": "Включить {provider}",
       "desc": "Сделать включённые модели {provider} доступными для новых бесед. Существующие сеансы сохраняются после отключения.",
-      "lastProviderWarning": "Для работы Claudian должен быть включён хотя бы один провайдер.",
+      "lastProviderWarning": "Для работы Oh My Claudian должен быть включён хотя бы один провайдер.",
       "noModelsWarning": "Нет включённых моделей {provider}. В разделе «Модели» ниже включите хотя бы одну модель."
     },
     "codex": {
       "installationMethod": {
         "name": "Способ установки",
-        "desc": "Как Claudian должен запускать Codex в Windows. Нативный Windows использует путь к Windows-исполняемому файлу. WSL запускает Linux CLI внутри выбранного дистрибутива.",
+        "desc": "Как Oh My Claudian должен запускать Codex в Windows. Нативный Windows использует путь к Windows-исполняемому файлу. WSL запускает Linux CLI внутри выбранного дистрибутива.",
         "nativeWindows": "Нативный Windows",
         "wsl": "WSL"
       },
@@ -377,7 +377,7 @@
       },
       "mcp": {
         "descBeforeCommand": "Codex управляет MCP-серверами через собственный CLI. Настройте через ",
-        "descAfterCommand": ", и они будут доступны в Claudian. ",
+        "descAfterCommand": ", и они будут доступны в Oh My Claudian. ",
         "learnMore": "Подробнее"
       },
       "environment": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -72,7 +72,7 @@
     }
   },
   "settings": {
-    "title": "Claudian 设置",
+    "title": "Oh My Claudian 设置",
     "tabs": {
       "general": "通用",
       "claude": "Claude",
@@ -86,7 +86,7 @@
     "models": "模型",
     "experimental": "实验性功能",
     "userName": {
-      "name": "Claudian 应该如何称呼你？",
+      "name": "Oh My Claudian 应该如何称呼你？",
       "desc": "用于个性化问候的用户名（留空使用通用问候）"
     },
     "excludedTags": {
@@ -165,7 +165,7 @@
     },
     "hiddenSlashCommands": {
       "name": "隐藏命令与技能",
-      "desc": "从下拉菜单中隐藏特定的命令与技能。适用于隐藏与 Claudian 无关的 Claude Code 条目。每行输入一个名称，无需前导斜杠。",
+      "desc": "从下拉菜单中隐藏特定的命令与技能。适用于隐藏与 Oh My Claudian 无关的 Claude Code 条目。每行输入一个名称，无需前导斜杠。",
       "placeholder": "commit\nbuild\ntest"
     },
     "mcpServers": {
@@ -297,7 +297,7 @@
       "desc": "Write 和 Edit diff 首次出现时以展开状态显示。"
     },
     "chatViewPlacement": {
-      "name": "Claudian 打开位置",
+      "name": "Oh My Claudian 打开位置",
       "desc": "选择新建聊天面板时的打开位置",
       "rightSidebar": "右侧边栏",
       "leftSidebar": "左侧边栏",
@@ -320,13 +320,13 @@
     "providerEnablement": {
       "name": "启用 {provider}",
       "desc": "让已启用的 {provider} 模型可用于新对话。禁用后，现有会话仍会保留。",
-      "lastProviderWarning": "至少需要启用一个提供商，Claudian 才能正常工作。",
+      "lastProviderWarning": "至少需要启用一个提供商，Oh My Claudian 才能正常工作。",
       "noModelsWarning": "未启用任何 {provider} 模型。请前往下方的“模型”部分并至少启用一个模型。"
     },
     "codex": {
       "installationMethod": {
         "name": "安装方式",
-        "desc": "Claudian 在 Windows 上启动 Codex 的方式。原生 Windows 使用 Windows 可执行文件路径；WSL 会在所选发行版内启动 Linux CLI。",
+        "desc": "Oh My Claudian 在 Windows 上启动 Codex 的方式。原生 Windows 使用 Windows 可执行文件路径；WSL 会在所选发行版内启动 Linux CLI。",
         "nativeWindows": "原生 Windows",
         "wsl": "WSL"
       },
@@ -377,7 +377,7 @@
       },
       "mcp": {
         "descBeforeCommand": "Codex 通过自己的 CLI 管理 MCP 服务器。请使用 ",
-        "descAfterCommand": " 进行配置，它们会在 Claudian 中可用。",
+        "descAfterCommand": " 进行配置，它们会在 Oh My Claudian 中可用。",
         "learnMore": "了解更多"
       },
       "environment": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -72,7 +72,7 @@
     }
   },
   "settings": {
-    "title": "Claudian 設定",
+    "title": "Oh My Claudian 設定",
     "tabs": {
       "general": "一般",
       "claude": "Claude",
@@ -86,7 +86,7 @@
     "models": "模型",
     "experimental": "實驗性功能",
     "userName": {
-      "name": "Claudian 應該如何稱呼您？",
+      "name": "Oh My Claudian 應該如何稱呼您？",
       "desc": "用於個人化問候的使用者名稱（留空使用通用問候）"
     },
     "excludedTags": {
@@ -165,7 +165,7 @@
     },
     "hiddenSlashCommands": {
       "name": "隱藏命令與技能",
-      "desc": "從下拉選單中隱藏特定的命令與技能。適用於隱藏與 Claudian 無關的 Claude Code 項目。每行輸入一個名稱，無需前導斜線。",
+      "desc": "從下拉選單中隱藏特定的命令與技能。適用於隱藏與 Oh My Claudian 無關的 Claude Code 項目。每行輸入一個名稱，無需前導斜線。",
       "placeholder": "commit\nbuild\ntest"
     },
     "mcpServers": {
@@ -297,7 +297,7 @@
       "desc": "Write 和 Edit diff 首次出現時以展開狀態顯示。"
     },
     "chatViewPlacement": {
-      "name": "Claudian 開啟位置",
+      "name": "Oh My Claudian 開啟位置",
       "desc": "選擇新建聊天面板時的開啟位置",
       "rightSidebar": "右側邊欄",
       "leftSidebar": "左側邊欄",
@@ -320,13 +320,13 @@
     "providerEnablement": {
       "name": "啟用 {provider}",
       "desc": "讓已啟用的 {provider} 模型可用於新對話。停用後，現有工作階段仍會保留。",
-      "lastProviderWarning": "至少需要啟用一個提供者，Claudian 才能正常運作。",
+      "lastProviderWarning": "至少需要啟用一個提供者，Oh My Claudian 才能正常運作。",
       "noModelsWarning": "未啟用任何 {provider} 模型。請前往下方的「模型」區段並至少啟用一個模型。"
     },
     "codex": {
       "installationMethod": {
         "name": "安裝方式",
-        "desc": "Claudian 在 Windows 上啟動 Codex 的方式。原生 Windows 使用 Windows 可執行檔路徑；WSL 會在所選發行版內啟動 Linux CLI。",
+        "desc": "Oh My Claudian 在 Windows 上啟動 Codex 的方式。原生 Windows 使用 Windows 可執行檔路徑；WSL 會在所選發行版內啟動 Linux CLI。",
         "nativeWindows": "原生 Windows",
         "wsl": "WSL"
       },
@@ -377,7 +377,7 @@
       },
       "mcp": {
         "descBeforeCommand": "Codex 透過自己的 CLI 管理 MCP 伺服器。請使用 ",
-        "descAfterCommand": " 進行設定，它們會在 Claudian 中可用。",
+        "descAfterCommand": " 進行設定，它們會在 Oh My Claudian 中可用。",
         "learnMore": "了解更多"
       },
       "environment": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -155,7 +155,8 @@ export default class ClaudianPlugin extends Plugin {
       );
       registerFileMenu(this);
 
-      this.addRibbonIcon('bot', 'Open Claudian', () => {
+      // eslint-disable-next-line obsidianmd/ui/sentence-case -- Preserve the product's title casing.
+      this.addRibbonIcon('bot', 'Open Oh My Claudian', () => {
         void this.activateView();
       });
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -3,6 +3,7 @@ import { ProviderWorkspaceRegistry } from '../core/providers/ProviderWorkspaceRe
 import { claudeProviderRegistration } from './claude/registration';
 import { codexProviderRegistration } from './codex/registration';
 import { grokProviderRegistration } from './grok/registration';
+import { ompProviderRegistration } from './omp/registration';
 import { opencodeProviderRegistration } from './opencode/registration';
 import { piProviderRegistration } from './pi/registration';
 
@@ -13,6 +14,7 @@ export const BUILT_IN_PROVIDER_MODULES = [
   codexProviderRegistration,
   grokProviderRegistration,
   opencodeProviderRegistration,
+  ompProviderRegistration,
   piProviderRegistration,
 ] as const;
 

--- a/src/providers/omp/app/OmpWorkspaceServices.ts
+++ b/src/providers/omp/app/OmpWorkspaceServices.ts
@@ -1,0 +1,43 @@
+import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
+import type {
+  ProviderWorkspaceRegistration,
+  ProviderWorkspaceServices,
+} from '../../../core/providers/types';
+import { OmpModelDiscoveryService } from '../metadata/OmpModelDiscoveryService';
+import { OmpCliResolver } from '../runtime/OmpCliResolver';
+import { updateOmpProviderSettings } from '../settings';
+import { ompSettingsTabRenderer } from '../ui/OmpSettingsTab';
+
+export interface OmpWorkspaceServices extends ProviderWorkspaceServices {
+  cliResolver: OmpCliResolver;
+  modelDiscoveryService: OmpModelDiscoveryService;
+}
+
+export const ompWorkspaceRegistration: ProviderWorkspaceRegistration<OmpWorkspaceServices> = {
+  initialize: async ({ plugin }) => {
+    const modelDiscoveryService = new OmpModelDiscoveryService(plugin);
+    return {
+      cliResolver: new OmpCliResolver(),
+      modelDiscoveryService,
+      refreshModelCatalog: async () => {
+        try {
+          const discoveredModels = await modelDiscoveryService.discover();
+          await plugin.mutateSettings(settings => {
+            updateOmpProviderSettings(settings, { discoveredModels });
+          });
+          return { changed: true };
+        } catch (error) {
+          return {
+            changed: false,
+            diagnostics: error instanceof Error ? error.message : String(error),
+          };
+        }
+      },
+      settingsTabRenderer: ompSettingsTabRenderer,
+    };
+  },
+};
+
+export function maybeGetOmpWorkspaceServices(): OmpWorkspaceServices | null {
+  return ProviderWorkspaceRegistry.getServices('omp') as OmpWorkspaceServices | null;
+}

--- a/src/providers/omp/app/OmpWorkspaceServices.ts
+++ b/src/providers/omp/app/OmpWorkspaceServices.ts
@@ -21,9 +21,13 @@ export const ompWorkspaceRegistration: ProviderWorkspaceRegistration<OmpWorkspac
       modelDiscoveryService,
       refreshModelCatalog: async () => {
         try {
-          const discoveredModels = await modelDiscoveryService.discover();
+          const catalog = await modelDiscoveryService.discoverCatalog();
           await plugin.mutateSettings(settings => {
-            updateOmpProviderSettings(settings, { discoveredModels });
+            updateOmpProviderSettings(settings, {
+              availableModes: catalog.modes,
+              discoveredModels: catalog.models,
+              ...(catalog.thinking ? { thinking: catalog.thinking } : {}),
+            });
           });
           return { changed: true };
         } catch (error) {

--- a/src/providers/omp/app/OmpWorkspaceServices.ts
+++ b/src/providers/omp/app/OmpWorkspaceServices.ts
@@ -24,7 +24,6 @@ export const ompWorkspaceRegistration: ProviderWorkspaceRegistration<OmpWorkspac
           const catalog = await modelDiscoveryService.discoverCatalog();
           await plugin.mutateSettings(settings => {
             updateOmpProviderSettings(settings, {
-              availableModes: catalog.modes,
               discoveredModels: catalog.models,
               ...(catalog.thinking ? { thinking: catalog.thinking } : {}),
             });

--- a/src/providers/omp/capabilities.ts
+++ b/src/providers/omp/capabilities.ts
@@ -3,7 +3,7 @@ import type { ProviderCapabilities } from '../../core/providers/types';
 export const OMP_PROVIDER_CAPABILITIES: Readonly<ProviderCapabilities> = Object.freeze({
   providerId: 'omp',
   supportsNativeHistory: true,
-  supportsPlanMode: true,
+  supportsPlanMode: false,
   supportsRewind: false,
   supportsFork: true,
   supportsProviderCommands: false,

--- a/src/providers/omp/capabilities.ts
+++ b/src/providers/omp/capabilities.ts
@@ -3,13 +3,13 @@ import type { ProviderCapabilities } from '../../core/providers/types';
 export const OMP_PROVIDER_CAPABILITIES: Readonly<ProviderCapabilities> = Object.freeze({
   providerId: 'omp',
   supportsNativeHistory: true,
-  supportsPlanMode: false,
+  supportsPlanMode: true,
   supportsRewind: false,
   supportsFork: true,
   supportsProviderCommands: false,
   supportsImageAttachments: true,
   supportsInstructionMode: true,
-  supportsMcpTools: true,
+  supportsMcpTools: false,
   supportsTurnSteer: false,
   reasoningControl: 'effort',
 });

--- a/src/providers/omp/capabilities.ts
+++ b/src/providers/omp/capabilities.ts
@@ -1,0 +1,15 @@
+import type { ProviderCapabilities } from '../../core/providers/types';
+
+export const OMP_PROVIDER_CAPABILITIES: Readonly<ProviderCapabilities> = Object.freeze({
+  providerId: 'omp',
+  supportsNativeHistory: true,
+  supportsPlanMode: false,
+  supportsRewind: false,
+  supportsFork: true,
+  supportsProviderCommands: false,
+  supportsImageAttachments: true,
+  supportsInstructionMode: true,
+  supportsMcpTools: true,
+  supportsTurnSteer: false,
+  reasoningControl: 'effort',
+});

--- a/src/providers/omp/env/OmpSettingsReconciler.ts
+++ b/src/providers/omp/env/OmpSettingsReconciler.ts
@@ -1,0 +1,18 @@
+import type { ProviderSettingsReconciler } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
+import { getOmpProviderSettings, updateOmpProviderSettings } from '../settings';
+
+export const ompSettingsReconciler: ProviderSettingsReconciler = {
+  invalidateConversationSessions(conversations: Conversation[]): Conversation[] {
+    return conversations.filter(conversation => conversation.providerId === 'omp');
+  },
+
+  reconcileModelWithEnvironment(settings, _conversations) {
+    const current = getOmpProviderSettings(settings);
+    if (!current.environmentHash) return { changed: false, invalidatedConversations: [] };
+    updateOmpProviderSettings(settings, { environmentHash: current.environmentHash });
+    return { changed: false, invalidatedConversations: [] };
+  },
+
+  normalizeModelVariantSettings(): boolean { return false; },
+};

--- a/src/providers/omp/execution/OmpAcpSessionKernel.ts
+++ b/src/providers/omp/execution/OmpAcpSessionKernel.ts
@@ -41,6 +41,12 @@ export interface OmpAcpSessionKernel {
   connect(): Promise<void>;
   openSession(resumeSessionId?: string): Promise<OmpNativeSessionInfo>;
   setModel(request: { modelId: string; sessionId: string }): Promise<void>;
+  setConfigOption(request: {
+    configId: string;
+    sessionId: string;
+    type: 'select';
+    value: string;
+  }): Promise<void>;
   prompt(request: AcpPromptRequest): Promise<Pick<AcpPromptResponse, 'usage' | 'userMessageId'>>;
   cancel(sessionId: string): void;
   dispose(): Promise<void>;
@@ -135,6 +141,16 @@ export class DefaultOmpAcpSessionKernel implements OmpAcpSessionKernel {
       type: 'select',
       value: request.modelId,
     });
+  }
+
+  async setConfigOption(request: {
+    configId: string;
+    sessionId: string;
+    type: 'select';
+    value: string;
+  }): Promise<void> {
+    if (!this.connection) throw new Error('OMP ACP kernel is not connected');
+    await this.connection.setConfigOption(request);
   }
 
   prompt(request: AcpPromptRequest): Promise<Pick<AcpPromptResponse, 'usage' | 'userMessageId'>> {

--- a/src/providers/omp/execution/OmpAcpSessionKernel.ts
+++ b/src/providers/omp/execution/OmpAcpSessionKernel.ts
@@ -1,0 +1,202 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import type { ProviderSessionConfig } from '@/core/execution';
+import type { ProviderHost } from '@/core/providers/ProviderHost';
+import {
+  AcpClientConnection,
+  AcpInteractionController,
+  AcpJsonRpcTransport,
+  type AcpPermissionPresentation,
+  type AcpPromptRequest,
+  type AcpPromptResponse,
+  type AcpReadTextFileRequest,
+  type AcpRequestPermissionRequest,
+  type AcpRequestPermissionResponse,
+  type AcpSessionConfigOption,
+  type AcpSessionModelState,
+  type AcpSessionNotification,
+  AcpSubprocess,
+  type AcpWriteTextFileRequest,
+} from '@/providers/acp';
+
+import { buildOmpLaunchSpec } from '../runtime/OmpLaunchSpec';
+import { getOmpProviderSettings } from '../settings';
+
+export interface OmpAcpSessionKernelOptions {
+  readonly config: ProviderSessionConfig;
+  readonly getActiveTurnId: () => string | null;
+  readonly onClosed: (error: Error) => void;
+  readonly onNotification: (notification: AcpSessionNotification) => void;
+  readonly plugin: ProviderHost;
+}
+
+export interface OmpNativeSessionInfo {
+  readonly configOptions?: AcpSessionConfigOption[] | null;
+  readonly models?: AcpSessionModelState | null;
+  readonly sessionId: string;
+}
+
+export interface OmpAcpSessionKernel {
+  connect(): Promise<void>;
+  openSession(resumeSessionId?: string): Promise<OmpNativeSessionInfo>;
+  setModel(request: { modelId: string; sessionId: string }): Promise<void>;
+  prompt(request: AcpPromptRequest): Promise<Pick<AcpPromptResponse, 'usage' | 'userMessageId'>>;
+  cancel(sessionId: string): void;
+  dispose(): Promise<void>;
+}
+
+export class DefaultOmpAcpSessionKernel implements OmpAcpSessionKernel {
+  private connection: AcpClientConnection | null = null;
+  private process: AcpSubprocess | null = null;
+  private transport: AcpJsonRpcTransport | null = null;
+  private interaction: AcpInteractionController | null = null;
+  private disposed = false;
+
+  constructor(private readonly options: OmpAcpSessionKernelOptions) {}
+
+  async connect(): Promise<void> {
+    if (this.disposed) throw new Error('OMP ACP kernel is disposed');
+    if (this.connection) return;
+
+    const command = await this.options.plugin.getResolvedProviderCliPath('omp') ?? 'omp';
+    const settings = getOmpProviderSettings(this.options.plugin.settings);
+    const spec = buildOmpLaunchSpec({
+      command,
+      cwd: this.options.config.vaultWorkingDirectory,
+      env: { ...process.env },
+      settings,
+    });
+    const subprocess = new AcpSubprocess(spec);
+    subprocess.onClose((error) => {
+      if (!this.disposed) this.options.onClosed(error ?? new Error('OMP ACP process closed'));
+    });
+    subprocess.start();
+    this.process = subprocess;
+    const transport = new AcpJsonRpcTransport({
+      input: subprocess.stdout,
+      onClose: (listener) => subprocess.onClose(listener),
+      output: subprocess.stdin,
+    });
+    this.transport = transport;
+    this.interaction = new AcpInteractionController({
+      getTurnId: this.options.getActiveTurnId,
+      interactionPort: this.options.config.interactionPort,
+      presentPermission: presentOmpPermission,
+      sessionInstanceId: 'omp',
+    });
+    const connection = new AcpClientConnection({
+      clientInfo: {
+        name: 'claudian',
+        version: this.options.plugin.manifest?.version ?? '0.0.0',
+      },
+      delegate: {
+        fileSystem: {
+          readTextFile: request => this.readTextFile(request),
+          writeTextFile: request => this.writeTextFile(request),
+        },
+        onSessionNotification: notification => this.options.onNotification(notification),
+        requestPermission: request => this.requestPermission(request),
+      },
+      transport,
+    });
+    this.connection = connection;
+    transport.start();
+    await connection.initialize();
+  }
+
+  async openSession(resumeSessionId?: string): Promise<OmpNativeSessionInfo> {
+    if (!this.connection) throw new Error('OMP ACP kernel is not connected');
+    const request = {
+      cwd: this.options.config.vaultWorkingDirectory,
+      mcpServers: [],
+    };
+    if (resumeSessionId) {
+      const response = await this.connection.loadSession({ ...request, sessionId: resumeSessionId });
+      return {
+        configOptions: response.configOptions,
+        models: response.models,
+        sessionId: response.sessionId ?? resumeSessionId,
+      };
+    }
+    const response = await this.connection.newSession(request);
+    return {
+      configOptions: response.configOptions,
+      models: response.models,
+      sessionId: response.sessionId,
+    };
+  }
+
+  async setModel(request: { modelId: string; sessionId: string }): Promise<void> {
+    if (!this.connection) throw new Error('OMP ACP kernel is not connected');
+    await this.connection.setConfigOption({
+      configId: 'model',
+      sessionId: request.sessionId,
+      type: 'select',
+      value: request.modelId,
+    });
+  }
+
+  prompt(request: AcpPromptRequest): Promise<Pick<AcpPromptResponse, 'usage' | 'userMessageId'>> {
+    if (!this.connection) throw new Error('OMP ACP kernel is not connected');
+    return this.connection.prompt(request);
+  }
+
+  cancel(sessionId: string): void {
+    this.connection?.cancel({ sessionId });
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.interaction?.dispose();
+    this.connection?.dispose();
+    this.transport?.dispose();
+    await this.process?.shutdown();
+    this.connection = null;
+    this.transport = null;
+    this.process = null;
+  }
+
+  private async readTextFile(request: AcpReadTextFileRequest): Promise<{ content: string }> {
+    const filePath = resolveWorkspacePath(this.options.config.vaultWorkingDirectory, request.path);
+    const content = await fs.readFile(filePath, 'utf8');
+    if (request.line === undefined && request.limit === undefined) return { content };
+    const lines = content.split(/\r?\n/u);
+    const start = Math.max(0, (request.line ?? 1) - 1);
+    const end = request.limit == null ? lines.length : start + Math.max(0, request.limit);
+    return { content: lines.slice(start, end).join('\n') };
+  }
+
+  private async writeTextFile(request: AcpWriteTextFileRequest): Promise<Record<string, never>> {
+    const filePath = resolveWorkspacePath(this.options.config.vaultWorkingDirectory, request.path);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, request.content, 'utf8');
+    return {};
+  }
+
+  private requestPermission(request: AcpRequestPermissionRequest): Promise<AcpRequestPermissionResponse> {
+    return this.interaction?.requestPermission(request)
+      ?? Promise.resolve({ outcome: { outcome: 'cancelled' } });
+  }
+}
+
+export function resolveWorkspacePath(workspaceRoot: string, requestedPath: string): string {
+  const root = path.resolve(workspaceRoot);
+  const resolved = path.resolve(root, requestedPath);
+  const relative = path.relative(root, resolved);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error('OMP file access is limited to the current workspace');
+  }
+  return resolved;
+}
+
+function presentOmpPermission(
+  request: AcpRequestPermissionRequest,
+  _input: Readonly<Record<string, unknown>>,
+): AcpPermissionPresentation {
+  return {
+    description: `OMP requests permission to use ${request.toolCall.title || 'a tool'}.`,
+    toolName: request.toolCall.title || 'OMP tool',
+  };
+}

--- a/src/providers/omp/execution/OmpExecutionBackend.ts
+++ b/src/providers/omp/execution/OmpExecutionBackend.ts
@@ -1,0 +1,27 @@
+import type {
+  ProviderExecutionBackend,
+  ProviderExecutionSession,
+  ProviderSessionConfig,
+} from '@/core/execution';
+import type { ProviderHost } from '@/core/providers/ProviderHost';
+
+import type { DefaultOmpAcpSessionKernel} from './OmpAcpSessionKernel';
+import { type OmpAcpSessionKernel } from './OmpAcpSessionKernel';
+import { OmpExecutionSession } from './OmpExecutionSession';
+
+export interface OmpExecutionBackendOptions {
+  readonly createKernel?: (options: ConstructorParameters<typeof DefaultOmpAcpSessionKernel>[0]) => OmpAcpSessionKernel;
+}
+
+export class OmpExecutionBackend implements ProviderExecutionBackend {
+  readonly providerId = 'omp' as const;
+
+  constructor(
+    private readonly plugin: ProviderHost,
+    private readonly options: OmpExecutionBackendOptions = {},
+  ) {}
+
+  createSession(config: ProviderSessionConfig): ProviderExecutionSession {
+    return new OmpExecutionSession(this.plugin, config, this.options);
+  }
+}

--- a/src/providers/omp/execution/OmpExecutionSession.ts
+++ b/src/providers/omp/execution/OmpExecutionSession.ts
@@ -12,6 +12,7 @@ import type {
   ProviderSessionStatus,
 } from '@/core/execution';
 import type { ProviderHost } from '@/core/providers/ProviderHost';
+import type { UsageInfo } from '@/core/types';
 import {
   type AcpContentBlock,
   AcpExecutionEventNormalizer,
@@ -189,6 +190,14 @@ export class OmpExecutionSession implements ProviderExecutionSession {
         },
       });
       this.normalizers.set(run, normalizer);
+      const selectedModel = decodeOmpModelId(request.configuration.model ?? '')
+        ?? getOmpProviderSettings(this.plugin.settings).visibleModels[0]
+        ?? undefined;
+      run.queue.push({
+        scope: run.scope(),
+        type: 'usage_updated',
+        usage: buildInitialOmpUsageInfo(selectedModel),
+      });
       const response = await this.kernel.prompt({
         prompt: buildOmpPrompt(request),
         sessionId: native.sessionId,
@@ -303,4 +312,17 @@ export function buildOmpUsageInfo(usage: AcpUsageUpdate, model?: string) {
     model,
     promptUsage: null,
   });
+}
+
+export function buildInitialOmpUsageInfo(model?: string): UsageInfo {
+  return {
+    cacheCreationInputTokens: 0,
+    cacheReadInputTokens: 0,
+    contextTokens: 0,
+    contextWindow: 200_000,
+    contextWindowIsAuthoritative: false,
+    inputTokens: 0,
+    ...(model ? { model } : {}),
+    percentage: 0,
+  };
 }

--- a/src/providers/omp/execution/OmpExecutionSession.ts
+++ b/src/providers/omp/execution/OmpExecutionSession.ts
@@ -16,6 +16,8 @@ import {
   type AcpContentBlock,
   AcpExecutionEventNormalizer,
   type AcpSessionNotification,
+  type AcpUsageUpdate,
+  buildAcpUsageInfo,
   extractAcpSessionThoughtLevelState,
 } from '@/providers/acp';
 import { appendCurrentNote } from '@/utils/context';
@@ -175,6 +177,10 @@ export class OmpExecutionSession implements ProviderExecutionSession {
       this.snapshot = this.makeSnapshot('executing');
       this.emitSnapshot(run);
       const normalizer = new AcpExecutionEventNormalizer({
+        mapUsage: usage => buildOmpUsageInfo(
+          usage,
+          decodeOmpModelId(request.configuration.model ?? '') ?? undefined,
+        ),
         scope: {
           executionId: run.executionId,
           kind: 'requested',
@@ -289,4 +295,12 @@ export function buildOmpPrompt(request: ProviderExecutionRequest): AcpContentBlo
     }
   }
   return blocks;
+}
+
+export function buildOmpUsageInfo(usage: AcpUsageUpdate, model?: string) {
+  return buildAcpUsageInfo({
+    contextWindow: usage,
+    model,
+    promptUsage: null,
+  });
 }

--- a/src/providers/omp/execution/OmpExecutionSession.ts
+++ b/src/providers/omp/execution/OmpExecutionSession.ts
@@ -16,9 +16,11 @@ import {
   type AcpContentBlock,
   AcpExecutionEventNormalizer,
   type AcpSessionNotification,
+  extractAcpSessionThoughtLevelState,
 } from '@/providers/acp';
 
 import { decodeOmpModelId } from '../models';
+import { getOmpProviderSettings } from '../settings';
 import {
   DefaultOmpAcpSessionKernel,
   type OmpAcpSessionKernel,
@@ -167,12 +169,7 @@ export class OmpExecutionSession implements ProviderExecutionSession {
       }
       const native = await this.kernel.openSession(this.nativeSessionId ?? undefined);
       this.nativeSessionId = native.sessionId;
-      const modelId = request.configuration.model
-        ? decodeOmpModelId(request.configuration.model)
-        : null;
-      if (modelId) {
-        await this.kernel.setModel({ modelId, sessionId: native.sessionId });
-      }
+      await this.applyConfiguration(native, request);
       this.snapshot = this.makeSnapshot('executing');
       this.emitSnapshot(run);
       const normalizer = new AcpExecutionEventNormalizer({
@@ -200,6 +197,38 @@ export class OmpExecutionSession implements ProviderExecutionSession {
   }
 
   private readonly normalizers = new WeakMap<OmpExecutionRun, AcpExecutionEventNormalizer>();
+
+  private async applyConfiguration(
+    native: Awaited<ReturnType<OmpAcpSessionKernel['openSession']>>,
+    request: ProviderExecutionRequest,
+  ): Promise<void> {
+    if (!this.kernel) return;
+    const modelId = request.configuration.model
+      ? decodeOmpModelId(request.configuration.model)
+      : null;
+    if (modelId) await this.kernel.setModel({ modelId, sessionId: native.sessionId });
+
+    const thinking = extractAcpSessionThoughtLevelState({ configOptions: native.configOptions });
+    if (
+      request.configuration.reasoning
+      && thinking.configId
+      && thinking.availableLevels.some(level => level.id === request.configuration.reasoning)
+    ) {
+      await this.kernel.setConfigOption({
+        configId: thinking.configId,
+        sessionId: native.sessionId,
+        type: 'select',
+        value: request.configuration.reasoning,
+      });
+    }
+
+    const mode = getOmpProviderSettings(this.plugin.settings).selectedMode;
+    if (mode && (mode === 'default' || mode === 'plan')) {
+      await this.kernel.setConfigOption({
+        configId: 'mode', sessionId: native.sessionId, type: 'select', value: mode,
+      });
+    }
+  }
 
   private handleNotification(run: OmpExecutionRun, notification: AcpSessionNotification): void {
     if (run.terminal || notification.sessionId !== this.nativeSessionId) return;

--- a/src/providers/omp/execution/OmpExecutionSession.ts
+++ b/src/providers/omp/execution/OmpExecutionSession.ts
@@ -1,0 +1,255 @@
+import { randomUUID } from 'node:crypto';
+
+import type {
+  ProviderExecutionEvent,
+  ProviderExecutionRequest,
+  ProviderExecutionRun,
+  ProviderExecutionSession,
+  ProviderRequestedEventScope,
+  ProviderSessionConfig,
+  ProviderSessionEvent,
+  ProviderSessionSnapshot,
+  ProviderSessionStatus,
+} from '@/core/execution';
+import type { ProviderHost } from '@/core/providers/ProviderHost';
+import {
+  type AcpContentBlock,
+  AcpExecutionEventNormalizer,
+  type AcpSessionNotification,
+} from '@/providers/acp';
+
+import { decodeOmpModelId } from '../models';
+import {
+  DefaultOmpAcpSessionKernel,
+  type OmpAcpSessionKernel,
+  type OmpAcpSessionKernelOptions,
+} from './OmpAcpSessionKernel';
+
+class EventQueue<T> implements AsyncIterable<T>, AsyncIterator<T> {
+  private closed = false;
+  private values: T[] = [];
+  private waiters: Array<(result: IteratorResult<T>) => void> = [];
+
+  constructor(private readonly onReturn: () => void) {}
+
+  [Symbol.asyncIterator](): AsyncIterator<T> { return this; }
+
+  next(): Promise<IteratorResult<T>> {
+    const value = this.values.shift();
+    if (value !== undefined) return Promise.resolve({ done: false, value });
+    if (this.closed) return Promise.resolve({ done: true, value: undefined });
+    return new Promise(resolve => this.waiters.push(resolve));
+  }
+
+  return(): Promise<IteratorResult<T>> {
+    if (!this.closed) this.onReturn();
+    return Promise.resolve({ done: true, value: undefined });
+  }
+
+  push(value: T): void {
+    if (this.closed) return;
+    const waiter = this.waiters.shift();
+    if (waiter) waiter({ done: false, value });
+    else this.values.push(value);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    for (const waiter of this.waiters.splice(0)) waiter({ done: true, value: undefined });
+  }
+}
+
+class OmpExecutionRun implements ProviderExecutionRun {
+  readonly executionId = randomUUID();
+  readonly turnId = randomUUID();
+  readonly queue: EventQueue<ProviderExecutionEvent>;
+  readonly events: AsyncIterable<ProviderExecutionEvent>;
+  terminal = false;
+  private sequence = 0;
+
+  constructor(private readonly cancelRun: () => void) {
+    this.queue = new EventQueue(() => this.cancel());
+    this.events = this.queue;
+  }
+
+  cancel(): void { if (!this.terminal) this.cancelRun(); }
+
+  scope(): ProviderRequestedEventScope {
+    return {
+      executionId: this.executionId,
+      kind: 'requested',
+      sequence: ++this.sequence,
+      sessionInstanceId: this.sessionInstanceId,
+      turnId: this.turnId,
+    };
+  }
+
+  get sessionInstanceId(): string { return this._sessionInstanceId; }
+  setSessionInstanceId(value: string): void { this._sessionInstanceId = value; }
+  finish(event: ProviderExecutionEvent): void {
+    if (this.terminal) return;
+    this.terminal = true;
+    this.queue.push(event);
+    this.queue.close();
+  }
+
+  private _sessionInstanceId = '';
+}
+
+export interface OmpExecutionSessionOptions {
+  readonly createKernel?: (options: OmpAcpSessionKernelOptions) => OmpAcpSessionKernel;
+}
+
+export class OmpExecutionSession implements ProviderExecutionSession {
+  readonly providerId = 'omp' as const;
+  readonly sessionInstanceId = randomUUID();
+  private readonly createKernel: (options: OmpAcpSessionKernelOptions) => OmpAcpSessionKernel;
+  private readonly listeners = new Set<(event: ProviderSessionEvent) => void>();
+  private kernel: OmpAcpSessionKernel | null = null;
+  private nativeSessionId: string | null;
+  private activeRun: OmpExecutionRun | null = null;
+  private snapshot: ProviderSessionSnapshot;
+  private disposed = false;
+
+  constructor(
+    private readonly plugin: ProviderHost,
+    private readonly config: ProviderSessionConfig,
+    options: OmpExecutionSessionOptions = {},
+  ) {
+    this.createKernel = options.createKernel ?? (kernelOptions => new DefaultOmpAcpSessionKernel(kernelOptions));
+    this.nativeSessionId = config.resumeSeed?.providerSessionId ?? null;
+    this.snapshot = this.makeSnapshot('idle');
+  }
+
+  execute(request: ProviderExecutionRequest): ProviderExecutionRun {
+    if (this.disposed) throw new Error('OMP execution session is disposed');
+    if (this.activeRun) throw new Error('OMP execution session already has an active run');
+    const run = new OmpExecutionRun(() => this.cancelRun(run));
+    run.setSessionInstanceId(this.sessionInstanceId);
+    this.activeRun = run;
+    void this.startRun(run, request);
+    return run;
+  }
+
+  cancel(): void { this.activeRun?.cancel(); }
+
+  getSnapshot(): ProviderSessionSnapshot { return this.snapshot; }
+  getStatus(): ProviderSessionStatus { return this.snapshot.status; }
+
+  onEvent(listener: (event: ProviderSessionEvent) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.activeRun?.finish({ reason: 'session-disposed', scope: this.activeRun.scope(), type: 'cancelled' });
+    this.activeRun = null;
+    this.snapshot = this.makeSnapshot('disposed');
+    await this.kernel?.dispose();
+    this.kernel = null;
+    this.listeners.clear();
+  }
+
+  private async startRun(run: OmpExecutionRun, request: ProviderExecutionRequest): Promise<void> {
+    try {
+      if (!this.kernel) {
+        this.kernel = this.createKernel({
+          config: this.config,
+          getActiveTurnId: () => this.activeRun?.turnId ?? null,
+          onClosed: error => this.failRun(run, error),
+          onNotification: notification => this.handleNotification(run, notification),
+          plugin: this.plugin,
+        });
+        await this.kernel.connect();
+      }
+      const native = await this.kernel.openSession(this.nativeSessionId ?? undefined);
+      this.nativeSessionId = native.sessionId;
+      const modelId = request.configuration.model
+        ? decodeOmpModelId(request.configuration.model)
+        : null;
+      if (modelId) {
+        await this.kernel.setModel({ modelId, sessionId: native.sessionId });
+      }
+      this.snapshot = this.makeSnapshot('executing');
+      this.emitSnapshot(run);
+      const normalizer = new AcpExecutionEventNormalizer({
+        scope: {
+          executionId: run.executionId,
+          kind: 'requested',
+          sessionInstanceId: this.sessionInstanceId,
+          turnId: run.turnId,
+        },
+      });
+      this.normalizers.set(run, normalizer);
+      const response = await this.kernel.prompt({
+        prompt: buildPrompt(request),
+        sessionId: native.sessionId,
+      });
+      if (run.terminal) return;
+      run.queue.push({ accepted: true, nativeUserMessageId: response.userMessageId ?? undefined, scope: run.scope(), type: 'turn_started' });
+      this.snapshot = this.makeSnapshot('idle');
+      this.emitSnapshot(run);
+      run.finish({ reason: 'completed', scope: run.scope(), type: 'turn_completed' });
+      this.activeRun = null;
+    } catch (error) {
+      this.failRun(run, error);
+    }
+  }
+
+  private readonly normalizers = new WeakMap<OmpExecutionRun, AcpExecutionEventNormalizer>();
+
+  private handleNotification(run: OmpExecutionRun, notification: AcpSessionNotification): void {
+    if (run.terminal || notification.sessionId !== this.nativeSessionId) return;
+    const result = this.normalizers.get(run)?.normalize(notification.update);
+    for (const event of result?.events ?? []) run.queue.push({ ...event, scope: run.scope() });
+  }
+
+  private cancelRun(run: OmpExecutionRun): void {
+    if (this.activeRun !== run || run.terminal) return;
+    if (this.nativeSessionId) this.kernel?.cancel(this.nativeSessionId);
+    run.finish({ reason: 'cancelled', scope: run.scope(), type: 'cancelled' });
+    this.activeRun = null;
+  }
+
+  private failRun(run: OmpExecutionRun, error: unknown): void {
+    if (run.terminal) return;
+    const message = error instanceof Error ? error.message : String(error);
+    this.snapshot = {
+      ...this.makeSnapshot('invalidated'),
+      invalidation: { message, reason: 'provider-error', recoverable: true },
+      status: 'invalidated',
+    };
+    run.finish({ category: 'provider', message, recoverable: true, scope: run.scope(), type: 'execution_error' });
+    this.activeRun = null;
+  }
+
+  private emitSnapshot(run: OmpExecutionRun): void {
+    run.queue.push({ scope: run.scope(), snapshot: this.snapshot, type: 'session_state_changed' });
+  }
+
+  private makeSnapshot(status: ProviderSessionStatus): ProviderSessionSnapshot {
+    const base = {
+      providerId: this.providerId,
+      providerSessionId: this.nativeSessionId ?? undefined,
+      revision: Date.now(),
+    };
+    if (status === 'invalidated') {
+      return { ...base, invalidation: { reason: 'provider-error', recoverable: true }, status };
+    }
+    return { ...base, status };
+  }
+}
+
+function buildPrompt(request: ProviderExecutionRequest): AcpContentBlock[] {
+  const text = request.input.filter(block => block.type === 'text').map(block => block.text).join('\n');
+  const blocks: AcpContentBlock[] = [{ type: 'text', text }];
+  for (const block of request.input) {
+    if (block.type === 'image' && block.image.data) {
+      blocks.push({ type: 'image', data: block.image.data, mimeType: block.image.mediaType });
+    }
+  }
+  return blocks;
+}

--- a/src/providers/omp/execution/OmpExecutionSession.ts
+++ b/src/providers/omp/execution/OmpExecutionSession.ts
@@ -245,12 +245,6 @@ export class OmpExecutionSession implements ProviderExecutionSession {
       });
     }
 
-    const mode = getOmpProviderSettings(this.plugin.settings).selectedMode;
-    if (mode && (mode === 'default' || mode === 'plan')) {
-      await this.kernel.setConfigOption({
-        configId: 'mode', sessionId: native.sessionId, type: 'select', value: mode,
-      });
-    }
   }
 
   private handleNotification(run: OmpExecutionRun, notification: AcpSessionNotification): void {

--- a/src/providers/omp/execution/OmpExecutionSession.ts
+++ b/src/providers/omp/execution/OmpExecutionSession.ts
@@ -166,8 +166,14 @@ export class OmpExecutionSession implements ProviderExecutionSession {
         this.kernel = this.createKernel({
           config: this.config,
           getActiveTurnId: () => this.activeRun?.turnId ?? null,
-          onClosed: error => this.failRun(run, error),
-          onNotification: notification => this.handleNotification(run, notification),
+          onClosed: error => {
+            const activeRun = this.activeRun;
+            if (activeRun) this.failRun(activeRun, error);
+          },
+          onNotification: notification => {
+            const activeRun = this.activeRun;
+            if (activeRun) this.handleNotification(activeRun, notification);
+          },
           plugin: this.plugin,
         });
         await this.kernel.connect();

--- a/src/providers/omp/execution/OmpExecutionSession.ts
+++ b/src/providers/omp/execution/OmpExecutionSession.ts
@@ -18,6 +18,8 @@ import {
   type AcpSessionNotification,
   extractAcpSessionThoughtLevelState,
 } from '@/providers/acp';
+import { appendCurrentNote } from '@/utils/context';
+import { appendEditorContext } from '@/utils/editor';
 
 import { decodeOmpModelId } from '../models';
 import { getOmpProviderSettings } from '../settings';
@@ -182,7 +184,7 @@ export class OmpExecutionSession implements ProviderExecutionSession {
       });
       this.normalizers.set(run, normalizer);
       const response = await this.kernel.prompt({
-        prompt: buildPrompt(request),
+        prompt: buildOmpPrompt(request),
         sessionId: native.sessionId,
       });
       if (run.terminal) return;
@@ -272,8 +274,14 @@ export class OmpExecutionSession implements ProviderExecutionSession {
   }
 }
 
-function buildPrompt(request: ProviderExecutionRequest): AcpContentBlock[] {
-  const text = request.input.filter(block => block.type === 'text').map(block => block.text).join('\n');
+export function buildOmpPrompt(request: ProviderExecutionRequest): AcpContentBlock[] {
+  let text = request.input.filter(block => block.type === 'text').map(block => block.text).join('\n');
+  if (request.context?.currentNote?.path) {
+    text = appendCurrentNote(text, request.context.currentNote.path);
+  }
+  if (request.context?.editorSelection) {
+    text = appendEditorContext(text, request.context.editorSelection);
+  }
   const blocks: AcpContentBlock[] = [{ type: 'text', text }];
   for (const block of request.input) {
     if (block.type === 'image' && block.image.data) {

--- a/src/providers/omp/history/OmpConversationHistoryService.ts
+++ b/src/providers/omp/history/OmpConversationHistoryService.ts
@@ -1,0 +1,66 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import type { ProviderConversationHistoryService, ProviderHistoryPathContext } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
+import { findOmpSessionFileInRoot, parseOmpSessionContent } from './OmpHistoryStore';
+
+export class OmpConversationHistoryService implements ProviderConversationHistoryService {
+  async hydrateConversationHistory(
+    conversation: Conversation,
+    _vaultPath: string | null,
+    context?: ProviderHistoryPathContext,
+  ): Promise<void> {
+    if (!conversation.sessionId || conversation.messages.length > 0) return;
+    const sessionFile = resolveOmpSessionFile(conversation.sessionId, context);
+    if (!sessionFile) return;
+    try {
+      const content = await fs.readFile(sessionFile, 'utf8');
+      const messages = parseOmpSessionContent(content);
+      if (messages.length > 0) conversation.messages = messages;
+    } catch {
+      // OMP history remains provider-owned and is best-effort read-only input.
+    }
+  }
+
+  resolveSessionIdForConversation(conversation: { sessionId: string | null } | null): string | null {
+    return conversation?.sessionId ?? null;
+  }
+
+  isPendingForkConversation(): boolean {
+    return false;
+  }
+
+  buildForkProviderState(sourceSessionId: string): Record<string, unknown> {
+    return { sourceSessionId };
+  }
+
+  buildPersistedProviderState(conversation: { providerState?: Record<string, unknown> }): Record<string, unknown> | undefined {
+    return conversation.providerState;
+  }
+}
+
+function resolveOmpSessionFile(
+  sessionId: string,
+  context?: ProviderHistoryPathContext,
+): string | null {
+  for (const root of getSessionRoots(context)) {
+    const sessionFile = findOmpSessionFileInRoot(sessionId, root);
+    if (sessionFile) return sessionFile;
+  }
+  return null;
+}
+
+function getSessionRoots(context?: ProviderHistoryPathContext): string[] {
+  const environment = context?.environment ?? {};
+  const configDir = environment.PI_CONFIG_DIR?.trim() || path.join(
+    environment.HOME?.trim() || environment.USERPROFILE?.trim() || os.homedir(),
+    '.omp',
+  );
+  const profile = environment.OMP_PROFILE?.trim() || environment.PI_PROFILE?.trim();
+  const agentDir = profile
+    ? path.join(configDir, 'profiles', profile, 'agent')
+    : path.join(configDir, 'agent');
+  return [path.join(agentDir, 'sessions')];
+}

--- a/src/providers/omp/history/OmpHistoryStore.ts
+++ b/src/providers/omp/history/OmpHistoryStore.ts
@@ -1,0 +1,112 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import type { ChatMessage, ContentBlock } from '../../../core/types';
+
+export function parseOmpSessionContent(content: string): ChatMessage[] {
+  const messages: ChatMessage[] = [];
+  for (const line of content.split(/\r?\n/u)) {
+    if (!line.trim()) continue;
+    let entry: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      if (!isRecord(parsed)) continue;
+      entry = parsed;
+    } catch {
+      continue;
+    }
+    if (entry.type !== 'message' || !isRecord(entry.message)) continue;
+    const message = entry.message;
+    const role = typeof message.role === 'string' ? message.role : '';
+    const id = typeof entry.id === 'string' ? entry.id : `omp-${messages.length}`;
+    const timestamp = getTimestamp(message.timestamp ?? entry.timestamp);
+    if (role === 'user') {
+      messages.push({
+        content: getText(message.content),
+        id,
+        role: 'user',
+        timestamp,
+        userMessageId: id,
+      });
+      continue;
+    }
+    if (role === 'assistant') {
+      const contentBlocks = getAssistantContentBlocks(message.content);
+      messages.push({
+        assistantMessageId: id,
+        content: contentBlocks
+          .filter((block): block is Extract<ContentBlock, { type: 'text' }> => block.type === 'text')
+          .map(block => block.content)
+          .join(''),
+        ...(contentBlocks.length > 0 ? { contentBlocks } : {}),
+        id,
+        role: 'assistant',
+        timestamp,
+      });
+    }
+  }
+  return messages;
+}
+
+export function findOmpSessionFileInRoot(sessionId: string, root: string): string | null {
+  const trimmed = sessionId.trim();
+  if (!trimmed || /[\\/]/u.test(trimmed)) return null;
+  return findRecursively(root, trimmed);
+}
+
+function findRecursively(root: string, sessionId: string): string | null {
+  try {
+    for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+      const candidate = path.join(root, entry.name);
+      if (entry.isDirectory()) {
+        const found = findRecursively(candidate, sessionId);
+        if (found) return found;
+      } else if (entry.isFile() && entry.name.endsWith('.jsonl') && entry.name.includes(sessionId)) {
+        return candidate;
+      }
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function getAssistantContentBlocks(value: unknown): ContentBlock[] {
+  const parts = Array.isArray(value) ? value : [];
+  const blocks: ContentBlock[] = [];
+  for (const part of parts) {
+    if (!isRecord(part)) continue;
+    if (part.type === 'thinking') {
+      const content = getText(part.thinking ?? part.text ?? part.content);
+      if (content) blocks.push({ content, type: 'thinking' });
+    } else if (part.type === 'text') {
+      const content = getText(part.text ?? part.content);
+      if (content) blocks.push({ content, type: 'text' });
+    }
+  }
+  return blocks;
+}
+
+function getText(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return value.map(getText).join('');
+  if (!isRecord(value)) return '';
+  return typeof value.text === 'string'
+    ? value.text
+    : typeof value.content === 'string'
+      ? value.content
+      : '';
+}
+
+function getTimestamp(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const timestamp = Date.parse(value);
+    if (!Number.isNaN(timestamp)) return timestamp;
+  }
+  return Date.now();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/providers/omp/metadata/OmpModelDiscoveryService.ts
+++ b/src/providers/omp/metadata/OmpModelDiscoveryService.ts
@@ -6,9 +6,20 @@ import {
   type OmpAcpSessionKernelOptions,
 } from '../execution/OmpAcpSessionKernel';
 import {
+  normalizeOmpConfigChoices,
   normalizeOmpConfigOptionModels,
   type OmpDiscoveredModel,
 } from '../models';
+
+export interface OmpModelCatalog {
+  models: OmpDiscoveredModel[];
+  modes: Array<{ description?: string; id: string; name: string }>;
+  thinking: {
+    configId: string;
+    currentValue: string | null;
+    options: Array<{ description?: string; id: string; name: string }>;
+  } | null;
+}
 
 export interface OmpModelDiscoveryServiceOptions {
   readonly createKernel?: (options: OmpAcpSessionKernelOptions) => OmpAcpSessionKernel;
@@ -26,6 +37,10 @@ export class OmpModelDiscoveryService {
   }
 
   async discover(signal?: AbortSignal): Promise<OmpDiscoveredModel[]> {
+    return (await this.discoverCatalog(signal)).models;
+  }
+
+  async discoverCatalog(signal?: AbortSignal): Promise<OmpModelCatalog> {
     signal?.throwIfAborted();
     const kernel = this.createKernel({
       config: getMetadataSessionConfig(this.plugin),
@@ -39,8 +54,19 @@ export class OmpModelDiscoveryService {
       signal?.throwIfAborted();
       const session = await kernel.openSession();
       signal?.throwIfAborted();
-      const models = normalizeOmpConfigOptionModels(session.configOptions);
-      return models;
+      const modes = normalizeOmpConfigChoices(session.configOptions, 'mode');
+      const thinking = normalizeOmpConfigChoices(session.configOptions, 'thought_level');
+      return {
+        models: normalizeOmpConfigOptionModels(session.configOptions),
+        modes: modes.options,
+        thinking: thinking.configId
+          ? {
+            configId: thinking.configId,
+            currentValue: thinking.currentValue,
+            options: thinking.options,
+          }
+          : null,
+      };
     } finally {
       await kernel.dispose();
     }

--- a/src/providers/omp/metadata/OmpModelDiscoveryService.ts
+++ b/src/providers/omp/metadata/OmpModelDiscoveryService.ts
@@ -1,0 +1,68 @@
+import type { ProviderInteractionPort, ProviderSessionConfig } from '../../../core/execution';
+import type { ProviderHost } from '../../../core/providers/ProviderHost';
+import {
+  DefaultOmpAcpSessionKernel,
+  type OmpAcpSessionKernel,
+  type OmpAcpSessionKernelOptions,
+} from '../execution/OmpAcpSessionKernel';
+import {
+  normalizeOmpConfigOptionModels,
+  type OmpDiscoveredModel,
+} from '../models';
+
+export interface OmpModelDiscoveryServiceOptions {
+  readonly createKernel?: (options: OmpAcpSessionKernelOptions) => OmpAcpSessionKernel;
+}
+
+export class OmpModelDiscoveryService {
+  private readonly createKernel: (options: OmpAcpSessionKernelOptions) => OmpAcpSessionKernel;
+
+  constructor(
+    private readonly plugin: ProviderHost,
+    options: OmpModelDiscoveryServiceOptions = {},
+  ) {
+    this.createKernel = options.createKernel
+      ?? (kernelOptions => new DefaultOmpAcpSessionKernel(kernelOptions));
+  }
+
+  async discover(signal?: AbortSignal): Promise<OmpDiscoveredModel[]> {
+    signal?.throwIfAborted();
+    const kernel = this.createKernel({
+      config: getMetadataSessionConfig(this.plugin),
+      getActiveTurnId: () => null,
+      onClosed: () => undefined,
+      onNotification: () => undefined,
+      plugin: this.plugin,
+    });
+    try {
+      await kernel.connect();
+      signal?.throwIfAborted();
+      const session = await kernel.openSession();
+      signal?.throwIfAborted();
+      const models = normalizeOmpConfigOptionModels(session.configOptions);
+      return models;
+    } finally {
+      await kernel.dispose();
+    }
+  }
+
+}
+
+function getMetadataSessionConfig(plugin: ProviderHost): ProviderSessionConfig {
+  const adapter = plugin.app.vault.adapter as { basePath?: unknown };
+  return {
+    interactionPort: DENY_INTERACTION_PORT,
+    lifecycle: 'ephemeral',
+    nativePersistence: 'disabled-if-supported',
+    vaultWorkingDirectory: typeof adapter.basePath === 'string' && adapter.basePath
+      ? adapter.basePath
+      : process.cwd(),
+  };
+}
+
+const DENY_INTERACTION_PORT: ProviderInteractionPort = {
+  askUserQuestion: async ({ interactionId }) => ({ answers: null, interactionId }),
+  dismissInteraction: () => undefined,
+  requestApproval: async ({ interactionId }) => ({ decision: 'deny', interactionId }),
+  requestPlanDecision: async ({ interactionId }) => ({ decision: null, interactionId }),
+};

--- a/src/providers/omp/metadata/OmpModelDiscoveryService.ts
+++ b/src/providers/omp/metadata/OmpModelDiscoveryService.ts
@@ -13,7 +13,6 @@ import {
 
 export interface OmpModelCatalog {
   models: OmpDiscoveredModel[];
-  modes: Array<{ description?: string; id: string; name: string }>;
   thinking: {
     configId: string;
     currentValue: string | null;
@@ -54,11 +53,9 @@ export class OmpModelDiscoveryService {
       signal?.throwIfAborted();
       const session = await kernel.openSession();
       signal?.throwIfAborted();
-      const modes = normalizeOmpConfigChoices(session.configOptions, 'mode');
       const thinking = normalizeOmpConfigChoices(session.configOptions, 'thought_level');
       return {
         models: normalizeOmpConfigOptionModels(session.configOptions),
-        modes: modes.options,
         thinking: thinking.configId
           ? {
             configId: thinking.configId,

--- a/src/providers/omp/models.ts
+++ b/src/providers/omp/models.ts
@@ -1,0 +1,75 @@
+export interface OmpDiscoveredModel {
+  description?: string;
+  label: string;
+  rawId: string;
+}
+
+const OMP_MODEL_PREFIX = 'omp:';
+
+export function encodeOmpModelId(rawId: string): string {
+  const normalized = rawId.trim();
+  return normalized ? `${OMP_MODEL_PREFIX}${normalized}` : '';
+}
+
+export function decodeOmpModelId(value: string): string | null {
+  if (!value.startsWith(OMP_MODEL_PREFIX)) return null;
+  const rawId = value.slice(OMP_MODEL_PREFIX.length).trim();
+  return rawId || null;
+}
+
+export function normalizeOmpDiscoveredModels(value: unknown): OmpDiscoveredModel[] {
+  if (!Array.isArray(value)) return [];
+  const result: OmpDiscoveredModel[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const record = entry as Record<string, unknown>;
+    const rawId = firstText(record.rawId, record.id, record.modelId)?.trim() ?? '';
+    if (!rawId || seen.has(rawId)) continue;
+    seen.add(rawId);
+    const label = firstText(record.label, record.name)?.trim() || rawId;
+    const description = firstText(record.description)?.trim();
+    result.push({ ...(description ? { description } : {}), label, rawId });
+  }
+  return result;
+}
+
+export function normalizeOmpConfigOptionModels(value: unknown): OmpDiscoveredModel[] {
+  if (!Array.isArray(value)) return [];
+  const modelOption = value.find(option => {
+    if (!option || typeof option !== 'object' || Array.isArray(option)) return false;
+    const record = option as Record<string, unknown>;
+    return record.id === 'model' && record.type === 'select';
+  }) as Record<string, unknown> | undefined;
+  if (!modelOption || !Array.isArray(modelOption.options)) return [];
+
+  return normalizeOmpDiscoveredModels(modelOption.options.map(option => {
+    if (!option || typeof option !== 'object' || Array.isArray(option)) return null;
+    const record = option as Record<string, unknown>;
+    return {
+      description: record.description,
+      name: record.name,
+      modelId: record.value,
+    };
+  }));
+}
+
+export function normalizeOmpVisibleModels(
+  value: unknown,
+  discoveredModels: OmpDiscoveredModel[] = [],
+): string[] {
+  if (!Array.isArray(value)) return [];
+  const known = new Set(discoveredModels.map(model => model.rawId));
+  const result: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== 'string') continue;
+    const rawId = entry.trim();
+    if (!rawId || (known.size > 0 && !known.has(rawId)) || result.includes(rawId)) continue;
+    result.push(rawId);
+  }
+  return result;
+}
+
+function firstText(...values: unknown[]): string | undefined {
+  return values.find((value): value is string => typeof value === 'string' && value.trim().length > 0);
+}

--- a/src/providers/omp/models.ts
+++ b/src/providers/omp/models.ts
@@ -4,6 +4,51 @@ export interface OmpDiscoveredModel {
   rawId: string;
 }
 
+export interface OmpConfigChoice {
+  description?: string;
+  id: string;
+  name: string;
+}
+
+export interface OmpThinkingConfig {
+  configId: string;
+  currentValue: string | null;
+  options: OmpConfigChoice[];
+}
+
+export function normalizeOmpConfigChoiceList(value: unknown): OmpConfigChoice[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const result: OmpConfigChoice[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const record = entry as Record<string, unknown>;
+    const id = typeof record.id === 'string' ? record.id.trim() : '';
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    const name = typeof record.name === 'string' && record.name.trim() ? record.name.trim() : id;
+    const description = typeof record.description === 'string' && record.description.trim()
+      ? record.description.trim()
+      : undefined;
+    result.push({ ...(description ? { description } : {}), id, name });
+  }
+  return result;
+}
+
+export function normalizeOmpThinkingConfig(value: unknown): OmpThinkingConfig | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const configId = typeof record.configId === 'string' ? record.configId.trim() : '';
+  if (!configId) return null;
+  return {
+    configId,
+    currentValue: typeof record.currentValue === 'string' && record.currentValue.trim()
+      ? record.currentValue
+      : null,
+    options: normalizeOmpConfigChoiceList(record.options),
+  };
+}
+
 const OMP_MODEL_PREFIX = 'omp:';
 
 export function encodeOmpModelId(rawId: string): string {
@@ -52,6 +97,43 @@ export function normalizeOmpConfigOptionModels(value: unknown): OmpDiscoveredMod
       modelId: record.value,
     };
   }));
+}
+
+export function normalizeOmpConfigChoices(
+  value: unknown,
+  category: 'mode' | 'thought_level',
+): { configId: string | null; currentValue: string | null; options: OmpConfigChoice[] } {
+  if (!Array.isArray(value)) return { configId: null, currentValue: null, options: [] };
+  const configOption = value.find(option => {
+    if (!option || typeof option !== 'object' || Array.isArray(option)) return false;
+    const record = option as Record<string, unknown>;
+    return record.type === 'select'
+      && (record.category === category || (category === 'thought_level' && record.id === 'thinking'));
+  }) as Record<string, unknown> | undefined;
+  if (!configOption || !Array.isArray(configOption.options)) {
+    return { configId: null, currentValue: null, options: [] };
+  }
+  const seen = new Set<string>();
+  const options: OmpConfigChoice[] = [];
+  for (const option of configOption.options) {
+    if (!option || typeof option !== 'object' || Array.isArray(option)) continue;
+    const record = option as Record<string, unknown>;
+    const id = typeof record.value === 'string' ? record.value.trim() : '';
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    const name = typeof record.name === 'string' && record.name.trim() ? record.name.trim() : id;
+    const description = typeof record.description === 'string' && record.description.trim()
+      ? record.description.trim()
+      : undefined;
+    options.push({ ...(description ? { description } : {}), id, name });
+  }
+  return {
+    configId: typeof configOption.id === 'string' && configOption.id.trim() ? configOption.id : null,
+    currentValue: typeof configOption.currentValue === 'string' && configOption.currentValue.trim()
+      ? configOption.currentValue
+      : null,
+    options,
+  };
 }
 
 export function normalizeOmpVisibleModels(

--- a/src/providers/omp/registration.ts
+++ b/src/providers/omp/registration.ts
@@ -1,0 +1,32 @@
+import { NOOP_TASK_RESULT_INTERPRETER } from '../../core/providers/NoopTaskResultInterpreter';
+import type { ProviderModule } from '../../core/providers/types';
+import { ompWorkspaceRegistration } from './app/OmpWorkspaceServices';
+import { OMP_PROVIDER_CAPABILITIES } from './capabilities';
+import { ompSettingsReconciler } from './env/OmpSettingsReconciler';
+import { OmpExecutionBackend } from './execution/OmpExecutionBackend';
+import { OmpConversationHistoryService } from './history/OmpConversationHistoryService';
+import { getOmpProviderSettings, updateOmpProviderSettings } from './settings';
+import { ompChatUIConfig } from './ui/OmpChatUIConfig';
+
+export const ompProviderRegistration: ProviderModule = {
+  id: 'omp',
+  blankTabOrder: 12,
+  capabilities: OMP_PROVIDER_CAPABILITIES,
+  chatUIConfig: ompChatUIConfig,
+  createExecutionBackend: plugin => new OmpExecutionBackend(plugin),
+  displayName: 'OMP',
+  environmentKeyPatterns: [/^(?:OMP|PI)_/i],
+  historyService: new OmpConversationHistoryService(),
+  isEnabled: settings => getOmpProviderSettings(settings).enabled,
+  setEnabled: (settings, enabled) => updateOmpProviderSettings(settings, { enabled }),
+  settingsReconciler: ompSettingsReconciler,
+  settingsStorage: {
+    hostScopedFields: ['cliPathsByHost'],
+    normalizeStored(target, stored) {
+      updateOmpProviderSettings(target, getOmpProviderSettings(stored));
+      return false;
+    },
+  },
+  taskResultInterpreter: NOOP_TASK_RESULT_INTERPRETER,
+  workspace: ompWorkspaceRegistration,
+};

--- a/src/providers/omp/runtime/OmpCliResolver.ts
+++ b/src/providers/omp/runtime/OmpCliResolver.ts
@@ -1,0 +1,24 @@
+import { CachedProviderCliResolver } from '../../../core/providers/cli/CachedProviderCliResolver';
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import { getOmpProviderSettings } from '../settings';
+
+export class OmpCliResolver {
+  private readonly resolver = new CachedProviderCliResolver({
+    binaryName: 'omp',
+    getSettingsProjection: settings => {
+      const provider = getOmpProviderSettings(settings);
+      return {
+        cliPathsByHost: provider.cliPathsByHost,
+        environmentText: getRuntimeEnvironmentText(settings, 'omp'),
+        legacyCliPath: provider.cliPath,
+      };
+    },
+    providerId: 'omp',
+  });
+
+  resolveFromSettings(settings: Record<string, unknown>): string | null {
+    return this.resolver.resolveFromSettings(settings);
+  }
+
+  reset(): void { this.resolver.reset(); }
+}

--- a/src/providers/omp/runtime/OmpLaunchSpec.ts
+++ b/src/providers/omp/runtime/OmpLaunchSpec.ts
@@ -1,0 +1,37 @@
+import * as path from 'node:path';
+
+import type { OmpProviderSettings } from '../settings';
+
+export interface BuildOmpLaunchSpecParams {
+  command: string;
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  settings: OmpProviderSettings;
+}
+
+export interface OmpLaunchSpec {
+  args: string[];
+  command: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+}
+
+export function buildOmpLaunchSpec(params: BuildOmpLaunchSpecParams): OmpLaunchSpec {
+  return {
+    args: ['acp'],
+    command: params.command,
+    cwd: params.cwd,
+    env: withCommandDirectoryOnPath(params.command, params.env ?? process.env),
+  };
+}
+
+function withCommandDirectoryOnPath(command: string, env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const commandPath = command.trim();
+  if (!path.isAbsolute(commandPath)) return env;
+
+  const commandDirectory = path.dirname(commandPath);
+  const existingPath = env.PATH ?? '';
+  const entries = existingPath.split(path.delimiter).filter(Boolean);
+  if (entries.includes(commandDirectory)) return env;
+  return { ...env, PATH: [commandDirectory, ...entries].join(path.delimiter) };
+}

--- a/src/providers/omp/settings.ts
+++ b/src/providers/omp/settings.ts
@@ -1,0 +1,66 @@
+import { getProviderConfig, setProviderConfig } from '../../core/providers/providerConfig';
+import { getProviderEnvironmentVariables } from '../../core/providers/providerEnvironment';
+import { normalizeHostnameStringMap } from '../../core/providers/settings/HostnameStringMap';
+import type { HostnameCliPaths } from '../../core/types/settings';
+import {
+  normalizeOmpDiscoveredModels,
+  normalizeOmpVisibleModels,
+  type OmpDiscoveredModel,
+} from './models';
+
+export interface OmpProviderSettings {
+  cliPath: string;
+  cliPathsByHost: HostnameCliPaths;
+  enabled: boolean;
+  environmentHash: string;
+  environmentVariables: string;
+  discoveredModels: OmpDiscoveredModel[];
+  visibleModels: string[];
+}
+
+export const DEFAULT_OMP_PROVIDER_SETTINGS: Readonly<OmpProviderSettings> = Object.freeze({
+  cliPath: '',
+  cliPathsByHost: {},
+  enabled: false,
+  environmentHash: '',
+  environmentVariables: '',
+  discoveredModels: [],
+  visibleModels: [],
+});
+
+export function getOmpProviderSettings(settings: Record<string, unknown>): OmpProviderSettings {
+  const config = getProviderConfig(settings, 'omp');
+  const discoveredModels = normalizeOmpDiscoveredModels(config.discoveredModels);
+  return {
+    cliPath: typeof config.cliPath === 'string' ? config.cliPath : DEFAULT_OMP_PROVIDER_SETTINGS.cliPath,
+    cliPathsByHost: normalizeHostnameStringMap(config.cliPathsByHost),
+    enabled: config.enabled === true,
+    environmentHash: typeof config.environmentHash === 'string' ? config.environmentHash : '',
+    environmentVariables: typeof config.environmentVariables === 'string'
+      ? config.environmentVariables
+      : getProviderEnvironmentVariables(settings, 'omp') ?? '',
+    discoveredModels,
+    visibleModels: normalizeOmpVisibleModels(config.visibleModels, discoveredModels),
+  };
+}
+
+export function updateOmpProviderSettings(
+  settings: Record<string, unknown>,
+  updates: Partial<OmpProviderSettings>,
+): OmpProviderSettings {
+  const current = getOmpProviderSettings(settings);
+  const discoveredModels = normalizeOmpDiscoveredModels(
+    updates.discoveredModels ?? current.discoveredModels,
+  );
+  const next = {
+    ...current,
+    ...updates,
+    discoveredModels,
+    visibleModels: normalizeOmpVisibleModels(
+      updates.visibleModels ?? current.visibleModels,
+      discoveredModels,
+    ),
+  };
+  setProviderConfig(settings, 'omp', next);
+  return next;
+}

--- a/src/providers/omp/settings.ts
+++ b/src/providers/omp/settings.ts
@@ -3,11 +3,9 @@ import { getProviderEnvironmentVariables } from '../../core/providers/providerEn
 import { normalizeHostnameStringMap } from '../../core/providers/settings/HostnameStringMap';
 import type { HostnameCliPaths } from '../../core/types/settings';
 import {
-  normalizeOmpConfigChoiceList,
   normalizeOmpDiscoveredModels,
   normalizeOmpThinkingConfig,
   normalizeOmpVisibleModels,
-  type OmpConfigChoice,
   type OmpDiscoveredModel,
   type OmpThinkingConfig,
 } from './models';
@@ -15,11 +13,9 @@ import {
 export interface OmpProviderSettings {
   cliPath: string;
   cliPathsByHost: HostnameCliPaths;
-  availableModes: OmpConfigChoice[];
   enabled: boolean;
   environmentHash: string;
   environmentVariables: string;
-  selectedMode: string;
   thinking: OmpThinkingConfig | null;
   discoveredModels: OmpDiscoveredModel[];
   visibleModels: string[];
@@ -28,11 +24,9 @@ export interface OmpProviderSettings {
 export const DEFAULT_OMP_PROVIDER_SETTINGS: Readonly<OmpProviderSettings> = Object.freeze({
   cliPath: '',
   cliPathsByHost: {},
-  availableModes: [],
   enabled: false,
   environmentHash: '',
   environmentVariables: '',
-  selectedMode: 'default',
   thinking: null,
   discoveredModels: [],
   visibleModels: [],
@@ -44,15 +38,11 @@ export function getOmpProviderSettings(settings: Record<string, unknown>): OmpPr
   return {
     cliPath: typeof config.cliPath === 'string' ? config.cliPath : DEFAULT_OMP_PROVIDER_SETTINGS.cliPath,
     cliPathsByHost: normalizeHostnameStringMap(config.cliPathsByHost),
-    availableModes: normalizeOmpConfigChoiceList(config.availableModes),
     enabled: config.enabled === true,
     environmentHash: typeof config.environmentHash === 'string' ? config.environmentHash : '',
     environmentVariables: typeof config.environmentVariables === 'string'
       ? config.environmentVariables
       : getProviderEnvironmentVariables(settings, 'omp') ?? '',
-    selectedMode: typeof config.selectedMode === 'string' && config.selectedMode.trim()
-      ? config.selectedMode
-      : DEFAULT_OMP_PROVIDER_SETTINGS.selectedMode,
     thinking: normalizeOmpThinkingConfig(config.thinking),
     discoveredModels,
     visibleModels: normalizeOmpVisibleModels(config.visibleModels, discoveredModels),

--- a/src/providers/omp/settings.ts
+++ b/src/providers/omp/settings.ts
@@ -3,17 +3,24 @@ import { getProviderEnvironmentVariables } from '../../core/providers/providerEn
 import { normalizeHostnameStringMap } from '../../core/providers/settings/HostnameStringMap';
 import type { HostnameCliPaths } from '../../core/types/settings';
 import {
+  normalizeOmpConfigChoiceList,
   normalizeOmpDiscoveredModels,
+  normalizeOmpThinkingConfig,
   normalizeOmpVisibleModels,
+  type OmpConfigChoice,
   type OmpDiscoveredModel,
+  type OmpThinkingConfig,
 } from './models';
 
 export interface OmpProviderSettings {
   cliPath: string;
   cliPathsByHost: HostnameCliPaths;
+  availableModes: OmpConfigChoice[];
   enabled: boolean;
   environmentHash: string;
   environmentVariables: string;
+  selectedMode: string;
+  thinking: OmpThinkingConfig | null;
   discoveredModels: OmpDiscoveredModel[];
   visibleModels: string[];
 }
@@ -21,9 +28,12 @@ export interface OmpProviderSettings {
 export const DEFAULT_OMP_PROVIDER_SETTINGS: Readonly<OmpProviderSettings> = Object.freeze({
   cliPath: '',
   cliPathsByHost: {},
+  availableModes: [],
   enabled: false,
   environmentHash: '',
   environmentVariables: '',
+  selectedMode: 'default',
+  thinking: null,
   discoveredModels: [],
   visibleModels: [],
 });
@@ -34,11 +44,16 @@ export function getOmpProviderSettings(settings: Record<string, unknown>): OmpPr
   return {
     cliPath: typeof config.cliPath === 'string' ? config.cliPath : DEFAULT_OMP_PROVIDER_SETTINGS.cliPath,
     cliPathsByHost: normalizeHostnameStringMap(config.cliPathsByHost),
+    availableModes: normalizeOmpConfigChoiceList(config.availableModes),
     enabled: config.enabled === true,
     environmentHash: typeof config.environmentHash === 'string' ? config.environmentHash : '',
     environmentVariables: typeof config.environmentVariables === 'string'
       ? config.environmentVariables
       : getProviderEnvironmentVariables(settings, 'omp') ?? '',
+    selectedMode: typeof config.selectedMode === 'string' && config.selectedMode.trim()
+      ? config.selectedMode
+      : DEFAULT_OMP_PROVIDER_SETTINGS.selectedMode,
+    thinking: normalizeOmpThinkingConfig(config.thinking),
     discoveredModels,
     visibleModels: normalizeOmpVisibleModels(config.visibleModels, discoveredModels),
   };

--- a/src/providers/omp/ui/OmpChatUIConfig.ts
+++ b/src/providers/omp/ui/OmpChatUIConfig.ts
@@ -7,15 +7,13 @@ import {
   decodeOmpModelId,
   encodeOmpModelId,
 } from '../models';
-import { getOmpProviderSettings, updateOmpProviderSettings } from '../settings';
+import { getOmpProviderSettings } from '../settings';
 
 const PERMISSION_MODE: ProviderPermissionModeToggleConfig = {
-  inactiveValue: 'plan',
-  inactiveLabel: 'Plan',
+  inactiveValue: 'normal',
+  inactiveLabel: 'Safe',
   activeValue: 'yolo',
-  activeLabel: 'Build',
-  planValue: 'plan',
-  planLabel: 'Plan',
+  activeLabel: 'YOLO',
 };
 
 export const ompChatUIConfig: ProviderChatUIConfig = {
@@ -53,14 +51,11 @@ export const ompChatUIConfig: ProviderChatUIConfig = {
   getCustomModelIds: () => new Set<string>(),
   getPermissionModeToggle: (): ProviderPermissionModeToggleConfig => PERMISSION_MODE,
   resolvePermissionMode(settings) {
-    const omp = getOmpProviderSettings(settings);
-    if (omp.selectedMode === 'plan') return 'plan';
-    return 'yolo';
+    return settings.permissionMode === 'yolo' ? 'yolo' : 'normal';
   },
   applyPermissionMode(value, settings) {
     if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return;
     const target = settings as Record<string, unknown>;
-    target.permissionMode = value;
-    updateOmpProviderSettings(target, { selectedMode: value === 'plan' ? 'plan' : 'default' });
+    target.permissionMode = value === 'yolo' ? 'yolo' : 'normal';
   },
 };

--- a/src/providers/omp/ui/OmpChatUIConfig.ts
+++ b/src/providers/omp/ui/OmpChatUIConfig.ts
@@ -10,10 +10,10 @@ import {
 import { getOmpProviderSettings, updateOmpProviderSettings } from '../settings';
 
 const PERMISSION_MODE: ProviderPermissionModeToggleConfig = {
-  inactiveValue: 'normal',
-  inactiveLabel: 'Read-only',
+  inactiveValue: 'plan',
+  inactiveLabel: 'Plan',
   activeValue: 'yolo',
-  activeLabel: 'All tools',
+  activeLabel: 'Build',
   planValue: 'plan',
   planLabel: 'Plan',
 };
@@ -55,7 +55,7 @@ export const ompChatUIConfig: ProviderChatUIConfig = {
   resolvePermissionMode(settings) {
     const omp = getOmpProviderSettings(settings);
     if (omp.selectedMode === 'plan') return 'plan';
-    return typeof settings.permissionMode === 'string' ? settings.permissionMode : 'normal';
+    return 'yolo';
   },
   applyPermissionMode(value, settings) {
     if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return;

--- a/src/providers/omp/ui/OmpChatUIConfig.ts
+++ b/src/providers/omp/ui/OmpChatUIConfig.ts
@@ -2,7 +2,11 @@ import type {
   ProviderChatUIConfig,
   ProviderPermissionModeToggleConfig,
 } from '../../../core/providers/types';
-import { decodeOmpModelId, encodeOmpModelId } from '../models';
+import {
+  decodeOmpModelId,
+  encodeOmpModelId,
+  type OmpConfigChoice,
+} from '../models';
 import { getOmpProviderSettings, updateOmpProviderSettings } from '../settings';
 
 const PERMISSION_MODE: ProviderPermissionModeToggleConfig = {
@@ -13,6 +17,11 @@ const PERMISSION_MODE: ProviderPermissionModeToggleConfig = {
   planValue: 'plan',
   planLabel: 'Plan',
 };
+
+const OMP_FALLBACK_MODES = [
+  { id: 'default', name: 'Default' },
+  { id: 'plan', name: 'Plan' },
+] as const;
 
 export const ompChatUIConfig: ProviderChatUIConfig = {
   getModelOptions(settings) {
@@ -55,5 +64,31 @@ export const ompChatUIConfig: ProviderChatUIConfig = {
     const target = settings as Record<string, unknown>;
     target.permissionMode = value;
     updateOmpProviderSettings(target, { selectedMode: value === 'plan' ? 'plan' : 'default' });
+  },
+  getModeSelector(settings) {
+    const omp = getOmpProviderSettings(settings);
+    const modes: readonly OmpConfigChoice[] = omp.availableModes.length === 2
+      ? omp.availableModes
+      : OMP_FALLBACK_MODES;
+    return {
+      label: 'Mode',
+      options: modes.map(mode => ({
+        ...(mode.description ? { description: mode.description } : {}),
+        label: mode.name,
+        value: mode.id,
+      })),
+      value: modes.some(mode => mode.id === omp.selectedMode) ? omp.selectedMode : modes[0].id,
+    };
+  },
+  applyModeSelection(value, settings) {
+    if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return;
+    const target = settings as Record<string, unknown>;
+    const available = getOmpProviderSettings(target).availableModes;
+    const modes: readonly OmpConfigChoice[] = available.length === 2
+      ? available
+      : OMP_FALLBACK_MODES;
+    if (!modes.some(mode => mode.id === value)) return;
+    target.permissionMode = value === 'plan' ? 'plan' : 'normal';
+    updateOmpProviderSettings(target, { selectedMode: value });
   },
 };

--- a/src/providers/omp/ui/OmpChatUIConfig.ts
+++ b/src/providers/omp/ui/OmpChatUIConfig.ts
@@ -5,7 +5,6 @@ import type {
 import {
   decodeOmpModelId,
   encodeOmpModelId,
-  type OmpConfigChoice,
 } from '../models';
 import { getOmpProviderSettings, updateOmpProviderSettings } from '../settings';
 
@@ -17,11 +16,6 @@ const PERMISSION_MODE: ProviderPermissionModeToggleConfig = {
   planValue: 'plan',
   planLabel: 'Plan',
 };
-
-const OMP_FALLBACK_MODES = [
-  { id: 'default', name: 'Default' },
-  { id: 'plan', name: 'Plan' },
-] as const;
 
 export const ompChatUIConfig: ProviderChatUIConfig = {
   getModelOptions(settings) {
@@ -64,31 +58,5 @@ export const ompChatUIConfig: ProviderChatUIConfig = {
     const target = settings as Record<string, unknown>;
     target.permissionMode = value;
     updateOmpProviderSettings(target, { selectedMode: value === 'plan' ? 'plan' : 'default' });
-  },
-  getModeSelector(settings) {
-    const omp = getOmpProviderSettings(settings);
-    const modes: readonly OmpConfigChoice[] = omp.availableModes.length === 2
-      ? omp.availableModes
-      : OMP_FALLBACK_MODES;
-    return {
-      label: 'Mode',
-      options: modes.map(mode => ({
-        ...(mode.description ? { description: mode.description } : {}),
-        label: mode.name,
-        value: mode.id,
-      })),
-      value: modes.some(mode => mode.id === omp.selectedMode) ? omp.selectedMode : modes[0].id,
-    };
-  },
-  applyModeSelection(value, settings) {
-    if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return;
-    const target = settings as Record<string, unknown>;
-    const available = getOmpProviderSettings(target).availableModes;
-    const modes: readonly OmpConfigChoice[] = available.length === 2
-      ? available
-      : OMP_FALLBACK_MODES;
-    if (!modes.some(mode => mode.id === value)) return;
-    target.permissionMode = value === 'plan' ? 'plan' : 'normal';
-    updateOmpProviderSettings(target, { selectedMode: value });
   },
 };

--- a/src/providers/omp/ui/OmpChatUIConfig.ts
+++ b/src/providers/omp/ui/OmpChatUIConfig.ts
@@ -3,13 +3,15 @@ import type {
   ProviderPermissionModeToggleConfig,
 } from '../../../core/providers/types';
 import { decodeOmpModelId, encodeOmpModelId } from '../models';
-import { getOmpProviderSettings } from '../settings';
+import { getOmpProviderSettings, updateOmpProviderSettings } from '../settings';
 
 const PERMISSION_MODE: ProviderPermissionModeToggleConfig = {
   inactiveValue: 'normal',
   inactiveLabel: 'Read-only',
   activeValue: 'yolo',
   activeLabel: 'All tools',
+  planValue: 'plan',
+  planLabel: 'Plan',
 };
 
 export const ompChatUIConfig: ProviderChatUIConfig = {
@@ -30,13 +32,28 @@ export const ompChatUIConfig: ProviderChatUIConfig = {
     return rawId ? encodeOmpModelId(rawId) : null;
   },
   ownsModel: model => decodeOmpModelId(model) !== null,
-  isAdaptiveReasoningModel: () => false,
-  getReasoningOptions: () => [{ label: 'Default', value: 'default' }],
-  getDefaultReasoningValue: () => 'default',
+  isAdaptiveReasoningModel: (_model, settings) => getOmpProviderSettings(settings).thinking !== null,
+  getReasoningOptions: (_model, settings) => getOmpProviderSettings(settings).thinking?.options.map(option => ({
+    ...(option.description ? { description: option.description } : {}),
+    label: option.name,
+    value: option.id,
+  })) ?? [],
+  getDefaultReasoningValue: (_model, settings) => getOmpProviderSettings(settings).thinking?.currentValue ?? 'default',
   getContextWindowSize: (_model, customLimits) => customLimits?.omp ?? 200_000,
   isDefaultModel: model => decodeOmpModelId(model) !== null,
   applyModelDefaults: () => undefined,
   normalizeModelVariant: model => model,
   getCustomModelIds: () => new Set<string>(),
   getPermissionModeToggle: (): ProviderPermissionModeToggleConfig => PERMISSION_MODE,
+  resolvePermissionMode(settings) {
+    const omp = getOmpProviderSettings(settings);
+    if (omp.selectedMode === 'plan') return 'plan';
+    return typeof settings.permissionMode === 'string' ? settings.permissionMode : 'normal';
+  },
+  applyPermissionMode(value, settings) {
+    if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return;
+    const target = settings as Record<string, unknown>;
+    target.permissionMode = value;
+    updateOmpProviderSettings(target, { selectedMode: value === 'plan' ? 'plan' : 'default' });
+  },
 };

--- a/src/providers/omp/ui/OmpChatUIConfig.ts
+++ b/src/providers/omp/ui/OmpChatUIConfig.ts
@@ -1,0 +1,42 @@
+import type {
+  ProviderChatUIConfig,
+  ProviderPermissionModeToggleConfig,
+} from '../../../core/providers/types';
+import { decodeOmpModelId, encodeOmpModelId } from '../models';
+import { getOmpProviderSettings } from '../settings';
+
+const PERMISSION_MODE: ProviderPermissionModeToggleConfig = {
+  inactiveValue: 'normal',
+  inactiveLabel: 'Read-only',
+  activeValue: 'yolo',
+  activeLabel: 'All tools',
+};
+
+export const ompChatUIConfig: ProviderChatUIConfig = {
+  getModelOptions(settings) {
+    const provider = getOmpProviderSettings(settings);
+    const discovered = new Map(provider.discoveredModels.map(model => [model.rawId, model]));
+    return [...provider.visibleModels].reverse().flatMap(rawId => {
+      const model = discovered.get(rawId);
+      return model ? [{
+        description: model.description ?? 'OMP ACP runtime',
+        label: model.label,
+        value: encodeOmpModelId(rawId),
+      }] : [];
+    });
+  },
+  getDefaultModel: settings => {
+    const rawId = getOmpProviderSettings(settings).visibleModels[0];
+    return rawId ? encodeOmpModelId(rawId) : null;
+  },
+  ownsModel: model => decodeOmpModelId(model) !== null,
+  isAdaptiveReasoningModel: () => false,
+  getReasoningOptions: () => [{ label: 'Default', value: 'default' }],
+  getDefaultReasoningValue: () => 'default',
+  getContextWindowSize: (_model, customLimits) => customLimits?.omp ?? 200_000,
+  isDefaultModel: model => decodeOmpModelId(model) !== null,
+  applyModelDefaults: () => undefined,
+  normalizeModelVariant: model => model,
+  getCustomModelIds: () => new Set<string>(),
+  getPermissionModeToggle: (): ProviderPermissionModeToggleConfig => PERMISSION_MODE,
+};

--- a/src/providers/omp/ui/OmpChatUIConfig.ts
+++ b/src/providers/omp/ui/OmpChatUIConfig.ts
@@ -2,6 +2,7 @@ import type {
   ProviderChatUIConfig,
   ProviderPermissionModeToggleConfig,
 } from '../../../core/providers/types';
+import { buildInitialOmpUsageInfo } from '../execution/OmpExecutionSession';
 import {
   decodeOmpModelId,
   encodeOmpModelId,
@@ -42,6 +43,9 @@ export const ompChatUIConfig: ProviderChatUIConfig = {
     value: option.id,
   })) ?? [],
   getDefaultReasoningValue: (_model, settings) => getOmpProviderSettings(settings).thinking?.currentValue ?? 'default',
+  getInitialUsage(model) {
+    return buildInitialOmpUsageInfo(decodeOmpModelId(model) ?? undefined);
+  },
   getContextWindowSize: (_model, customLimits) => customLimits?.omp ?? 200_000,
   isDefaultModel: model => decodeOmpModelId(model) !== null,
   applyModelDefaults: () => undefined,

--- a/src/providers/omp/ui/OmpSettingsTab.ts
+++ b/src/providers/omp/ui/OmpSettingsTab.ts
@@ -1,0 +1,142 @@
+import * as fs from 'node:fs';
+
+import { Notice, Setting } from 'obsidian';
+
+import type {
+  ProviderSettingsTabRenderer,
+} from '../../../core/providers/types';
+import { renderHostnameCliPathSetting } from '../../../shared/settings/HostnameCliPathSetting';
+import { renderProviderEnablementSetting } from '../../../shared/settings/ProviderEnablementSetting';
+import {
+  type ProviderModelPickerModel,
+  type ProviderModelPickerState,
+  renderProviderModelPicker,
+} from '../../../shared/settings/ProviderModelPicker';
+import { getHostnameKey } from '../../../utils/env';
+import { expandHomePath } from '../../../utils/path';
+import { maybeGetOmpWorkspaceServices } from '../app/OmpWorkspaceServices';
+import { normalizeOmpVisibleModels } from '../models';
+import {
+  getOmpProviderSettings,
+  updateOmpProviderSettings,
+} from '../settings';
+
+export const ompSettingsTabRenderer: ProviderSettingsTabRenderer = {
+  render(container, context) {
+    const settings = context.plugin.settings as unknown as Record<string, unknown>;
+    const workspace = maybeGetOmpWorkspaceServices();
+    const hostnameKey = getHostnameKey();
+    new Setting(container).setName('Setup').setHeading();
+    renderProviderEnablementSetting({
+      container,
+      description: 'Enable the Oh My Pi ACP provider.',
+      getValue: () => getOmpProviderSettings(settings).enabled,
+      name: 'Enable OMP',
+      onChange: async enabled => {
+        await context.plugin.mutateSettings(target => {
+          updateOmpProviderSettings(target, { enabled });
+        });
+        context.notifyProviderModelOptionsChanged('omp');
+      },
+    });
+    renderHostnameCliPathSetting({
+      container,
+      description: 'Absolute path to OMP on this computer. This also makes its Bun runtime available to Obsidian.',
+      getValue: () => getOmpProviderSettings(settings).cliPathsByHost[hostnameKey] || '',
+      name: 'CLI path',
+      onChange: async value => {
+        const provider = getOmpProviderSettings(settings);
+        const cliPathsByHost = { ...provider.cliPathsByHost };
+        if (value) cliPathsByHost[hostnameKey] = value;
+        else delete cliPathsByHost[hostnameKey];
+        await context.plugin.applyProviderRuntimeSettings(
+          ['omp'],
+          target => {
+            updateOmpProviderSettings(target, { cliPathsByHost, discoveredModels: [] });
+          },
+          () => workspace?.cliResolver.reset(),
+        );
+        context.notifyProviderModelOptionsChanged('omp');
+      },
+      placeholder: process.platform === 'win32'
+        ? 'C:\\Users\\you\\.bun\\bin\\omp.exe'
+        : '/Users/you/.bun/bin/omp',
+      validate: validateCliPath,
+    });
+    new Setting(container).setName('Models').setHeading();
+    renderOmpModelPicker(container, context, settings);
+  },
+};
+
+function renderOmpModelPicker(
+  container: HTMLElement,
+  context: Parameters<ProviderSettingsTabRenderer['render']>[1],
+  settings: Record<string, unknown>,
+): void {
+  const getState = (): ProviderModelPickerState => {
+    const provider = getOmpProviderSettings(settings);
+    return {
+      aliases: {},
+      discoveredCount: provider.discoveredModels.length,
+      models: provider.discoveredModels.map(toPickerModel),
+      selectedIds: provider.visibleModels,
+    };
+  };
+  renderProviderModelPicker({
+    container,
+    emptyCatalogText: 'No OMP models discovered yet. Check OMP login and click Discover.',
+    failedCatalogText: 'Could not load the OMP model catalog. Check the CLI path and login state.',
+    getState,
+    async loadCatalog() {
+      const result = await maybeGetOmpWorkspaceServices()?.refreshModelCatalog?.();
+      if (!result || result.diagnostics) {
+        new Notice(`OMP model discovery failed: ${result?.diagnostics ?? 'OMP workspace is not initialized'}`);
+        return 'failed';
+      }
+      context.notifyProviderModelOptionsChanged('omp');
+      return getOmpProviderSettings(settings).discoveredModels.length > 0 ? 'loaded' : 'empty';
+    },
+    loadingCatalogText: 'Loading OMP models...',
+    modifier: 'omp',
+    onAliasesChange: async () => undefined,
+    async onSelectedIdsChange(visibleModels) {
+      await context.plugin.mutateSettings(target => {
+        const provider = getOmpProviderSettings(target);
+        updateOmpProviderSettings(target, {
+          visibleModels: normalizeOmpVisibleModels(visibleModels, provider.discoveredModels),
+        });
+      });
+      context.notifyProviderModelOptionsChanged('omp');
+    },
+    providerName: 'OMP',
+  });
+}
+
+function validateCliPath(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const expandedPath = expandHomePath(trimmed);
+  if (!fs.existsSync(expandedPath)) return 'Path does not exist';
+  return fs.statSync(expandedPath).isFile() ? null : 'Path must point to a file';
+}
+
+function toPickerModel(
+  model: ReturnType<typeof getOmpProviderSettings>['discoveredModels'][number],
+): ProviderModelPickerModel {
+  const [providerKey, ...modelIdParts] = model.rawId.split('/');
+  const providerLabel = providerKey ? formatProviderLabel(providerKey) : undefined;
+  return {
+    description: model.description,
+    id: model.rawId,
+    isAvailable: true,
+    name: model.label || modelIdParts.join('/') || model.rawId,
+    ...(providerKey && providerLabel ? { providerKey, providerLabel } : {}),
+  };
+}
+
+function formatProviderLabel(providerKey: string): string {
+  return providerKey
+    .split(/[-_]/u)
+    .map(part => part ? `${part[0].toUpperCase()}${part.slice(1)}` : part)
+    .join(' ');
+}

--- a/src/style/base/variables.css
+++ b/src/style/base/variables.css
@@ -8,6 +8,8 @@
   --claudian-brand-codex-rgb: 208, 208, 208;
   --claudian-brand-opencode: #B8B8B8;
   --claudian-brand-opencode-rgb: 184, 184, 184;
+  --claudian-brand-omp: #00B8D9;
+  --claudian-brand-omp-rgb: 0, 184, 217;
   --claudian-brand-pi: #ffffff;
   --claudian-brand-pi-rgb: 255, 255, 255;
   --claudian-brand-grok: #ffffff;
@@ -42,6 +44,11 @@ body.theme-light .claudian-container {
 .claudian-container[data-provider="opencode"] {
   --claudian-brand: var(--claudian-brand-opencode);
   --claudian-brand-rgb: var(--claudian-brand-opencode-rgb);
+}
+
+.claudian-container[data-provider="omp"] {
+  --claudian-brand: var(--claudian-brand-omp);
+  --claudian-brand-rgb: var(--claudian-brand-omp-rgb);
 }
 
 .claudian-container[data-provider="pi"] {

--- a/src/style/components/tabs.css
+++ b/src/style/components/tabs.css
@@ -82,6 +82,10 @@
   border-color: var(--claudian-brand-opencode, #C8C8C8);
 }
 
+.claudian-tab-badge-streaming[data-provider="omp"] {
+  border-color: var(--claudian-brand-omp, #00B8D9);
+}
+
 .claudian-tab-badge-streaming[data-provider="pi"] {
   border-color: var(--claudian-brand-pi, #ffffff);
 }

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -185,7 +185,7 @@ describe('ClaudianPlugin', () => {
 
       expect((plugin.addRibbonIcon as jest.Mock)).toHaveBeenCalledWith(
         'bot',
-        'Open Claudian',
+        'Open Oh My Claudian',
         expect.any(Function)
       );
     });

--- a/tests/unit/features/chat/ui/InputToolbar.test.ts
+++ b/tests/unit/features/chat/ui/InputToolbar.test.ts
@@ -670,7 +670,7 @@ describe('PermissionToggle', () => {
     expect(label?.textContent).toBe('YOLO');
   });
 
-  it('should show PLAN label and hide toggle in plan mode', () => {
+  it('should show PLAN label and keep the toggle available in plan mode', () => {
     callbacks.getSettings.mockReturnValue({
       model: 'sonnet',
       thinkingBudget: 'low',
@@ -687,7 +687,7 @@ describe('PermissionToggle', () => {
     expect(label?.hasClass('plan-active')).toBe(true);
 
     const toggle = parentEl2.querySelector('.claudian-toggle-switch');
-    expect(toggle?.style.display).toBe('none');
+    expect(toggle?.style.display).not.toBe('none');
   });
 
   it('should add active class when in yolo mode', () => {
@@ -720,6 +720,19 @@ describe('PermissionToggle', () => {
       model: 'sonnet',
       thinkingBudget: 'low',
       permissionMode: 'yolo',
+    });
+    const parentEl2 = createMockEl();
+    new PermissionToggle(parentEl2, callbacks);
+
+    const toggle = parentEl2.querySelector('.claudian-toggle-switch');
+    await toggle?.dispatchEvent('click');
+    expect(callbacks.onPermissionModeChange).toHaveBeenCalledWith('plan');
+  });
+
+  it('should toggle from plan back to normal on click', async () => {
+    callbacks.getSettings.mockReturnValue({
+      model: 'sonnet',
+      permissionMode: 'plan',
     });
     const parentEl2 = createMockEl();
     new PermissionToggle(parentEl2, callbacks);

--- a/tests/unit/features/chat/ui/InputToolbar.test.ts
+++ b/tests/unit/features/chat/ui/InputToolbar.test.ts
@@ -1121,10 +1121,10 @@ describe('ContextUsageMeter', () => {
     expect(container?.style.display).toBe('none');
   });
 
-  it('should remain hidden when contextTokens is 0', () => {
+  it('should show a known context window even when contextTokens is 0', () => {
     meter.update(makeUsage({ contextTokens: 0, contextWindow: 200000, percentage: 0 }));
     const container = parentEl.querySelector('.claudian-context-meter');
-    expect(container?.style.display).toBe('none');
+    expect(container?.style.display).toBe('flex');
   });
 
   it('should become visible when contextTokens > 0', () => {

--- a/tests/unit/providers/ProviderModuleCatalog.test.ts
+++ b/tests/unit/providers/ProviderModuleCatalog.test.ts
@@ -7,6 +7,7 @@ describe('built-in ProviderModule catalog', () => {
       'codex',
       'grok',
       'opencode',
+      'omp',
       'pi',
     ]);
     for (const module of BUILT_IN_PROVIDER_MODULES) {

--- a/tests/unit/providers/omp/OmpBrandColor.test.ts
+++ b/tests/unit/providers/omp/OmpBrandColor.test.ts
@@ -1,0 +1,27 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+describe('OMP brand color', () => {
+  const variablesCss = fs.readFileSync(
+    path.join(process.cwd(), 'src/style/base/variables.css'),
+    'utf8',
+  );
+  const tabsCss = fs.readFileSync(
+    path.join(process.cwd(), 'src/style/components/tabs.css'),
+    'utf8',
+  );
+
+  it('uses OMP cyan instead of the Claude brand token', () => {
+    expect(variablesCss).toContain('--claudian-brand-omp: #00B8D9;');
+    expect(variablesCss).toContain('--claudian-brand-omp-rgb: 0, 184, 217;');
+  });
+
+  it('routes active and streaming OMP surfaces through its brand token', () => {
+    expect(variablesCss).toMatch(
+      /\.claudian-container\[data-provider="omp"\] \{[\s\S]*?--claudian-brand: var\(--claudian-brand-omp\);[\s\S]*?--claudian-brand-rgb: var\(--claudian-brand-omp-rgb\);[\s\S]*?\}/,
+    );
+    expect(tabsCss).toMatch(
+      /\.claudian-tab-badge-streaming\[data-provider="omp"\] \{[\s\S]*?border-color: var\(--claudian-brand-omp, #00B8D9\);[\s\S]*?\}/,
+    );
+  });
+});

--- a/tests/unit/providers/omp/OmpChatUIConfig.test.ts
+++ b/tests/unit/providers/omp/OmpChatUIConfig.test.ts
@@ -28,6 +28,14 @@ describe('OMP chat configuration', () => {
     ]);
     expect(ompChatUIConfig.getDefaultReasoningValue('omp:openai/gpt-5-mini', settings)).toBe('auto');
     expect(ompChatUIConfig.resolvePermissionMode?.(settings)).toBe('plan');
+    expect(ompChatUIConfig.getModeSelector?.(settings)).toEqual({
+      label: 'Mode',
+      options: [
+        { label: 'Default', value: 'default' },
+        { label: 'Plan', value: 'plan' },
+      ],
+      value: 'plan',
+    });
   });
 
   it('maps the shared plan control to OMP native mode selection', () => {
@@ -35,5 +43,12 @@ describe('OMP chat configuration', () => {
     expect(ompChatUIConfig.resolvePermissionMode?.(settings)).toBe('normal');
     ompChatUIConfig.applyPermissionMode?.('plan', settings);
     expect(ompChatUIConfig.resolvePermissionMode?.(settings)).toBe('plan');
+  });
+
+  it('updates the visible OMP mode selector', () => {
+    ompChatUIConfig.applyModeSelection?.('default', settings);
+    expect(ompChatUIConfig.getModeSelector?.(settings)?.value).toBe('default');
+    ompChatUIConfig.applyModeSelection?.('plan', settings);
+    expect(ompChatUIConfig.getModeSelector?.(settings)?.value).toBe('plan');
   });
 });

--- a/tests/unit/providers/omp/OmpChatUIConfig.test.ts
+++ b/tests/unit/providers/omp/OmpChatUIConfig.test.ts
@@ -38,4 +38,13 @@ describe('OMP chat configuration', () => {
     expect(ompChatUIConfig.resolvePermissionMode?.(settings)).toBe('plan');
   });
 
+  it('provides a context snapshot when restoring an OMP conversation', () => {
+    expect(ompChatUIConfig.getInitialUsage?.('omp:openai/gpt-5-mini', settings)).toMatchObject({
+      contextTokens: 0,
+      contextWindow: 200_000,
+      model: 'openai/gpt-5-mini',
+      percentage: 0,
+    });
+  });
+
 });

--- a/tests/unit/providers/omp/OmpChatUIConfig.test.ts
+++ b/tests/unit/providers/omp/OmpChatUIConfig.test.ts
@@ -31,9 +31,17 @@ describe('OMP chat configuration', () => {
     expect(ompChatUIConfig.getModeSelector?.(settings) ?? null).toBeNull();
   });
 
-  it('maps the shared plan control to OMP native mode selection', () => {
-    ompChatUIConfig.applyPermissionMode?.('normal', settings);
-    expect(ompChatUIConfig.resolvePermissionMode?.(settings)).toBe('normal');
+  it('exposes only Build and Plan through the shared control', () => {
+    expect(ompChatUIConfig.getPermissionModeToggle?.()).toEqual({
+      activeLabel: 'Build',
+      activeValue: 'yolo',
+      inactiveLabel: 'Plan',
+      inactiveValue: 'plan',
+      planLabel: 'Plan',
+      planValue: 'plan',
+    });
+    ompChatUIConfig.applyPermissionMode?.('yolo', settings);
+    expect(ompChatUIConfig.resolvePermissionMode?.(settings)).toBe('yolo');
     ompChatUIConfig.applyPermissionMode?.('plan', settings);
     expect(ompChatUIConfig.resolvePermissionMode?.(settings)).toBe('plan');
   });

--- a/tests/unit/providers/omp/OmpChatUIConfig.test.ts
+++ b/tests/unit/providers/omp/OmpChatUIConfig.test.ts
@@ -28,14 +28,7 @@ describe('OMP chat configuration', () => {
     ]);
     expect(ompChatUIConfig.getDefaultReasoningValue('omp:openai/gpt-5-mini', settings)).toBe('auto');
     expect(ompChatUIConfig.resolvePermissionMode?.(settings)).toBe('plan');
-    expect(ompChatUIConfig.getModeSelector?.(settings)).toEqual({
-      label: 'Mode',
-      options: [
-        { label: 'Default', value: 'default' },
-        { label: 'Plan', value: 'plan' },
-      ],
-      value: 'plan',
-    });
+    expect(ompChatUIConfig.getModeSelector?.(settings) ?? null).toBeNull();
   });
 
   it('maps the shared plan control to OMP native mode selection', () => {
@@ -45,10 +38,4 @@ describe('OMP chat configuration', () => {
     expect(ompChatUIConfig.resolvePermissionMode?.(settings)).toBe('plan');
   });
 
-  it('updates the visible OMP mode selector', () => {
-    ompChatUIConfig.applyModeSelection?.('default', settings);
-    expect(ompChatUIConfig.getModeSelector?.(settings)?.value).toBe('default');
-    ompChatUIConfig.applyModeSelection?.('plan', settings);
-    expect(ompChatUIConfig.getModeSelector?.(settings)?.value).toBe('plan');
-  });
 });

--- a/tests/unit/providers/omp/OmpChatUIConfig.test.ts
+++ b/tests/unit/providers/omp/OmpChatUIConfig.test.ts
@@ -5,7 +5,6 @@ describe('OMP chat configuration', () => {
   const settings: Record<string, unknown> = {
     providerConfigs: {
       omp: {
-        selectedMode: 'plan',
         thinking: {
           configId: 'thinking',
           currentValue: 'auto',
@@ -19,31 +18,29 @@ describe('OMP chat configuration', () => {
     },
   };
 
-  it('exposes OMP ACP thinking levels and the native plan mode', () => {
-    expect(OMP_PROVIDER_CAPABILITIES.supportsPlanMode).toBe(true);
+  it('exposes OMP ACP thinking levels without a provider plan mode', () => {
+    expect(OMP_PROVIDER_CAPABILITIES.supportsPlanMode).toBe(false);
     expect(ompChatUIConfig.getReasoningOptions('omp:openai/gpt-5-mini', settings)).toEqual([
       { label: 'Off', value: 'off' },
       { label: 'Auto', value: 'auto' },
       { label: 'High', value: 'high' },
     ]);
     expect(ompChatUIConfig.getDefaultReasoningValue('omp:openai/gpt-5-mini', settings)).toBe('auto');
-    expect(ompChatUIConfig.resolvePermissionMode?.(settings)).toBe('plan');
+    expect(ompChatUIConfig.resolvePermissionMode?.(settings)).toBe('normal');
     expect(ompChatUIConfig.getModeSelector?.(settings) ?? null).toBeNull();
   });
 
-  it('exposes only Build and Plan through the shared control', () => {
+  it('reuses the shared Safe and YOLO permission control', () => {
     expect(ompChatUIConfig.getPermissionModeToggle?.()).toEqual({
-      activeLabel: 'Build',
+      activeLabel: 'YOLO',
       activeValue: 'yolo',
-      inactiveLabel: 'Plan',
-      inactiveValue: 'plan',
-      planLabel: 'Plan',
-      planValue: 'plan',
+      inactiveLabel: 'Safe',
+      inactiveValue: 'normal',
     });
     ompChatUIConfig.applyPermissionMode?.('yolo', settings);
     expect(ompChatUIConfig.resolvePermissionMode?.(settings)).toBe('yolo');
-    ompChatUIConfig.applyPermissionMode?.('plan', settings);
-    expect(ompChatUIConfig.resolvePermissionMode?.(settings)).toBe('plan');
+    ompChatUIConfig.applyPermissionMode?.('normal', settings);
+    expect(ompChatUIConfig.resolvePermissionMode?.(settings)).toBe('normal');
   });
 
   it('provides a context snapshot when restoring an OMP conversation', () => {

--- a/tests/unit/providers/omp/OmpChatUIConfig.test.ts
+++ b/tests/unit/providers/omp/OmpChatUIConfig.test.ts
@@ -1,0 +1,39 @@
+import { OMP_PROVIDER_CAPABILITIES } from '@/providers/omp/capabilities';
+import { ompChatUIConfig } from '@/providers/omp/ui/OmpChatUIConfig';
+
+describe('OMP chat configuration', () => {
+  const settings: Record<string, unknown> = {
+    providerConfigs: {
+      omp: {
+        selectedMode: 'plan',
+        thinking: {
+          configId: 'thinking',
+          currentValue: 'auto',
+          options: [
+            { id: 'off', name: 'Off' },
+            { id: 'auto', name: 'Auto' },
+            { id: 'high', name: 'High' },
+          ],
+        },
+      },
+    },
+  };
+
+  it('exposes OMP ACP thinking levels and the native plan mode', () => {
+    expect(OMP_PROVIDER_CAPABILITIES.supportsPlanMode).toBe(true);
+    expect(ompChatUIConfig.getReasoningOptions('omp:openai/gpt-5-mini', settings)).toEqual([
+      { label: 'Off', value: 'off' },
+      { label: 'Auto', value: 'auto' },
+      { label: 'High', value: 'high' },
+    ]);
+    expect(ompChatUIConfig.getDefaultReasoningValue('omp:openai/gpt-5-mini', settings)).toBe('auto');
+    expect(ompChatUIConfig.resolvePermissionMode?.(settings)).toBe('plan');
+  });
+
+  it('maps the shared plan control to OMP native mode selection', () => {
+    ompChatUIConfig.applyPermissionMode?.('normal', settings);
+    expect(ompChatUIConfig.resolvePermissionMode?.(settings)).toBe('normal');
+    ompChatUIConfig.applyPermissionMode?.('plan', settings);
+    expect(ompChatUIConfig.resolvePermissionMode?.(settings)).toBe('plan');
+  });
+});

--- a/tests/unit/providers/omp/OmpExecutionSession.test.ts
+++ b/tests/unit/providers/omp/OmpExecutionSession.test.ts
@@ -1,0 +1,83 @@
+import { OmpExecutionSession } from '@/providers/omp/execution/OmpExecutionSession';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(next => { resolve = next; });
+  return { promise, resolve };
+}
+
+async function flush(): Promise<void> {
+  await new Promise<void>(resolve => setTimeout(resolve, 0));
+}
+
+describe('OmpExecutionSession', () => {
+  it('routes second-turn ACP notifications to the active run', async () => {
+    const firstPrompt = deferred<{ userMessageId: string }>();
+    const secondPrompt = deferred<{ userMessageId: string }>();
+    let kernelOptions: any;
+    const kernel = {
+      cancel: jest.fn(),
+      connect: jest.fn().mockResolvedValue(undefined),
+      dispose: jest.fn().mockResolvedValue(undefined),
+      openSession: jest.fn().mockResolvedValue({ configOptions: [], sessionId: 'omp-session' }),
+      prompt: jest.fn()
+        .mockReturnValueOnce(firstPrompt.promise)
+        .mockReturnValueOnce(secondPrompt.promise),
+      setConfigOption: jest.fn().mockResolvedValue(undefined),
+      setModel: jest.fn().mockResolvedValue(undefined),
+    };
+    const session = new OmpExecutionSession({ settings: {} } as never, {
+      interactionPort: {} as never,
+      lifecycle: 'persistent',
+      nativePersistence: 'provider-default',
+      vaultWorkingDirectory: '/vault',
+    }, {
+      createKernel: options => {
+        kernelOptions = options;
+        return kernel;
+      },
+    });
+    const request = {
+      configuration: { systemInstructions: { kind: 'provider-default' } },
+      input: [{ text: 'Hello', type: 'text' }],
+      signal: new AbortController().signal,
+      toolPolicy: { kind: 'provider-default' },
+    } as never;
+
+    const first = session.execute(request);
+    await flush();
+    firstPrompt.resolve({ userMessageId: 'first' });
+    for await (const event of first.events) {
+      expect(event).toBeDefined();
+    }
+
+    const second = session.execute(request);
+    const events: unknown[] = [];
+    const collecting = (async () => {
+      for await (const event of second.events) events.push(event);
+    })();
+    await flush();
+    await kernelOptions.onNotification({
+      sessionId: 'omp-session',
+      update: {
+        content: { text: 'Second reply', type: 'text' },
+        sessionUpdate: 'agent_message_chunk',
+      },
+    });
+    await kernelOptions.onNotification({
+      sessionId: 'omp-session',
+      update: { sessionUpdate: 'usage_update', size: 200_000, used: 42_000 },
+    });
+    secondPrompt.resolve({ userMessageId: 'second' });
+    await collecting;
+
+    expect(events).toContainEqual(expect.objectContaining({
+      text: 'Second reply',
+      type: 'text_delta',
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'usage_updated',
+      usage: expect.objectContaining({ contextTokens: 42_000, percentage: 21 }),
+    }));
+  });
+});

--- a/tests/unit/providers/omp/OmpHistoryStore.test.ts
+++ b/tests/unit/providers/omp/OmpHistoryStore.test.ts
@@ -1,0 +1,44 @@
+import { parseOmpSessionContent } from '@/providers/omp/history/OmpHistoryStore';
+
+describe('parseOmpSessionContent', () => {
+  it('projects OMP user and assistant JSONL messages without mutating native data', () => {
+    const content = [
+      JSON.stringify({ type: 'session', id: 'session-1' }),
+      JSON.stringify({
+        id: 'user-1',
+        message: { content: [{ type: 'text', text: 'Summarize this.' }], role: 'user', timestamp: '2026-08-04T00:00:00.000Z' },
+        type: 'message',
+      }),
+      JSON.stringify({
+        id: 'assistant-1',
+        message: {
+          content: [{ thinking: 'Thinking', type: 'thinking' }, { text: 'Summary', type: 'text' }],
+          role: 'assistant',
+          timestamp: '2026-08-04T00:00:01.000Z',
+        },
+        type: 'message',
+      }),
+    ].join('\n');
+
+    expect(parseOmpSessionContent(content)).toEqual([
+      {
+        content: 'Summarize this.',
+        id: 'user-1',
+        role: 'user',
+        timestamp: 1785801600000,
+        userMessageId: 'user-1',
+      },
+      {
+        assistantMessageId: 'assistant-1',
+        content: 'Summary',
+        contentBlocks: [
+          { content: 'Thinking', type: 'thinking' },
+          { content: 'Summary', type: 'text' },
+        ],
+        id: 'assistant-1',
+        role: 'assistant',
+        timestamp: 1785801601000,
+      },
+    ]);
+  });
+});

--- a/tests/unit/providers/omp/OmpLaunchSpec.test.ts
+++ b/tests/unit/providers/omp/OmpLaunchSpec.test.ts
@@ -1,0 +1,31 @@
+import { buildOmpLaunchSpec } from '@/providers/omp/runtime/OmpLaunchSpec';
+import { DEFAULT_OMP_PROVIDER_SETTINGS } from '@/providers/omp/settings';
+
+describe('buildOmpLaunchSpec', () => {
+  it('starts OMP in ACP mode with the conversation working directory', () => {
+    const spec = buildOmpLaunchSpec({
+      command: '/usr/local/bin/omp',
+      cwd: '/vault/project',
+      env: { OMP_PROFILE: 'test', PATH: '/usr/local/bin' },
+      settings: DEFAULT_OMP_PROVIDER_SETTINGS,
+    });
+
+    expect(spec).toEqual({
+      args: ['acp'],
+      command: '/usr/local/bin/omp',
+      cwd: '/vault/project',
+      env: { OMP_PROFILE: 'test', PATH: '/usr/local/bin' },
+    });
+  });
+
+  it('makes Bun available for an absolute OMP executable path', () => {
+    const spec = buildOmpLaunchSpec({
+      command: '/Users/lee/.bun/bin/omp',
+      cwd: '/vault/project',
+      env: { PATH: '/usr/bin:/bin' },
+      settings: DEFAULT_OMP_PROVIDER_SETTINGS,
+    });
+
+    expect(spec.env.PATH).toBe('/Users/lee/.bun/bin:/usr/bin:/bin');
+  });
+});

--- a/tests/unit/providers/omp/OmpModelDiscoveryService.test.ts
+++ b/tests/unit/providers/omp/OmpModelDiscoveryService.test.ts
@@ -1,0 +1,83 @@
+import { OmpModelDiscoveryService } from '@/providers/omp/metadata/OmpModelDiscoveryService';
+
+describe('OmpModelDiscoveryService', () => {
+  it('returns models advertised through OMP ACP config options', async () => {
+    const kernel = {
+      cancel: jest.fn(),
+      connect: jest.fn().mockResolvedValue(undefined),
+      dispose: jest.fn().mockResolvedValue(undefined),
+      openSession: jest.fn().mockResolvedValue({
+        configOptions: [{
+          category: 'model',
+          currentValue: 'openai/gpt-5-mini',
+          id: 'model',
+          name: 'Model',
+          options: [{
+            description: 'OpenAI/gpt-5-mini',
+            name: 'GPT-5 mini',
+            value: 'openai/gpt-5-mini',
+          }, {
+            description: 'Anthropic/claude-sonnet',
+            name: 'Claude Sonnet',
+            value: 'anthropic/claude-sonnet',
+          }],
+          type: 'select',
+        }],
+        sessionId: 'metadata-session',
+      }),
+      prompt: jest.fn(),
+      setModel: jest.fn(),
+    };
+    const plugin = {
+      app: { vault: { adapter: { basePath: '/vault' } } },
+    } as never;
+
+    const service = new OmpModelDiscoveryService(plugin, {
+      createKernel: () => kernel,
+    });
+
+    await expect(service.discover()).resolves.toEqual([
+      {
+        description: 'OpenAI/gpt-5-mini',
+        label: 'GPT-5 mini',
+        rawId: 'openai/gpt-5-mini',
+      },
+      {
+        description: 'Anthropic/claude-sonnet',
+        label: 'Claude Sonnet',
+        rawId: 'anthropic/claude-sonnet',
+      },
+    ]);
+    expect(kernel.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns every model that OMP ACP marks available', async () => {
+    const kernel = {
+      cancel: jest.fn(),
+      connect: jest.fn().mockResolvedValue(undefined),
+      dispose: jest.fn().mockResolvedValue(undefined),
+      openSession: jest.fn().mockResolvedValue({
+        configOptions: [{
+          currentValue: 'openai/gpt-5-mini', id: 'model', name: 'Model', options: [
+            { name: 'GPT-5 mini', value: 'openai/gpt-5-mini' },
+            { name: 'Claude Sonnet', value: 'anthropic/claude-sonnet' },
+          ], type: 'select',
+        }], sessionId: 'metadata-session',
+      }),
+      prompt: jest.fn(),
+      setModel: jest.fn(),
+    };
+    const plugin = {
+      app: { vault: { adapter: { basePath: '/vault' } } },
+    } as never;
+
+    const service = new OmpModelDiscoveryService(plugin, {
+      createKernel: () => kernel,
+    });
+
+    await expect(service.discover()).resolves.toEqual([
+      { label: 'GPT-5 mini', rawId: 'openai/gpt-5-mini' },
+      { label: 'Claude Sonnet', rawId: 'anthropic/claude-sonnet' },
+    ]);
+  });
+});

--- a/tests/unit/providers/omp/OmpModelDiscoveryService.test.ts
+++ b/tests/unit/providers/omp/OmpModelDiscoveryService.test.ts
@@ -1,7 +1,7 @@
 import { OmpModelDiscoveryService } from '@/providers/omp/metadata/OmpModelDiscoveryService';
 
 describe('OmpModelDiscoveryService', () => {
-  it('discovers OMP native mode and thinking choices alongside models', async () => {
+  it('discovers OMP thinking choices alongside models', async () => {
     const kernel = {
       cancel: jest.fn(),
       connect: jest.fn().mockResolvedValue(undefined),
@@ -33,10 +33,6 @@ describe('OmpModelDiscoveryService', () => {
 
     await expect(service.discoverCatalog()).resolves.toEqual({
       models: [{ label: 'GPT-5 mini', rawId: 'openai/gpt-5-mini' }],
-      modes: [
-        { id: 'default', name: 'Default' },
-        { id: 'plan', name: 'Plan' },
-      ],
       thinking: {
         configId: 'thinking',
         currentValue: 'auto',

--- a/tests/unit/providers/omp/OmpModelDiscoveryService.test.ts
+++ b/tests/unit/providers/omp/OmpModelDiscoveryService.test.ts
@@ -1,6 +1,53 @@
 import { OmpModelDiscoveryService } from '@/providers/omp/metadata/OmpModelDiscoveryService';
 
 describe('OmpModelDiscoveryService', () => {
+  it('discovers OMP native mode and thinking choices alongside models', async () => {
+    const kernel = {
+      cancel: jest.fn(),
+      connect: jest.fn().mockResolvedValue(undefined),
+      dispose: jest.fn().mockResolvedValue(undefined),
+      openSession: jest.fn().mockResolvedValue({
+        configOptions: [{
+          category: 'mode', currentValue: 'default', id: 'mode', name: 'Mode', options: [
+            { name: 'Default', value: 'default' },
+            { name: 'Plan', value: 'plan' },
+          ], type: 'select',
+        }, {
+          category: 'thought_level', currentValue: 'auto', id: 'thinking', name: 'Thinking', options: [
+            { name: 'Off', value: 'off' },
+            { name: 'Auto', value: 'auto' },
+          ], type: 'select',
+        }, {
+          category: 'model', currentValue: 'openai/gpt-5-mini', id: 'model', name: 'Model', options: [
+            { name: 'GPT-5 mini', value: 'openai/gpt-5-mini' },
+          ], type: 'select',
+        }],
+        sessionId: 'metadata-session',
+      }),
+      prompt: jest.fn(),
+      setModel: jest.fn(),
+      setConfigOption: jest.fn(),
+    };
+    const plugin = { app: { vault: { adapter: { basePath: '/vault' } } } } as never;
+    const service = new OmpModelDiscoveryService(plugin, { createKernel: () => kernel });
+
+    await expect(service.discoverCatalog()).resolves.toEqual({
+      models: [{ label: 'GPT-5 mini', rawId: 'openai/gpt-5-mini' }],
+      modes: [
+        { id: 'default', name: 'Default' },
+        { id: 'plan', name: 'Plan' },
+      ],
+      thinking: {
+        configId: 'thinking',
+        currentValue: 'auto',
+        options: [
+          { id: 'off', name: 'Off' },
+          { id: 'auto', name: 'Auto' },
+        ],
+      },
+    });
+  });
+
   it('returns models advertised through OMP ACP config options', async () => {
     const kernel = {
       cancel: jest.fn(),
@@ -27,6 +74,7 @@ describe('OmpModelDiscoveryService', () => {
       }),
       prompt: jest.fn(),
       setModel: jest.fn(),
+      setConfigOption: jest.fn(),
     };
     const plugin = {
       app: { vault: { adapter: { basePath: '/vault' } } },
@@ -66,6 +114,7 @@ describe('OmpModelDiscoveryService', () => {
       }),
       prompt: jest.fn(),
       setModel: jest.fn(),
+      setConfigOption: jest.fn(),
     };
     const plugin = {
       app: { vault: { adapter: { basePath: '/vault' } } },

--- a/tests/unit/providers/omp/OmpPromptEncoding.test.ts
+++ b/tests/unit/providers/omp/OmpPromptEncoding.test.ts
@@ -1,0 +1,22 @@
+import { buildOmpPrompt } from '@/providers/omp/execution/OmpExecutionSession';
+
+describe('OMP prompt encoding', () => {
+  it('includes the current note and editor selection in the ACP prompt', () => {
+    expect(buildOmpPrompt({
+      context: {
+        currentNote: { path: 'Projects/OMP.md' },
+        editorSelection: {
+          lineCount: 2,
+          mode: 'selection',
+          notePath: 'Projects/OMP.md',
+          selectedText: 'first line\nsecond line',
+          startLine: 8,
+        },
+      },
+      input: [{ text: 'Explain this', type: 'text' }],
+    } as never)).toEqual([{
+      text: `Explain this\n\n<linked_note path="Projects/OMP.md" />\n\n<editor_selection path="Projects/OMP.md" lines="8-9">\n<![CDATA[first line\nsecond line]]>\n</editor_selection>`,
+      type: 'text',
+    }]);
+  });
+});

--- a/tests/unit/providers/omp/OmpUsage.test.ts
+++ b/tests/unit/providers/omp/OmpUsage.test.ts
@@ -1,4 +1,7 @@
-import { buildOmpUsageInfo } from '@/providers/omp/execution/OmpExecutionSession';
+import {
+  buildInitialOmpUsageInfo,
+  buildOmpUsageInfo,
+} from '@/providers/omp/execution/OmpExecutionSession';
 
 describe('OMP usage projection', () => {
   it('projects ACP context usage into the chat context meter', () => {
@@ -11,6 +14,16 @@ describe('OMP usage projection', () => {
       inputTokens: 0,
       model: 'openai/gpt-5-mini',
       percentage: 21,
+    });
+  });
+
+  it('provides an initial context snapshot before ACP emits usage', () => {
+    expect(buildInitialOmpUsageInfo('openai/gpt-5-mini')).toMatchObject({
+      contextTokens: 0,
+      contextWindow: 200_000,
+      contextWindowIsAuthoritative: false,
+      model: 'openai/gpt-5-mini',
+      percentage: 0,
     });
   });
 });

--- a/tests/unit/providers/omp/OmpUsage.test.ts
+++ b/tests/unit/providers/omp/OmpUsage.test.ts
@@ -1,0 +1,16 @@
+import { buildOmpUsageInfo } from '@/providers/omp/execution/OmpExecutionSession';
+
+describe('OMP usage projection', () => {
+  it('projects ACP context usage into the chat context meter', () => {
+    expect(buildOmpUsageInfo({ size: 200_000, used: 42_000 }, 'openai/gpt-5-mini')).toEqual({
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      contextTokens: 42_000,
+      contextWindow: 200_000,
+      contextWindowIsAuthoritative: true,
+      inputTokens: 0,
+      model: 'openai/gpt-5-mini',
+      percentage: 21,
+    });
+  });
+});

--- a/tests/unit/providers/omp/models.test.ts
+++ b/tests/unit/providers/omp/models.test.ts
@@ -1,0 +1,56 @@
+import {
+  encodeOmpModelId,
+  normalizeOmpConfigOptionModels,
+  normalizeOmpDiscoveredModels,
+} from '@/providers/omp/models';
+
+describe('OMP models', () => {
+  it('normalizes real ACP model metadata into stable selector values', () => {
+    expect(normalizeOmpDiscoveredModels([
+      { description: 'Fast model', modelId: 'gpt-5-mini', name: 'OpenAI GPT-5 mini' },
+      { id: 'gpt-5-mini', name: 'Duplicate' },
+      { modelId: 'claude-sonnet', name: 'Claude Sonnet' },
+    ])).toEqual([
+      {
+        description: 'Fast model',
+        label: 'OpenAI GPT-5 mini',
+        rawId: 'gpt-5-mini',
+      },
+      {
+        label: 'Claude Sonnet',
+        rawId: 'claude-sonnet',
+      },
+    ]);
+  });
+
+  it('preserves persisted OMP model records during settings normalization', () => {
+    expect(normalizeOmpDiscoveredModels([
+      { description: 'openai/gpt-5-mini', label: 'GPT-5 mini', rawId: 'openai/gpt-5-mini' },
+    ])).toEqual([
+      { description: 'openai/gpt-5-mini', label: 'GPT-5 mini', rawId: 'openai/gpt-5-mini' },
+    ]);
+  });
+
+  it('keeps the provider namespace out of the native model id', () => {
+    expect(encodeOmpModelId('gpt-5-mini')).toBe('omp:gpt-5-mini');
+  });
+
+  it('reads OMP model choices from the ACP model config option', () => {
+    expect(normalizeOmpConfigOptionModels([
+      {
+        category: 'model',
+        currentValue: 'openai/gpt-5-mini',
+        id: 'model',
+        name: 'Model',
+        options: [
+          { description: 'openai/gpt-5-mini', name: 'GPT-5 mini', value: 'openai/gpt-5-mini' },
+          { name: 'Claude Sonnet', value: 'anthropic/claude-sonnet' },
+        ],
+        type: 'select',
+      },
+    ])).toEqual([
+      { description: 'openai/gpt-5-mini', label: 'GPT-5 mini', rawId: 'openai/gpt-5-mini' },
+      { label: 'Claude Sonnet', rawId: 'anthropic/claude-sonnet' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add an ACP-backed Oh My Pi (OMP) provider with model discovery, conversation context, history, and usage reporting.
- Add OMP Safe/YOLO permission handling and provider styling.
- Rename the plugin to Oh My Claudian and prepare the independent `2.1.0` release.

## Validation

- `npm run test:unit -- --runInBand tests/unit/providers/omp/OmpChatUIConfig.test.ts tests/unit/providers/omp/OmpModelDiscoveryService.test.ts tests/unit/features/chat/ui/InputToolbar.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `node scripts/check-release-version.mjs 2.1.0`