### PR TITLE
release: prepare 2.1.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Claudian
+# Contributing to Oh My Claudian
 
 Issues and pull requests are welcome. Issues are the preferred way to contribute: if you describe the problem and your environment clearly, I will review it and make a best effort to address it.
 
@@ -15,7 +15,7 @@ A useful issue explains the problem well enough for someone else to understand a
 - What you were trying to do.
 - What happened and what you expected instead.
 - Clear reproduction steps or a minimal example.
-- Your Claudian version, Obsidian version, operating system, provider, provider CLI version, and installation method.
+- Your Oh My Claudian version, Obsidian version, operating system, provider, provider CLI version, and installation method.
 - Relevant logs, screenshots, or recordings.
 
 Remove API keys, tokens, private vault content, personal paths, and other sensitive information before attaching logs or screenshots.
@@ -48,7 +48,7 @@ Provider contributions should preserve provider isolation, use provider-native b
 
 ## Development
 
-Claudian requires the Node.js version declared in `.node-version`.
+Oh My Claudian requires the Node.js version declared in `.node-version`.
 
 ```bash
 npm install

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Oh My Claudian is an Obsidian plugin that embeds coding agents in your vault. Agents can read, write, search, run commands, and carry out multi-step workflows in the vault working directory.
 
+[Install from Obsidian Community Plugins](https://community.obsidian.md/plugins/oh-my-claudian) · [View on GitHub](https://github.com/lee259/oh-my-claudian)
+
 > This repository is based on [YishenTu/claudian](https://github.com/YishenTu/claudian) and adds Oh My Pi (OMP) support through ACP.
 
 ## Added in This Repository
@@ -17,6 +19,7 @@ Oh My Claudian is an Obsidian plugin that embeds coding agents in your vault. Ag
 - Slash commands, skills, `@` mentions, and instruction mode.
 - Provider-specific planning, permissions, reasoning controls, and model selection.
 - MCP support where available from the selected provider.
+- Internationalized interface with 10 locales, including Simplified and Traditional Chinese.
 
 ## Requirements
 
@@ -30,7 +33,16 @@ Oh My Claudian is an Obsidian plugin that embeds coding agents in your vault. Ag
 - A compatible subscription or API provider.
 - Obsidian v1.7.2+ on macOS, Linux, or Windows.
 
-## Installation from Source
+## Installation
+
+### From Obsidian Community Plugins (recommended)
+
+1. Open Obsidian → **Settings → Community plugins → Browse**.
+2. Search for **Oh My Claudian**, install it, and enable the plugin.
+
+You can also open the [Oh My Claudian community plugin page](https://community.obsidian.md/plugins/oh-my-claudian) directly.
+
+### From source (development)
 
 ```bash
 cd /path/to/vault/.obsidian/plugins
@@ -41,6 +53,12 @@ npm run build
 ```
 
 Then enable the plugin in Obsidian under **Settings → Community plugins**.
+
+## Usage
+
+Open the chat sidebar from the ribbon icon or command palette. Select text and use the inline-edit hotkey to edit notes with a diff preview. Use `/` for commands and skills, `@` to reference vault files or provider resources, and the provider selector to choose Claude, Codex, Grok, OMP, OpenCode, or Pi.
+
+OMP requires its CLI to be installed and logged in separately. In **Settings → Oh My Claudian → OMP**, enable the provider, set the CLI path if it is not detected automatically, and use **Discover** to load available models.
 
 ## Development
 
@@ -59,6 +77,8 @@ Your input, attachments, and tool results are sent only to the provider you sele
 ## Troubleshooting
 
 If a provider CLI is not found, first leave its configured path blank so Oh My Claudian can auto-detect it. If detection fails, set the executable path in the provider settings and ensure its runtime is available to Obsidian's `PATH`.
+
+For OMP specifically, verify that the CLI is installed, logged in, and executable by the Obsidian desktop process. If model discovery fails, set the absolute OMP path in the OMP settings tab and try **Discover** again.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,31 @@ npm run lint
 npm run test
 ```
 
+## Release
+
+Releases are created automatically by [`.github/workflows/release.yml`](.github/workflows/release.yml) when a version tag is pushed.
+
+1. Update the version in `manifest.json` and commit the change.
+2. Run the local validation checks:
+
+   ```bash
+   npm run typecheck
+   npm run lint
+   npm run test
+   npm run build
+   ```
+
+3. Create a tag that exactly matches the `manifest.json` version, for example:
+
+   ```bash
+   git tag 2.1.2
+   git push origin 2.1.2
+   ```
+
+   If your writable remote is named `fork`, use `git push fork 2.1.2` instead.
+
+The workflow validates the version, builds the plugin, runs the performance check, generates release notes, and publishes `main.js`, `manifest.json`, and `styles.css` to the GitHub Release. These are the files used for the Obsidian Community Plugins release.
+
 ## Privacy
 
 Your input, attachments, and tool results are sent only to the provider you select: Claude, Codex, Grok, OMP, OpenCode, Pi, or their configured model providers. Oh My Claudian does not send telemetry. Network activity is limited to explicit provider work and configured MCP endpoints.
@@ -94,7 +119,18 @@ src/
 
 ## Contributing
 
-Issues and focused pull requests are welcome. Please describe the problem, reproduction steps, proposed solution, and validation.
+Issues and focused pull requests are welcome. Before opening one, please search existing issues and pull requests to avoid duplicates. For substantial changes, open an issue first so the problem and scope can be discussed.
+
+Pull requests should focus on one problem and explain:
+
+- Why the change is needed and who it affects.
+- What behavior or code changed, and why this approach was chosen.
+- How it was validated, including tests and manual checks.
+- Known limitations, compatibility risks, and follow-up work.
+
+Add or update tests for behavior changes, preserve provider ownership boundaries, avoid unnecessary production dependencies, and update documentation for user-facing changes. New provider additions are not accepted; improvements to existing providers should document provider-specific capabilities and limitations.
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full development and pull request guide.
 
 ## License
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-claudian",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-claudian",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claudian",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Coding agents embedded in an Obsidian sidebar, including Oh My Pi support",
   "main": "main.js",
   "engines": {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -78,6 +78,7 @@
       "claude": "Claude",
       "codex": "Codex"
     },
+    "omp": { "setup": "Einrichtung", "enable": "OMP aktivieren", "enableDesc": "Oh My Pi ACP-Anbieter aktivieren.", "cliPath": "CLI-Pfad", "cliPathDesc": "Absoluter OMP-Pfad auf diesem Computer.", "models": "Modelle", "noModels": "Noch keine OMP-Modelle gefunden.", "catalogFailed": "OMP-Modellkatalog konnte nicht geladen werden.", "loadingModels": "OMP-Modelle werden geladen…", "discoveryFailed": "OMP-Modellerkennung fehlgeschlagen: {error}", "workspaceNotInitialized": "OMP-Arbeitsbereich ist nicht initialisiert", "safe": "Sicher", "yolo": "YOLO", "permissionRequest": "OMP bittet um Berechtigung für {tool}.", "tool": "ein Tool" },
     "display": "Anzeige",
     "conversations": "Unterhaltungen",
     "content": "Inhalte",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -78,6 +78,14 @@
       "claude": "Claude",
       "codex": "Codex"
     },
+    "omp": {
+      "setup": "Setup", "enable": "Enable OMP", "enableDesc": "Enable the Oh My Pi ACP provider.",
+      "cliPath": "CLI path", "cliPathDesc": "Absolute path to OMP on this computer. This also makes its Bun runtime available to Obsidian.",
+      "models": "Models", "noModels": "No OMP models discovered yet. Check OMP login and click Discover.",
+      "catalogFailed": "Could not load the OMP model catalog. Check the CLI path and login state.", "loadingModels": "Loading OMP models...",
+      "discoveryFailed": "OMP model discovery failed: {error}", "workspaceNotInitialized": "OMP workspace is not initialized",
+      "safe": "Safe", "yolo": "YOLO", "permissionRequest": "OMP requests permission to use {tool}.", "tool": "a tool"
+    },
     "display": "Display",
     "conversations": "Conversations",
     "content": "Content",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -78,6 +78,7 @@
       "claude": "Claude",
       "codex": "Codex"
     },
+    "omp": { "setup": "Configuración", "enable": "Activar OMP", "enableDesc": "Activar el proveedor ACP de Oh My Pi.", "cliPath": "Ruta del CLI", "cliPathDesc": "Ruta absoluta a OMP en este equipo.", "models": "Modelos", "noModels": "Aún no se han descubierto modelos OMP.", "catalogFailed": "No se pudo cargar el catálogo de modelos OMP.", "loadingModels": "Cargando modelos OMP…", "discoveryFailed": "Error al descubrir modelos OMP: {error}", "workspaceNotInitialized": "El espacio de trabajo OMP no está inicializado", "safe": "Seguro", "yolo": "YOLO", "permissionRequest": "OMP solicita permiso para usar {tool}.", "tool": "una herramienta" },
     "display": "Pantalla",
     "conversations": "Conversaciones",
     "content": "Contenido",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -78,6 +78,7 @@
       "claude": "Claude",
       "codex": "Codex"
     },
+    "omp": { "setup": "Configuration", "enable": "Activer OMP", "enableDesc": "Activer le fournisseur ACP Oh My Pi.", "cliPath": "Chemin CLI", "cliPathDesc": "Chemin absolu vers OMP sur cet ordinateur.", "models": "Modèles", "noModels": "Aucun modèle OMP trouvé.", "catalogFailed": "Impossible de charger le catalogue des modèles OMP.", "loadingModels": "Chargement des modèles OMP…", "discoveryFailed": "Échec de la détection des modèles OMP : {error}", "workspaceNotInitialized": "L’espace de travail OMP n’est pas initialisé", "safe": "Sûr", "yolo": "YOLO", "permissionRequest": "OMP demande l’autorisation d’utiliser {tool}.", "tool": "un outil" },
     "display": "Affichage",
     "conversations": "Conversations",
     "content": "Contenu",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -78,6 +78,7 @@
       "claude": "Claude",
       "codex": "Codex"
     },
+    "omp": { "setup": "セットアップ", "enable": "OMP を有効化", "enableDesc": "Oh My Pi ACP プロバイダーを有効にします。", "cliPath": "CLI パス", "cliPathDesc": "このコンピューター上の OMP の絶対パスです。", "models": "モデル", "noModels": "OMP モデルがまだ見つかりません。", "catalogFailed": "OMP モデルカタログを読み込めませんでした。", "loadingModels": "OMP モデルを読み込み中…", "discoveryFailed": "OMP モデルの検出に失敗しました：{error}", "workspaceNotInitialized": "OMP ワークスペースが初期化されていません", "safe": "安全", "yolo": "YOLO", "permissionRequest": "OMP が{tool}を使用する権限を要求しています。", "tool": "ツール" },
     "display": "表示",
     "conversations": "会話",
     "content": "コンテンツ",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -78,6 +78,7 @@
       "claude": "Claude",
       "codex": "Codex"
     },
+    "omp": { "setup": "설정", "enable": "OMP 활성화", "enableDesc": "Oh My Pi ACP 공급자를 활성화합니다.", "cliPath": "CLI 경로", "cliPathDesc": "이 컴퓨터의 OMP 절대 경로입니다.", "models": "모델", "noModels": "아직 OMP 모델을 찾지 못했습니다.", "catalogFailed": "OMP 모델 카탈로그를 불러오지 못했습니다.", "loadingModels": "OMP 모델을 불러오는 중…", "discoveryFailed": "OMP 모델 검색 실패: {error}", "workspaceNotInitialized": "OMP 작업 공간이 초기화되지 않았습니다", "safe": "안전", "yolo": "YOLO", "permissionRequest": "OMP가 {tool} 사용 권한을 요청합니다.", "tool": "도구" },
     "display": "표시",
     "conversations": "대화",
     "content": "콘텐츠",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -78,6 +78,7 @@
       "claude": "Claude",
       "codex": "Codex"
     },
+    "omp": { "setup": "Configuração", "enable": "Ativar OMP", "enableDesc": "Ativar o provedor ACP do Oh My Pi.", "cliPath": "Caminho do CLI", "cliPathDesc": "Caminho absoluto para o OMP neste computador.", "models": "Modelos", "noModels": "Nenhum modelo OMP descoberto ainda.", "catalogFailed": "Não foi possível carregar o catálogo de modelos OMP.", "loadingModels": "Carregando modelos OMP…", "discoveryFailed": "Falha ao descobrir modelos OMP: {error}", "workspaceNotInitialized": "O workspace do OMP não foi inicializado", "safe": "Seguro", "yolo": "YOLO", "permissionRequest": "OMP solicita permissão para usar {tool}.", "tool": "uma ferramenta" },
     "display": "Exibição",
     "conversations": "Conversas",
     "content": "Conteúdo",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -78,6 +78,7 @@
       "claude": "Claude",
       "codex": "Codex"
     },
+    "omp": { "setup": "Настройка", "enable": "Включить OMP", "enableDesc": "Включить провайдер Oh My Pi ACP.", "cliPath": "Путь к CLI", "cliPathDesc": "Абсолютный путь к OMP на этом компьютере.", "models": "Модели", "noModels": "Модели OMP пока не обнаружены.", "catalogFailed": "Не удалось загрузить каталог моделей OMP.", "loadingModels": "Загрузка моделей OMP…", "discoveryFailed": "Не удалось обнаружить модели OMP: {error}", "workspaceNotInitialized": "Рабочая область OMP не инициализирована", "safe": "Безопасно", "yolo": "YOLO", "permissionRequest": "OMP запрашивает разрешение на использование: {tool}.", "tool": "инструмент" },
     "display": "Отображение",
     "conversations": "Разговоры",
     "content": "Содержание",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -78,6 +78,14 @@
       "claude": "Claude",
       "codex": "Codex"
     },
+    "omp": {
+      "setup": "配置", "enable": "启用 OMP", "enableDesc": "启用 Oh My Pi ACP 提供商。",
+      "cliPath": "CLI 路径", "cliPathDesc": "此电脑上的 OMP 绝对路径，同时会让 Obsidian 使用其 Bun 运行时。",
+      "models": "模型", "noModels": "尚未发现 OMP 模型。请检查 OMP 登录状态，然后点击“发现”。",
+      "catalogFailed": "无法加载 OMP 模型目录。请检查 CLI 路径和登录状态。", "loadingModels": "正在加载 OMP 模型……",
+      "discoveryFailed": "OMP 模型发现失败：{error}", "workspaceNotInitialized": "OMP 工作区尚未初始化",
+      "safe": "安全", "yolo": "YOLO", "permissionRequest": "OMP 请求使用{tool}的权限。", "tool": "工具"
+    },
     "display": "显示",
     "conversations": "对话",
     "content": "内容",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -78,6 +78,14 @@
       "claude": "Claude",
       "codex": "Codex"
     },
+    "omp": {
+      "setup": "設定", "enable": "啟用 OMP", "enableDesc": "啟用 Oh My Pi ACP 提供者。",
+      "cliPath": "CLI 路徑", "cliPathDesc": "此電腦上的 OMP 絕對路徑，也會讓 Obsidian 使用其 Bun 執行環境。",
+      "models": "模型", "noModels": "尚未發現 OMP 模型。請檢查 OMP 登入狀態，然後點擊「探索」。",
+      "catalogFailed": "無法載入 OMP 模型目錄。請檢查 CLI 路徑與登入狀態。", "loadingModels": "正在載入 OMP 模型……",
+      "discoveryFailed": "OMP 模型探索失敗：{error}", "workspaceNotInitialized": "OMP 工作區尚未初始化",
+      "safe": "安全", "yolo": "YOLO", "permissionRequest": "OMP 請求使用{tool}的權限。", "tool": "工具"
+    },
     "display": "顯示",
     "conversations": "對話",
     "content": "內容",

--- a/src/providers/omp/execution/OmpAcpSessionKernel.ts
+++ b/src/providers/omp/execution/OmpAcpSessionKernel.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 
 import type { ProviderSessionConfig } from '@/core/execution';
 import type { ProviderHost } from '@/core/providers/ProviderHost';
+import { t } from '@/i18n/i18n';
 import {
   AcpClientConnection,
   AcpInteractionController,
@@ -212,7 +213,9 @@ function presentOmpPermission(
   _input: Readonly<Record<string, unknown>>,
 ): AcpPermissionPresentation {
   return {
-    description: `OMP requests permission to use ${request.toolCall.title || 'a tool'}.`,
-    toolName: request.toolCall.title || 'OMP tool',
+    description: t('settings.omp.permissionRequest', {
+      tool: request.toolCall.title || t('settings.omp.tool'),
+    }),
+    toolName: request.toolCall.title || t('settings.omp.tool'),
   };
 }

--- a/src/providers/omp/ui/OmpChatUIConfig.ts
+++ b/src/providers/omp/ui/OmpChatUIConfig.ts
@@ -2,19 +2,13 @@ import type {
   ProviderChatUIConfig,
   ProviderPermissionModeToggleConfig,
 } from '../../../core/providers/types';
+import { t } from '../../../i18n/i18n';
 import { buildInitialOmpUsageInfo } from '../execution/OmpExecutionSession';
 import {
   decodeOmpModelId,
   encodeOmpModelId,
 } from '../models';
 import { getOmpProviderSettings } from '../settings';
-
-const PERMISSION_MODE: ProviderPermissionModeToggleConfig = {
-  inactiveValue: 'normal',
-  inactiveLabel: 'Safe',
-  activeValue: 'yolo',
-  activeLabel: 'YOLO',
-};
 
 export const ompChatUIConfig: ProviderChatUIConfig = {
   getModelOptions(settings) {
@@ -49,7 +43,12 @@ export const ompChatUIConfig: ProviderChatUIConfig = {
   applyModelDefaults: () => undefined,
   normalizeModelVariant: model => model,
   getCustomModelIds: () => new Set<string>(),
-  getPermissionModeToggle: (): ProviderPermissionModeToggleConfig => PERMISSION_MODE,
+  getPermissionModeToggle: (): ProviderPermissionModeToggleConfig => ({
+    inactiveValue: 'normal',
+    inactiveLabel: t('settings.omp.safe'),
+    activeValue: 'yolo',
+    activeLabel: t('settings.omp.yolo'),
+  }),
   resolvePermissionMode(settings) {
     return settings.permissionMode === 'yolo' ? 'yolo' : 'normal';
   },

--- a/src/providers/omp/ui/OmpSettingsTab.ts
+++ b/src/providers/omp/ui/OmpSettingsTab.ts
@@ -5,6 +5,7 @@ import { Notice, Setting } from 'obsidian';
 import type {
   ProviderSettingsTabRenderer,
 } from '../../../core/providers/types';
+import { t } from '../../../i18n/i18n';
 import { renderHostnameCliPathSetting } from '../../../shared/settings/HostnameCliPathSetting';
 import { renderProviderEnablementSetting } from '../../../shared/settings/ProviderEnablementSetting';
 import {
@@ -26,12 +27,12 @@ export const ompSettingsTabRenderer: ProviderSettingsTabRenderer = {
     const settings = context.plugin.settings as unknown as Record<string, unknown>;
     const workspace = maybeGetOmpWorkspaceServices();
     const hostnameKey = getHostnameKey();
-    new Setting(container).setName('Setup').setHeading();
+    new Setting(container).setName(t('settings.omp.setup')).setHeading();
     renderProviderEnablementSetting({
       container,
-      description: 'Enable the Oh My Pi ACP provider.',
+      description: t('settings.omp.enableDesc'),
       getValue: () => getOmpProviderSettings(settings).enabled,
-      name: 'Enable OMP',
+      name: t('settings.omp.enable'),
       onChange: async enabled => {
         await context.plugin.mutateSettings(target => {
           updateOmpProviderSettings(target, { enabled });
@@ -41,9 +42,9 @@ export const ompSettingsTabRenderer: ProviderSettingsTabRenderer = {
     });
     renderHostnameCliPathSetting({
       container,
-      description: 'Absolute path to OMP on this computer. This also makes its Bun runtime available to Obsidian.',
+      description: t('settings.omp.cliPathDesc'),
       getValue: () => getOmpProviderSettings(settings).cliPathsByHost[hostnameKey] || '',
-      name: 'CLI path',
+      name: t('settings.omp.cliPath'),
       onChange: async value => {
         const provider = getOmpProviderSettings(settings);
         const cliPathsByHost = { ...provider.cliPathsByHost };
@@ -63,7 +64,7 @@ export const ompSettingsTabRenderer: ProviderSettingsTabRenderer = {
         : '/Users/you/.bun/bin/omp',
       validate: validateCliPath,
     });
-    new Setting(container).setName('Models').setHeading();
+    new Setting(container).setName(t('settings.omp.models')).setHeading();
     renderOmpModelPicker(container, context, settings);
   },
 };
@@ -84,19 +85,21 @@ function renderOmpModelPicker(
   };
   renderProviderModelPicker({
     container,
-    emptyCatalogText: 'No OMP models discovered yet. Check OMP login and click Discover.',
-    failedCatalogText: 'Could not load the OMP model catalog. Check the CLI path and login state.',
+    emptyCatalogText: t('settings.omp.noModels'),
+    failedCatalogText: t('settings.omp.catalogFailed'),
     getState,
     async loadCatalog() {
       const result = await maybeGetOmpWorkspaceServices()?.refreshModelCatalog?.();
       if (!result || result.diagnostics) {
-        new Notice(`OMP model discovery failed: ${result?.diagnostics ?? 'OMP workspace is not initialized'}`);
+        new Notice(t('settings.omp.discoveryFailed', {
+          error: result?.diagnostics ?? t('settings.omp.workspaceNotInitialized'),
+        }));
         return 'failed';
       }
       context.notifyProviderModelOptionsChanged('omp');
       return getOmpProviderSettings(settings).discoveredModels.length > 0 ? 'loaded' : 'empty';
     },
-    loadingCatalogText: 'Loading OMP models...',
+    loadingCatalogText: t('settings.omp.loadingModels'),
     modifier: 'omp',
     onAliasesChange: async () => undefined,
     async onSelectedIdsChange(visibleModels) {

--- a/tests/unit/providers/omp/OmpChatUIConfig.test.ts
+++ b/tests/unit/providers/omp/OmpChatUIConfig.test.ts
@@ -1,7 +1,11 @@
+import { setLocale } from '@/i18n/i18n';
 import { OMP_PROVIDER_CAPABILITIES } from '@/providers/omp/capabilities';
 import { ompChatUIConfig } from '@/providers/omp/ui/OmpChatUIConfig';
 
 describe('OMP chat configuration', () => {
+  afterEach(() => {
+    setLocale('en');
+  });
   const settings: Record<string, unknown> = {
     providerConfigs: {
       omp: {
@@ -41,6 +45,14 @@ describe('OMP chat configuration', () => {
     expect(ompChatUIConfig.resolvePermissionMode?.(settings)).toBe('yolo');
     ompChatUIConfig.applyPermissionMode?.('normal', settings);
     expect(ompChatUIConfig.resolvePermissionMode?.(settings)).toBe('normal');
+  });
+
+  it('localizes the permission control with the active interface locale', () => {
+    setLocale('zh-CN');
+    expect(ompChatUIConfig.getPermissionModeToggle?.()).toMatchObject({
+      activeLabel: 'YOLO',
+      inactiveLabel: '安全',
+    });
   });
 
   it('provides a context snapshot when restoring an OMP conversation', () => {


### PR DESCRIPTION
## Summary
- Bump the plugin version to 2.1.2 across package and manifest files
- Document the automated tag-based release process
- Expand the contributing guide and align project naming

## Validation
- Release version validation passed for 2.1.2
- Previous PR CI passed: lint, typecheck, test, and build