### PR TITLE
release: prepare 2.1.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-claudian",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-claudian",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claudian",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Coding agents embedded in an Obsidian sidebar, including Oh My Pi support",
   "main": "main.js",
   "engines": {


### PR DESCRIPTION
## Release preparation

- bump `manifest.json`, `package.json`, and `package-lock.json` to `2.1.3`
- prepares the merged provider readiness diagnostics and dev resource watch changes for release

After merging, push the `2.1.3` tag to trigger the release workflow.