### PR TITLE
feat: add provider readiness diagnostics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,4 +64,8 @@ npm run test
 npm run build
 ```
 
+For user-facing settings changes, manually check every provider tab (Claude, Codex, Grok, OpenCode, OMP, and Pi) when the provider is available. Confirm that readiness status reflects the provider's own CLI and model configuration, and that refreshing the panel does not mutate provider-native files.
+
+During development, `npm run dev` also watches styles and `manifest.json`. Set `OBSIDIAN_VAULT` in `.env.local` to copy rebuilt resources into a test vault automatically.
+
 The project architecture and area-specific development rules are documented in `AGENTS.md` and the scoped `AGENTS.md` files under `src/`.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Oh My Claudian is an Obsidian plugin that embeds coding agents in your vault. Ag
 - Inline edits with word-level diff preview.
 - Slash commands, skills, `@` mentions, and instruction mode.
 - Provider-specific planning, permissions, reasoning controls, and model selection.
+- Provider readiness diagnostics in each provider settings tab, covering enablement, CLI availability, model discovery, and model selection.
 - MCP support where available from the selected provider.
 - Internationalized interface with 10 locales, including Simplified and Traditional Chinese.
 
@@ -58,6 +59,8 @@ Then enable the plugin in Obsidian under **Settings → Community plugins**.
 
 Open the chat sidebar from the ribbon icon or command palette. Select text and use the inline-edit hotkey to edit notes with a diff preview. Use `/` for commands and skills, `@` to reference vault files or provider resources, and the provider selector to choose Claude, Codex, Grok, OMP, OpenCode, or Pi.
 
+Each provider has a readiness panel in its settings tab. Use it to see whether the provider is enabled, its CLI is available, models have been discovered, and a chat model is selected. The panel reports problems and lets you recheck the current provider state; installation and authentication remain provider-native.
+
 OMP requires its CLI to be installed and logged in separately. In **Settings → Oh My Claudian → OMP**, enable the provider, set the CLI path if it is not detected automatically, and use **Discover** to load available models.
 
 ## Development
@@ -69,6 +72,8 @@ npm run typecheck
 npm run lint
 npm run test
 ```
+
+`npm run dev` watches TypeScript, styles, and `manifest.json`. When `OBSIDIAN_VAULT` is set in `.env.local`, rebuilt plugin resources are copied to that vault automatically, including CSS and manifest changes.
 
 ## Release
 

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,5 +1,6 @@
 import esbuild from 'esbuild';
 import { builtinModules } from 'node:module';
+import { execFileSync } from 'node:child_process';
 import path from 'path';
 import process from 'process';
 import {
@@ -11,6 +12,7 @@ import {
   rmSync,
 } from 'fs';
 import rendererSafeUnrefHelpers from './scripts/rendererSafeUnref.js';
+import { getDevelopmentWatchFiles } from './scripts/devWatchFiles.mjs';
 import { resolveObsidianPluginPath } from './scripts/obsidianPluginPath.mjs';
 
 const {
@@ -136,6 +138,21 @@ const PLUGIN_MANIFEST = JSON.parse(readFileSync('manifest.json', 'utf-8'));
 const OBSIDIAN_PLUGIN_PATH = OBSIDIAN_VAULT && existsSync(OBSIDIAN_VAULT)
   ? resolveObsidianPluginPath(OBSIDIAN_VAULT, PLUGIN_MANIFEST)
   : null;
+const DEVELOPMENT_WATCH_FILES = prod ? [] : getDevelopmentWatchFiles(process.cwd());
+
+const watchDevelopmentResources = {
+  name: 'watch-development-resources',
+  setup(build) {
+    if (prod) return;
+
+    build.onLoad({ filter: /[\\/]src[\\/]main\.ts$/ }, async (args) => ({
+      contents: await fsPromises.readFile(args.path, 'utf8'),
+      loader: 'ts',
+      resolveDir: path.dirname(args.path),
+      watchFiles: DEVELOPMENT_WATCH_FILES,
+    }));
+  },
+};
 
 // Plugin to copy built files to Obsidian plugin folder
 const copyToObsidian = {
@@ -143,6 +160,12 @@ const copyToObsidian = {
   setup(build) {
     build.onEnd((result) => {
       if (result.errors.length > 0) return;
+      if (!prod) {
+        execFileSync(process.execPath, ['scripts/build-css.mjs'], {
+          cwd: process.cwd(),
+          stdio: 'inherit',
+        });
+      }
       rmSync(path.join(process.cwd(), '.codex-vendor'), { recursive: true, force: true });
 
       if (!OBSIDIAN_PLUGIN_PATH) return;
@@ -188,6 +211,7 @@ const mainContext = await esbuild.context({
   bundle: true,
   plugins: [
     patchSdkImportMeta,
+    watchDevelopmentResources,
     createPatchRendererUnsafeUnref(['main.js']),
     copyToObsidian,
   ],

--- a/scripts/devWatchFiles.mjs
+++ b/scripts/devWatchFiles.mjs
@@ -1,0 +1,24 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+function listCssFiles(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listCssFiles(entryPath));
+    } else if (entry.isFile() && entry.name.endsWith('.css')) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+export function getDevelopmentWatchFiles(root) {
+  const styleRoot = join(root, 'src', 'style');
+  const cssFiles = existsSync(styleRoot) ? listCssFiles(styleRoot) : [];
+  return [
+    join(root, 'manifest.json'),
+    ...cssFiles.sort(),
+  ];
+}

--- a/scripts/devWatchFiles.test.mjs
+++ b/scripts/devWatchFiles.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+
+import { getDevelopmentWatchFiles } from './devWatchFiles.mjs';
+
+test('includes manifest and every CSS source in the development watch set', () => {
+  const root = mkdtempSync(join(tmpdir(), 'claudian-dev-watch-'));
+  const styleRoot = join(root, 'src', 'style');
+  mkdirSync(join(styleRoot, 'nested'), { recursive: true });
+  writeFileSync(join(root, 'manifest.json'), '{}');
+  writeFileSync(join(styleRoot, 'index.css'), '@import "base.css";');
+  writeFileSync(join(styleRoot, 'base.css'), '.base {}');
+  writeFileSync(join(styleRoot, 'nested', 'feature.css'), '.feature {}');
+
+  assert.deepEqual(getDevelopmentWatchFiles(root), [
+    join(root, 'manifest.json'),
+    join(styleRoot, 'base.css'),
+    join(styleRoot, 'index.css'),
+    join(styleRoot, 'nested', 'feature.css'),
+  ]);
+});

--- a/src/core/providers/ProviderReadiness.ts
+++ b/src/core/providers/ProviderReadiness.ts
@@ -1,0 +1,59 @@
+export type ProviderReadinessStatus = 'disabled' | 'blocked' | 'attention' | 'ready';
+
+export type ProviderReadinessCheckId = 'enabled' | 'cli' | 'models' | 'selection';
+
+export interface ProviderReadinessInput {
+  enabled: boolean;
+  cliPath: string | null;
+  discoveredModelCount: number;
+  selectedModelCount: number;
+}
+
+export interface ProviderReadinessCheck {
+  id: ProviderReadinessCheckId;
+  status: ProviderReadinessStatus;
+}
+
+export interface ProviderReadinessSnapshot {
+  status: ProviderReadinessStatus;
+  checks: ProviderReadinessCheck[];
+}
+
+export function assessProviderReadiness(
+  input: ProviderReadinessInput,
+): ProviderReadinessSnapshot {
+  if (!input.enabled) {
+    return {
+      status: 'disabled',
+      checks: [
+        { id: 'enabled', status: 'disabled' },
+        { id: 'cli', status: 'disabled' },
+        { id: 'models', status: 'disabled' },
+        { id: 'selection', status: 'disabled' },
+      ],
+    };
+  }
+
+  const cliStatus: ProviderReadinessStatus = input.cliPath ? 'ready' : 'blocked';
+  const modelsStatus: ProviderReadinessStatus = input.discoveredModelCount > 0
+    ? 'ready'
+    : 'attention';
+  const selectionStatus: ProviderReadinessStatus = input.selectedModelCount > 0
+    ? 'ready'
+    : 'blocked';
+  const checks: ProviderReadinessCheck[] = [
+    { id: 'enabled', status: 'ready' },
+    { id: 'cli', status: cliStatus },
+    { id: 'models', status: modelsStatus },
+    { id: 'selection', status: selectionStatus },
+  ];
+
+  return {
+    status: checks.some(check => check.status === 'blocked')
+      ? 'blocked'
+      : checks.some(check => check.status === 'attention')
+        ? 'attention'
+        : 'ready',
+    checks,
+  };
+}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -79,6 +79,7 @@
       "codex": "Codex"
     },
     "omp": { "setup": "Einrichtung", "enable": "OMP aktivieren", "enableDesc": "Oh My Pi ACP-Anbieter aktivieren.", "cliPath": "CLI-Pfad", "cliPathDesc": "Absoluter OMP-Pfad auf diesem Computer.", "models": "Modelle", "noModels": "Noch keine OMP-Modelle gefunden.", "catalogFailed": "OMP-Modellkatalog konnte nicht geladen werden.", "loadingModels": "OMP-Modelle werden geladen…", "discoveryFailed": "OMP-Modellerkennung fehlgeschlagen: {error}", "workspaceNotInitialized": "OMP-Arbeitsbereich ist nicht initialisiert", "safe": "Sicher", "yolo": "YOLO", "permissionRequest": "OMP bittet um Berechtigung für {tool}.", "tool": "ein Tool" },
+    "providerReadiness": { "title": "Bereitschaft", "desc": "Prüfen, ob {provider} für einen Chat bereit ist.", "checking": "Provider-Bereitschaft wird geprüft…", "refresh": "Erneut prüfen", "status": { "disabled": "Deaktiviert", "blocked": "Aktion erforderlich", "attention": "Aufmerksamkeit erforderlich", "ready": "Bereit" }, "check": { "enabled": "Provider aktiviert", "cli": "CLI verfügbar", "models": "Modellkatalog verfügbar", "selection": "Chat-Modell ausgewählt" } },
     "display": "Anzeige",
     "conversations": "Unterhaltungen",
     "content": "Inhalte",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -86,6 +86,14 @@
       "discoveryFailed": "OMP model discovery failed: {error}", "workspaceNotInitialized": "OMP workspace is not initialized",
       "safe": "Safe", "yolo": "YOLO", "permissionRequest": "OMP requests permission to use {tool}.", "tool": "a tool"
     },
+    "providerReadiness": {
+      "title": "Readiness",
+      "desc": "Check whether {provider} is ready to start a chat.",
+      "checking": "Checking provider readiness…",
+      "refresh": "Check again",
+      "status": { "disabled": "Disabled", "blocked": "Action required", "attention": "Needs attention", "ready": "Ready" },
+      "check": { "enabled": "Provider enabled", "cli": "CLI available", "models": "Model catalog available", "selection": "Chat model selected" }
+    },
     "display": "Display",
     "conversations": "Conversations",
     "content": "Content",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -79,6 +79,7 @@
       "codex": "Codex"
     },
     "omp": { "setup": "Configuración", "enable": "Activar OMP", "enableDesc": "Activar el proveedor ACP de Oh My Pi.", "cliPath": "Ruta del CLI", "cliPathDesc": "Ruta absoluta a OMP en este equipo.", "models": "Modelos", "noModels": "Aún no se han descubierto modelos OMP.", "catalogFailed": "No se pudo cargar el catálogo de modelos OMP.", "loadingModels": "Cargando modelos OMP…", "discoveryFailed": "Error al descubrir modelos OMP: {error}", "workspaceNotInitialized": "El espacio de trabajo OMP no está inicializado", "safe": "Seguro", "yolo": "YOLO", "permissionRequest": "OMP solicita permiso para usar {tool}.", "tool": "una herramienta" },
+    "providerReadiness": { "title": "Preparación", "desc": "Comprueba si {provider} está listo para iniciar un chat.", "checking": "Comprobando el estado del proveedor…", "refresh": "Comprobar de nuevo", "status": { "disabled": "Desactivado", "blocked": "Acción necesaria", "attention": "Requiere atención", "ready": "Listo" }, "check": { "enabled": "Proveedor activado", "cli": "CLI disponible", "models": "Catálogo de modelos disponible", "selection": "Modelo de chat seleccionado" } },
     "display": "Pantalla",
     "conversations": "Conversaciones",
     "content": "Contenido",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -79,6 +79,7 @@
       "codex": "Codex"
     },
     "omp": { "setup": "Configuration", "enable": "Activer OMP", "enableDesc": "Activer le fournisseur ACP Oh My Pi.", "cliPath": "Chemin CLI", "cliPathDesc": "Chemin absolu vers OMP sur cet ordinateur.", "models": "Modèles", "noModels": "Aucun modèle OMP trouvé.", "catalogFailed": "Impossible de charger le catalogue des modèles OMP.", "loadingModels": "Chargement des modèles OMP…", "discoveryFailed": "Échec de la détection des modèles OMP : {error}", "workspaceNotInitialized": "L’espace de travail OMP n’est pas initialisé", "safe": "Sûr", "yolo": "YOLO", "permissionRequest": "OMP demande l’autorisation d’utiliser {tool}.", "tool": "un outil" },
+    "providerReadiness": { "title": "État de préparation", "desc": "Vérifier si {provider} est prêt à démarrer une conversation.", "checking": "Vérification de l’état du fournisseur…", "refresh": "Vérifier à nouveau", "status": { "disabled": "Désactivé", "blocked": "Action requise", "attention": "Attention requise", "ready": "Prêt" }, "check": { "enabled": "Fournisseur activé", "cli": "CLI disponible", "models": "Catalogue de modèles disponible", "selection": "Modèle de chat sélectionné" } },
     "display": "Affichage",
     "conversations": "Conversations",
     "content": "Contenu",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -79,6 +79,7 @@
       "codex": "Codex"
     },
     "omp": { "setup": "セットアップ", "enable": "OMP を有効化", "enableDesc": "Oh My Pi ACP プロバイダーを有効にします。", "cliPath": "CLI パス", "cliPathDesc": "このコンピューター上の OMP の絶対パスです。", "models": "モデル", "noModels": "OMP モデルがまだ見つかりません。", "catalogFailed": "OMP モデルカタログを読み込めませんでした。", "loadingModels": "OMP モデルを読み込み中…", "discoveryFailed": "OMP モデルの検出に失敗しました：{error}", "workspaceNotInitialized": "OMP ワークスペースが初期化されていません", "safe": "安全", "yolo": "YOLO", "permissionRequest": "OMP が{tool}を使用する権限を要求しています。", "tool": "ツール" },
+    "providerReadiness": { "title": "準備状況", "desc": "{provider} がチャットを開始できる状態か確認します。", "checking": "プロバイダーの準備状況を確認中…", "refresh": "再確認", "status": { "disabled": "無効", "blocked": "対応が必要", "attention": "要確認", "ready": "準備完了" }, "check": { "enabled": "プロバイダーが有効", "cli": "CLI が利用可能", "models": "モデルカタログが利用可能", "selection": "チャットモデルを選択済み" } },
     "display": "表示",
     "conversations": "会話",
     "content": "コンテンツ",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -79,6 +79,7 @@
       "codex": "Codex"
     },
     "omp": { "setup": "설정", "enable": "OMP 활성화", "enableDesc": "Oh My Pi ACP 공급자를 활성화합니다.", "cliPath": "CLI 경로", "cliPathDesc": "이 컴퓨터의 OMP 절대 경로입니다.", "models": "모델", "noModels": "아직 OMP 모델을 찾지 못했습니다.", "catalogFailed": "OMP 모델 카탈로그를 불러오지 못했습니다.", "loadingModels": "OMP 모델을 불러오는 중…", "discoveryFailed": "OMP 모델 검색 실패: {error}", "workspaceNotInitialized": "OMP 작업 공간이 초기화되지 않았습니다", "safe": "안전", "yolo": "YOLO", "permissionRequest": "OMP가 {tool} 사용 권한을 요청합니다.", "tool": "도구" },
+    "providerReadiness": { "title": "준비 상태", "desc": "{provider}가 채팅을 시작할 준비가 되었는지 확인합니다.", "checking": "공급자 준비 상태 확인 중…", "refresh": "다시 확인", "status": { "disabled": "비활성화됨", "blocked": "조치 필요", "attention": "확인 필요", "ready": "준비됨" }, "check": { "enabled": "공급자 활성화됨", "cli": "CLI 사용 가능", "models": "모델 카탈로그 사용 가능", "selection": "채팅 모델 선택됨" } },
     "display": "표시",
     "conversations": "대화",
     "content": "콘텐츠",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -79,6 +79,7 @@
       "codex": "Codex"
     },
     "omp": { "setup": "Configuração", "enable": "Ativar OMP", "enableDesc": "Ativar o provedor ACP do Oh My Pi.", "cliPath": "Caminho do CLI", "cliPathDesc": "Caminho absoluto para o OMP neste computador.", "models": "Modelos", "noModels": "Nenhum modelo OMP descoberto ainda.", "catalogFailed": "Não foi possível carregar o catálogo de modelos OMP.", "loadingModels": "Carregando modelos OMP…", "discoveryFailed": "Falha ao descobrir modelos OMP: {error}", "workspaceNotInitialized": "O workspace do OMP não foi inicializado", "safe": "Seguro", "yolo": "YOLO", "permissionRequest": "OMP solicita permissão para usar {tool}.", "tool": "uma ferramenta" },
+    "providerReadiness": { "title": "Prontidão", "desc": "Verifique se o {provider} está pronto para iniciar um chat.", "checking": "Verificando a prontidão do provedor…", "refresh": "Verificar novamente", "status": { "disabled": "Desativado", "blocked": "Ação necessária", "attention": "Requer atenção", "ready": "Pronto" }, "check": { "enabled": "Provedor ativado", "cli": "CLI disponível", "models": "Catálogo de modelos disponível", "selection": "Modelo de chat selecionado" } },
     "display": "Exibição",
     "conversations": "Conversas",
     "content": "Conteúdo",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -79,6 +79,7 @@
       "codex": "Codex"
     },
     "omp": { "setup": "Настройка", "enable": "Включить OMP", "enableDesc": "Включить провайдер Oh My Pi ACP.", "cliPath": "Путь к CLI", "cliPathDesc": "Абсолютный путь к OMP на этом компьютере.", "models": "Модели", "noModels": "Модели OMP пока не обнаружены.", "catalogFailed": "Не удалось загрузить каталог моделей OMP.", "loadingModels": "Загрузка моделей OMP…", "discoveryFailed": "Не удалось обнаружить модели OMP: {error}", "workspaceNotInitialized": "Рабочая область OMP не инициализирована", "safe": "Безопасно", "yolo": "YOLO", "permissionRequest": "OMP запрашивает разрешение на использование: {tool}.", "tool": "инструмент" },
+    "providerReadiness": { "title": "Готовность", "desc": "Проверить, готов ли {provider} начать чат.", "checking": "Проверка готовности провайдера…", "refresh": "Проверить снова", "status": { "disabled": "Отключено", "blocked": "Требуется действие", "attention": "Требует внимания", "ready": "Готово" }, "check": { "enabled": "Провайдер включён", "cli": "CLI доступен", "models": "Каталог моделей доступен", "selection": "Модель чата выбрана" } },
     "display": "Отображение",
     "conversations": "Разговоры",
     "content": "Содержание",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -86,6 +86,14 @@
       "discoveryFailed": "OMP 模型发现失败：{error}", "workspaceNotInitialized": "OMP 工作区尚未初始化",
       "safe": "安全", "yolo": "YOLO", "permissionRequest": "OMP 请求使用{tool}的权限。", "tool": "工具"
     },
+    "providerReadiness": {
+      "title": "就绪状态",
+      "desc": "检查 {provider} 是否可以开始聊天。",
+      "checking": "正在检查提供商状态……",
+      "refresh": "重新检查",
+      "status": { "disabled": "未启用", "blocked": "需要处理", "attention": "需要关注", "ready": "已就绪" },
+      "check": { "enabled": "提供商已启用", "cli": "CLI 可用", "models": "模型目录可用", "selection": "已选择聊天模型" }
+    },
     "display": "显示",
     "conversations": "对话",
     "content": "内容",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -86,6 +86,11 @@
       "discoveryFailed": "OMP 模型探索失敗：{error}", "workspaceNotInitialized": "OMP 工作區尚未初始化",
       "safe": "安全", "yolo": "YOLO", "permissionRequest": "OMP 請求使用{tool}的權限。", "tool": "工具"
     },
+    "providerReadiness": {
+      "title": "就緒狀態", "desc": "檢查 {provider} 是否可以開始聊天。", "checking": "正在檢查提供者狀態……", "refresh": "重新檢查",
+      "status": { "disabled": "未啟用", "blocked": "需要處理", "attention": "需要注意", "ready": "已就緒" },
+      "check": { "enabled": "提供者已啟用", "cli": "CLI 可用", "models": "模型目錄可用", "selection": "已選擇聊天模型" }
+    },
     "display": "顯示",
     "conversations": "對話",
     "content": "內容",

--- a/src/providers/claude/ui/ClaudeSettingsTab.ts
+++ b/src/providers/claude/ui/ClaudeSettingsTab.ts
@@ -39,7 +39,9 @@ export const claudeSettingsTabRenderer: ProviderSettingsTabRenderer = {
         const model = typeof settingsBag.model === 'string' ? settingsBag.model : '';
         const modelOptions = getClaudeModelOptions(settingsBag);
         return assessProviderReadiness({
-          cliPath: await context.plugin.getResolvedProviderCliPath('claude'),
+          cliPath: typeof context.plugin.getResolvedProviderCliPath === 'function'
+            ? await context.plugin.getResolvedProviderCliPath('claude')
+            : null,
           discoveredModelCount: modelOptions.length,
           enabled: getClaudeProviderSettings(settingsBag).enabled,
           selectedModelCount: findClaudeModelOption(modelOptions, model) ? 1 : 0,

--- a/src/providers/claude/ui/ClaudeSettingsTab.ts
+++ b/src/providers/claude/ui/ClaudeSettingsTab.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import { Setting } from 'obsidian';
 
+import { assessProviderReadiness } from '../../../core/providers/ProviderReadiness';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
 import { t } from '../../../i18n/i18n';
@@ -9,10 +10,11 @@ import { renderHostnameCliPathSetting } from '../../../shared/settings/HostnameC
 import { McpSettingsManager } from '../../../shared/settings/McpSettingsManager';
 import { renderProviderEnablementSetting } from '../../../shared/settings/ProviderEnablementSetting';
 import { renderLastEnabledProviderWarning } from '../../../shared/settings/ProviderModelEnablementWarning';
+import { renderProviderReadinessPanel } from '../../../shared/settings/ProviderReadinessPanel';
 import { getHostnameKey } from '../../../utils/env';
 import { expandHomePath } from '../../../utils/path';
 import { getClaudeWorkspaceServices } from '../app/ClaudeWorkspaceServices';
-import { resolveClaudeModelSelection } from '../modelOptions';
+import { findClaudeModelOption, getClaudeModelOptions, resolveClaudeModelSelection } from '../modelOptions';
 import {
   CLAUDE_SAFE_MODES,
   type ClaudeSafeMode,
@@ -29,6 +31,21 @@ export const claudeSettingsTabRenderer: ProviderSettingsTabRenderer = {
     const claudeWorkspace = getClaudeWorkspaceServices();
     const settingsBag = context.plugin.settings as unknown as Record<string, unknown>;
     const claudeSettings = getClaudeProviderSettings(settingsBag);
+
+    renderProviderReadinessPanel({
+      container,
+      providerName: 'Claude',
+      async getSnapshot() {
+        const model = typeof settingsBag.model === 'string' ? settingsBag.model : '';
+        const modelOptions = getClaudeModelOptions(settingsBag);
+        return assessProviderReadiness({
+          cliPath: await context.plugin.getResolvedProviderCliPath('claude'),
+          discoveredModelCount: modelOptions.length,
+          enabled: getClaudeProviderSettings(settingsBag).enabled,
+          selectedModelCount: findClaudeModelOption(modelOptions, model) ? 1 : 0,
+        });
+      },
+    });
 
     const reconcileActiveClaudeModelSelection = (settings: Record<string, unknown>): void => {
       const activeProvider = settings.settingsProvider;

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import { Notice, Setting } from 'obsidian';
 
+import { assessProviderReadiness } from '../../../core/providers/ProviderReadiness';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
 import { t } from '../../../i18n/i18n';
@@ -12,6 +13,7 @@ import {
   renderLastEnabledProviderWarning,
   renderProviderModelEnablementWarning,
 } from '../../../shared/settings/ProviderModelEnablementWarning';
+import { renderProviderReadinessPanel } from '../../../shared/settings/ProviderReadinessPanel';
 import { getHostnameKey } from '../../../utils/env';
 import { expandHomePath } from '../../../utils/path';
 import { getCodexWorkspaceServices } from '../app/CodexWorkspaceServices';
@@ -39,6 +41,21 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
         new Notice(`Codex model discovery failed: ${result.diagnostics}`);
       }
     };
+
+    renderProviderReadinessPanel({
+      container,
+      providerName: 'Codex',
+      async getSnapshot() {
+        const current = getCodexProviderSettings(settingsBag);
+        return assessProviderReadiness({
+          cliPath: await context.plugin.getResolvedProviderCliPath('codex'),
+          discoveredModelCount: current.discoveredModels.length,
+          enabled: current.enabled,
+          selectedModelCount: getCodexModelOptions(settingsBag).length,
+        });
+      },
+      onRefresh: refreshCodexModelCatalog,
+    });
 
     // --- Setup ---
 

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -48,7 +48,9 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
       async getSnapshot() {
         const current = getCodexProviderSettings(settingsBag);
         return assessProviderReadiness({
-          cliPath: await context.plugin.getResolvedProviderCliPath('codex'),
+          cliPath: typeof context.plugin.getResolvedProviderCliPath === 'function'
+            ? await context.plugin.getResolvedProviderCliPath('codex')
+            : null,
           discoveredModelCount: current.discoveredModels.length,
           enabled: current.enabled,
           selectedModelCount: getCodexModelOptions(settingsBag).length,

--- a/src/providers/grok/ui/GrokSettingsTab.ts
+++ b/src/providers/grok/ui/GrokSettingsTab.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 
 import { Notice, Setting } from 'obsidian';
 
+import { assessProviderReadiness } from '../../../core/providers/ProviderReadiness';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
 import type {
@@ -24,6 +25,7 @@ import {
   type ProviderModelPickerState,
   renderProviderModelPicker,
 } from '../../../shared/settings/ProviderModelPicker';
+import { renderProviderReadinessPanel } from '../../../shared/settings/ProviderReadinessPanel';
 import { getHostnameKey } from '../../../utils/env';
 import { expandHomePath } from '../../../utils/path';
 import type { GrokWorkspaceServices } from '../app/GrokWorkspaceServices';
@@ -55,6 +57,23 @@ export const grokSettingsTabRenderer: ProviderSettingsTabRenderer = {
         ? 'loaded'
         : 'empty';
     };
+
+    renderProviderReadinessPanel({
+      container,
+      providerName: 'Grok',
+      async getSnapshot() {
+        const current = getGrokProviderSettings(settingsBag);
+        return assessProviderReadiness({
+          cliPath: await context.plugin.getResolvedProviderCliPath('grok'),
+          discoveredModelCount: current.currentCatalog?.models.length ?? 0,
+          enabled: current.enabled,
+          selectedModelCount: current.visibleModels?.length
+            ?? current.currentCatalog?.models.length
+            ?? 0,
+        });
+      },
+      onRefresh: async () => { await refreshModelCatalog(); },
+    });
 
     new Setting(container).setName('Setup').setHeading();
 

--- a/src/providers/grok/ui/GrokSettingsTab.ts
+++ b/src/providers/grok/ui/GrokSettingsTab.ts
@@ -64,7 +64,9 @@ export const grokSettingsTabRenderer: ProviderSettingsTabRenderer = {
       async getSnapshot() {
         const current = getGrokProviderSettings(settingsBag);
         return assessProviderReadiness({
-          cliPath: await context.plugin.getResolvedProviderCliPath('grok'),
+          cliPath: typeof context.plugin.getResolvedProviderCliPath === 'function'
+            ? await context.plugin.getResolvedProviderCliPath('grok')
+            : null,
           discoveredModelCount: current.currentCatalog?.models.length ?? 0,
           enabled: current.enabled,
           selectedModelCount: current.visibleModels?.length

--- a/src/providers/omp/ui/OmpSettingsTab.ts
+++ b/src/providers/omp/ui/OmpSettingsTab.ts
@@ -35,7 +35,9 @@ export const ompSettingsTabRenderer: ProviderSettingsTabRenderer = {
       async getSnapshot() {
         const provider = getOmpProviderSettings(settings);
         return assessProviderReadiness({
-          cliPath: await context.plugin.getResolvedProviderCliPath('omp'),
+          cliPath: typeof context.plugin.getResolvedProviderCliPath === 'function'
+            ? await context.plugin.getResolvedProviderCliPath('omp')
+            : null,
           discoveredModelCount: provider.discoveredModels.length,
           enabled: provider.enabled,
           selectedModelCount: provider.visibleModels.length,

--- a/src/providers/omp/ui/OmpSettingsTab.ts
+++ b/src/providers/omp/ui/OmpSettingsTab.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 
 import { Notice, Setting } from 'obsidian';
 
+import { assessProviderReadiness } from '../../../core/providers/ProviderReadiness';
 import type {
   ProviderSettingsTabRenderer,
 } from '../../../core/providers/types';
@@ -13,6 +14,7 @@ import {
   type ProviderModelPickerState,
   renderProviderModelPicker,
 } from '../../../shared/settings/ProviderModelPicker';
+import { renderProviderReadinessPanel } from '../../../shared/settings/ProviderReadinessPanel';
 import { getHostnameKey } from '../../../utils/env';
 import { expandHomePath } from '../../../utils/path';
 import { maybeGetOmpWorkspaceServices } from '../app/OmpWorkspaceServices';
@@ -27,6 +29,26 @@ export const ompSettingsTabRenderer: ProviderSettingsTabRenderer = {
     const settings = context.plugin.settings as unknown as Record<string, unknown>;
     const workspace = maybeGetOmpWorkspaceServices();
     const hostnameKey = getHostnameKey();
+    renderProviderReadinessPanel({
+      container,
+      providerName: 'OMP',
+      async getSnapshot() {
+        const provider = getOmpProviderSettings(settings);
+        return assessProviderReadiness({
+          cliPath: await context.plugin.getResolvedProviderCliPath('omp'),
+          discoveredModelCount: provider.discoveredModels.length,
+          enabled: provider.enabled,
+          selectedModelCount: provider.visibleModels.length,
+        });
+      },
+      async onRefresh() {
+        const result = await workspace?.refreshModelCatalog?.();
+        if (result?.diagnostics) {
+          new Notice(t('settings.omp.discoveryFailed', { error: result.diagnostics }));
+        }
+        context.notifyProviderModelOptionsChanged('omp');
+      },
+    });
     new Setting(container).setName(t('settings.omp.setup')).setHeading();
     renderProviderEnablementSetting({
       container,

--- a/src/providers/opencode/ui/OpencodeSettingsTab.ts
+++ b/src/providers/opencode/ui/OpencodeSettingsTab.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import { Setting } from 'obsidian';
 
+import { assessProviderReadiness } from '../../../core/providers/ProviderReadiness';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type {
   ProviderSettingsTabRenderer,
@@ -20,6 +21,7 @@ import {
   type ProviderModelPickerState,
   renderProviderModelPicker,
 } from '../../../shared/settings/ProviderModelPicker';
+import { renderProviderReadinessPanel } from '../../../shared/settings/ProviderReadinessPanel';
 import { getHostnameKey } from '../../../utils/env';
 import { expandHomePath } from '../../../utils/path';
 import { maybeGetOpencodeWorkspaceServices } from '../app/OpencodeWorkspaceServices';
@@ -45,6 +47,20 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
     const opencodeWorkspace = maybeGetOpencodeWorkspaceServices();
     const settingsBag = context.plugin.settings as unknown as Record<string, unknown>;
     const hostnameKey = getHostnameKey();
+
+    renderProviderReadinessPanel({
+      container,
+      providerName: 'OpenCode',
+      async getSnapshot() {
+        const current = getOpencodeProviderSettings(settingsBag);
+        return assessProviderReadiness({
+          cliPath: await context.plugin.getResolvedProviderCliPath('opencode'),
+          discoveredModelCount: current.discoveredModels.length,
+          enabled: current.enabled,
+          selectedModelCount: current.visibleModels.length,
+        });
+      },
+    });
 
     new Setting(container).setName('Setup').setHeading();
 

--- a/src/providers/opencode/ui/OpencodeSettingsTab.ts
+++ b/src/providers/opencode/ui/OpencodeSettingsTab.ts
@@ -54,7 +54,9 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
       async getSnapshot() {
         const current = getOpencodeProviderSettings(settingsBag);
         return assessProviderReadiness({
-          cliPath: await context.plugin.getResolvedProviderCliPath('opencode'),
+          cliPath: typeof context.plugin.getResolvedProviderCliPath === 'function'
+            ? await context.plugin.getResolvedProviderCliPath('opencode')
+            : null,
           discoveredModelCount: current.discoveredModels.length,
           enabled: current.enabled,
           selectedModelCount: current.visibleModels.length,

--- a/src/providers/pi/ui/PiSettingsTab.ts
+++ b/src/providers/pi/ui/PiSettingsTab.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 
 import { Notice, Setting } from 'obsidian';
 
+import { assessProviderReadiness } from '../../../core/providers/ProviderReadiness';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type {
   ProviderSettingsTabRenderer,
@@ -20,6 +21,7 @@ import {
   type ProviderModelPickerState,
   renderProviderModelPicker,
 } from '../../../shared/settings/ProviderModelPicker';
+import { renderProviderReadinessPanel } from '../../../shared/settings/ProviderReadinessPanel';
 import { getHostnameKey } from '../../../utils/env';
 import { expandHomePath } from '../../../utils/path';
 import { maybeGetPiWorkspaceServices } from '../app/PiWorkspaceServices';
@@ -37,6 +39,20 @@ export const piSettingsTabRenderer: ProviderSettingsTabRenderer = {
     const settingsBag = context.plugin.settings as unknown as Record<string, unknown>;
     const hostnameKey = getHostnameKey();
     const workspace = maybeGetPiWorkspaceServices();
+
+    renderProviderReadinessPanel({
+      container,
+      providerName: 'Pi',
+      async getSnapshot() {
+        const current = getPiProviderSettings(settingsBag);
+        return assessProviderReadiness({
+          cliPath: await context.plugin.getResolvedProviderCliPath('pi'),
+          discoveredModelCount: current.discoveredModels.length,
+          enabled: current.enabled,
+          selectedModelCount: current.visibleModels.length,
+        });
+      },
+    });
 
     new Setting(container).setName('Setup').setHeading();
 

--- a/src/providers/pi/ui/PiSettingsTab.ts
+++ b/src/providers/pi/ui/PiSettingsTab.ts
@@ -46,7 +46,9 @@ export const piSettingsTabRenderer: ProviderSettingsTabRenderer = {
       async getSnapshot() {
         const current = getPiProviderSettings(settingsBag);
         return assessProviderReadiness({
-          cliPath: await context.plugin.getResolvedProviderCliPath('pi'),
+          cliPath: typeof context.plugin.getResolvedProviderCliPath === 'function'
+            ? await context.plugin.getResolvedProviderCliPath('pi')
+            : null,
           discoveredModelCount: current.discoveredModels.length,
           enabled: current.enabled,
           selectedModelCount: current.visibleModels.length,

--- a/src/shared/settings/ProviderReadinessPanel.ts
+++ b/src/shared/settings/ProviderReadinessPanel.ts
@@ -1,0 +1,86 @@
+import { Setting } from 'obsidian';
+
+import type {
+  ProviderReadinessCheck,
+  ProviderReadinessSnapshot,
+  ProviderReadinessStatus,
+} from '../../core/providers/ProviderReadiness';
+import { t } from '../../i18n/i18n';
+
+export interface ProviderReadinessPanelOptions {
+  container: HTMLElement;
+  providerName: string;
+  getSnapshot: () => Promise<ProviderReadinessSnapshot>;
+  onRefresh?: () => Promise<void>;
+}
+
+export function renderProviderReadinessPanel(
+  options: ProviderReadinessPanelOptions,
+): void {
+  const root = options.container.createDiv({ cls: 'claudian-provider-readiness' });
+  new Setting(root)
+    .setName(t('settings.providerReadiness.title'))
+    .setDesc(t('settings.providerReadiness.desc', { provider: options.providerName }))
+    .setHeading();
+
+  const summary = root.createDiv({ cls: 'claudian-provider-readiness-summary' });
+  const checks = root.createDiv({ cls: 'claudian-provider-readiness-checks' });
+  const action = new Setting(root);
+  let refreshButton: HTMLButtonElement | null = null;
+
+  action.addButton(button => {
+    refreshButton = button.buttonEl;
+    button.setButtonText(t('settings.providerReadiness.refresh'));
+    button.onClick(() => { void refresh(true); });
+  });
+
+  const renderSnapshot = (snapshot: ProviderReadinessSnapshot): void => {
+    summary.setText(t(`settings.providerReadiness.status.${snapshot.status}`));
+    summary.dataset.status = snapshot.status;
+    checks.empty();
+    for (const check of snapshot.checks) {
+      renderCheck(checks, check);
+    }
+  };
+
+  const refresh = async (refreshCatalog = false): Promise<void> => {
+    if (refreshButton) refreshButton.disabled = true;
+    summary.setText(t('settings.providerReadiness.checking'));
+    try {
+      if (refreshCatalog) {
+        await options.onRefresh?.();
+      }
+      renderSnapshot(await options.getSnapshot());
+    } finally {
+      if (refreshButton) refreshButton.disabled = false;
+    }
+  };
+
+  void refresh();
+}
+
+function renderCheck(container: HTMLElement, check: ProviderReadinessCheck): void {
+  const row = container.createDiv({ cls: 'claudian-provider-readiness-check' });
+  row.dataset.status = check.status;
+  row.createSpan({
+    cls: 'claudian-provider-readiness-check-icon',
+    text: getStatusIcon(check.status),
+  });
+  row.createSpan({
+    cls: 'claudian-provider-readiness-check-label',
+    text: t(`settings.providerReadiness.check.${check.id}`),
+  });
+  row.createSpan({
+    cls: 'claudian-provider-readiness-check-status',
+    text: t(`settings.providerReadiness.status.${check.status}`),
+  });
+}
+
+function getStatusIcon(status: ProviderReadinessStatus): string {
+  switch (status) {
+    case 'ready': return '✓';
+    case 'attention': return '!';
+    case 'blocked': return '×';
+    case 'disabled': return '–';
+  }
+}

--- a/src/shared/settings/ProviderReadinessPanel.ts
+++ b/src/shared/settings/ProviderReadinessPanel.ts
@@ -25,19 +25,19 @@ export function renderProviderReadinessPanel(
 
   const summary = root.createDiv({ cls: 'claudian-provider-readiness-summary' });
   const checks = root.createDiv({ cls: 'claudian-provider-readiness-checks' });
-  const action = new Setting(root);
-  let refreshButton: HTMLButtonElement | null = null;
+  const refreshButton = options.onRefresh
+    ? root.createEl('button', {
+      cls: 'claudian-provider-readiness-refresh',
+      text: t('settings.providerReadiness.refresh'),
+    })
+    : null;
 
-  action.addButton(button => {
-    refreshButton = button.buttonEl;
-    button.setButtonText(t('settings.providerReadiness.refresh'));
-    button.onClick(() => { void refresh(true); });
-  });
+  refreshButton?.addEventListener?.('click', () => { void refresh(true); });
 
   const renderSnapshot = (snapshot: ProviderReadinessSnapshot): void => {
     summary.setText(t(`settings.providerReadiness.status.${snapshot.status}`));
-    summary.dataset.status = snapshot.status;
-    checks.empty();
+    if (summary.dataset) summary.dataset.status = snapshot.status;
+    checks.empty?.();
     for (const check of snapshot.checks) {
       renderCheck(checks, check);
     }
@@ -61,16 +61,23 @@ export function renderProviderReadinessPanel(
 
 function renderCheck(container: HTMLElement, check: ProviderReadinessCheck): void {
   const row = container.createDiv({ cls: 'claudian-provider-readiness-check' });
-  row.dataset.status = check.status;
-  row.createSpan({
+  if (row.dataset) row.dataset.status = check.status;
+  const createSpan = typeof row.createSpan === 'function'
+    ? row.createSpan.bind(row)
+    : (options: { cls: string; text: string }) => {
+      // Some lightweight settings test doubles do not implement Obsidian's createSpan helper.
+      // eslint-disable-next-line obsidianmd/prefer-create-el
+      return row.createEl('span', options);
+    };
+  createSpan({
     cls: 'claudian-provider-readiness-check-icon',
     text: getStatusIcon(check.status),
   });
-  row.createSpan({
+  createSpan({
     cls: 'claudian-provider-readiness-check-label',
     text: t(`settings.providerReadiness.check.${check.id}`),
   });
-  row.createSpan({
+  createSpan({
     cls: 'claudian-provider-readiness-check-status',
     text: t(`settings.providerReadiness.status.${check.status}`),
   });

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -57,6 +57,7 @@
 @import "./settings/agent-settings.css";
 @import "./settings/agent-skills.css";
 @import "./settings/provider-model-picker.css";
+@import "./settings/provider-readiness.css";
 
 /* Accessibility */
 @import "./accessibility.css";

--- a/src/style/settings/provider-readiness.css
+++ b/src/style/settings/provider-readiness.css
@@ -4,6 +4,7 @@
 .claudian-provider-readiness-summary[data-status="blocked"] { color: var(--text-error); }
 .claudian-provider-readiness-summary[data-status="attention"] { color: var(--text-warning); }
 .claudian-provider-readiness-checks { display: grid; gap: 6px; margin: 0 12px; }
+.claudian-provider-readiness-refresh { display: block; margin: 10px 12px 0 auto; }
 .claudian-provider-readiness-check { display: flex; align-items: center; gap: 8px; color: var(--text-muted); font-size: var(--font-ui-small); }
 .claudian-provider-readiness-check-icon { width: 18px; color: var(--text-faint); text-align: center; }
 .claudian-provider-readiness-check[data-status="ready"] .claudian-provider-readiness-check-icon { color: var(--text-success); }

--- a/src/style/settings/provider-readiness.css
+++ b/src/style/settings/provider-readiness.css
@@ -1,0 +1,13 @@
+.claudian-provider-readiness { margin-bottom: 18px; }
+.claudian-provider-readiness-summary { margin: 4px 12px 10px; color: var(--text-muted); font-size: var(--font-ui-small); font-weight: var(--font-medium); }
+.claudian-provider-readiness-summary[data-status="ready"] { color: var(--text-success); }
+.claudian-provider-readiness-summary[data-status="blocked"] { color: var(--text-error); }
+.claudian-provider-readiness-summary[data-status="attention"] { color: var(--text-warning); }
+.claudian-provider-readiness-checks { display: grid; gap: 6px; margin: 0 12px; }
+.claudian-provider-readiness-check { display: flex; align-items: center; gap: 8px; color: var(--text-muted); font-size: var(--font-ui-small); }
+.claudian-provider-readiness-check-icon { width: 18px; color: var(--text-faint); text-align: center; }
+.claudian-provider-readiness-check[data-status="ready"] .claudian-provider-readiness-check-icon { color: var(--text-success); }
+.claudian-provider-readiness-check[data-status="blocked"] .claudian-provider-readiness-check-icon { color: var(--text-error); }
+.claudian-provider-readiness-check[data-status="attention"] .claudian-provider-readiness-check-icon { color: var(--text-warning); }
+.claudian-provider-readiness-check-label { flex: 1; }
+.claudian-provider-readiness-check-status { color: var(--text-faint); }

--- a/tests/unit/core/providers/ProviderReadiness.test.ts
+++ b/tests/unit/core/providers/ProviderReadiness.test.ts
@@ -1,0 +1,57 @@
+import {
+  assessProviderReadiness,
+  type ProviderReadinessInput,
+} from '@/core/providers/ProviderReadiness';
+
+describe('assessProviderReadiness', () => {
+  const baseInput: ProviderReadinessInput = {
+    cliPath: '/usr/local/bin/omp',
+    discoveredModelCount: 3,
+    selectedModelCount: 2,
+    enabled: true,
+  };
+
+  it('reports a provider as ready when it can reach a selected model', () => {
+    expect(assessProviderReadiness(baseInput)).toEqual({
+      status: 'ready',
+      checks: [
+        { id: 'enabled', status: 'ready' },
+        { id: 'cli', status: 'ready' },
+        { id: 'models', status: 'ready' },
+        { id: 'selection', status: 'ready' },
+      ],
+    });
+  });
+
+  it('identifies the first actionable gaps when the provider is enabled but not configured', () => {
+    expect(assessProviderReadiness({
+      ...baseInput,
+      cliPath: null,
+      discoveredModelCount: 0,
+      selectedModelCount: 0,
+    })).toMatchObject({
+      status: 'blocked',
+      checks: [
+        { id: 'enabled', status: 'ready' },
+        { id: 'cli', status: 'blocked' },
+        { id: 'models', status: 'attention' },
+        { id: 'selection', status: 'blocked' },
+      ],
+    });
+  });
+
+  it('treats a disabled provider as intentionally inactive', () => {
+    expect(assessProviderReadiness({
+      ...baseInput,
+      enabled: false,
+    })).toMatchObject({
+      status: 'disabled',
+      checks: [
+        { id: 'enabled', status: 'disabled' },
+        { id: 'cli', status: 'disabled' },
+        { id: 'models', status: 'disabled' },
+        { id: 'selection', status: 'disabled' },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add provider readiness diagnostics to Claude, Codex, Grok, OpenCode, OMP, and Pi settings
- keep provider-specific CLI and model state behind each provider settings tab
- fix `npm run dev` resource watching and copying for CSS and manifest changes
- add localized readiness strings and focused tests

## Validation
- `npm run typecheck`
- `npm run lint -- --no-fix`
- `node --test scripts/devWatchFiles.test.mjs`
- focused readiness tests
- `npm run build`

The build synced the plugin resources to the configured wiki vault.