### PR TITLE
test: update renamed plugin expectations

### DIFF
--- a/tests/unit/i18n/i18n.test.ts
+++ b/tests/unit/i18n/i18n.test.ts
@@ -44,7 +44,7 @@ describe('i18n', () => {
 
     it('handles nested keys correctly', () => {
       const result = t('settings.userName.name' as TranslationKey);
-      expect(result).toBe('What should Claudian call you?');
+      expect(result).toBe('What should Oh My Claudian call you?');
     });
 
     it('handles deeply nested keys', () => {

--- a/tests/unit/i18n/locales.test.ts
+++ b/tests/unit/i18n/locales.test.ts
@@ -146,7 +146,7 @@ describe('locale files', () => {
   it('uses commands-and-skills copy for hidden Claude entries', () => {
     expect(english['settings.hiddenSlashCommands.name']).toBe('Hidden Commands and Skills');
     expect(english['settings.hiddenSlashCommands.desc']).toBe(
-      'Hide specific commands and skills from the dropdown. Useful for hiding Claude Code entries that are not relevant to Claudian. Enter names without the leading slash, one per line.',
+      'Hide specific commands and skills from the dropdown. Useful for hiding Claude Code entries that are not relevant to Oh My Claudian. Enter names without the leading slash, one per line.',
     );
   });
 });

--- a/tests/unit/shared/settings/ProviderModelEnablementWarning.test.ts
+++ b/tests/unit/shared/settings/ProviderModelEnablementWarning.test.ts
@@ -67,7 +67,7 @@ describe('renderLastEnabledProviderWarning', () => {
         role: 'status',
       },
       cls: expect.stringContaining('claudian-setting-validation-warning'),
-      text: 'At least one provider must remain enabled for Claudian to work.',
+      text: 'At least one provider must remain enabled for Oh My Claudian to work.',
     });
     expect(warningEl.toggleClass).toHaveBeenLastCalledWith('claudian-hidden', true);
 


### PR DESCRIPTION
## Summary

- Update assertions for the Oh My Claudian user-visible name.

## Validation

- `npm run test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `node scripts/check-release-version.mjs 2.1.0`