### PR TITLE
feat: improve execution recovery and provider readiness

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,8 @@ npm run build
 
 For user-facing settings changes, manually check every provider tab (Claude, Codex, Grok, OpenCode, OMP, and Pi) when the provider is available. Confirm that readiness status reflects the provider's own CLI and model configuration, and that refreshing the panel does not mutate provider-native files.
 
+When changing provider settings, also verify that enabling or disabling a provider immediately refreshes its readiness panel. For model catalog changes, check the cached/stale/failed state, default model label, and all-versus-explicit selection behavior for the affected provider.
+
 During development, `npm run dev` also watches styles and `manifest.json`. Set `OBSIDIAN_VAULT` in `.env.local` to copy rebuilt resources into a test vault automatically.
 
 The project architecture and area-specific development rules are documented in `AGENTS.md` and the scoped `AGENTS.md` files under `src/`.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Oh My Claudian is an Obsidian plugin that embeds coding agents in your vault. Ag
 - Slash commands, skills, `@` mentions, and instruction mode.
 - Provider-specific planning, permissions, reasoning controls, and model selection.
 - Provider readiness diagnostics in each provider settings tab, covering enablement, CLI availability, model discovery, and model selection.
+- Readiness state refreshes immediately after provider enablement changes, so the settings page does not show stale status.
+- Model catalog state in provider settings, including freshness, cached/failed refresh state, default model, and all-versus-explicit selection.
+- Provider-neutral execution outcomes for completion, cancellation, invalidation, and recoverable errors, with recovery actions fenced while a turn is active.
 - MCP support where available from the selected provider.
 - Internationalized interface with 10 locales, including Simplified and Traditional Chinese.
 
@@ -59,7 +62,7 @@ Then enable the plugin in Obsidian under **Settings → Community plugins**.
 
 Open the chat sidebar from the ribbon icon or command palette. Select text and use the inline-edit hotkey to edit notes with a diff preview. Use `/` for commands and skills, `@` to reference vault files or provider resources, and the provider selector to choose Claude, Codex, Grok, OMP, OpenCode, or Pi.
 
-Each provider has a readiness panel in its settings tab. Use it to see whether the provider is enabled, its CLI is available, models have been discovered, and a chat model is selected. The panel reports problems and lets you recheck the current provider state; installation and authentication remain provider-native.
+Each provider has a readiness panel in its settings tab. Use it to see whether the provider is enabled, its CLI is available, models have been discovered, and a chat model is selected. The panel refreshes after enablement changes and lets you recheck the current provider state; installation and authentication remain provider-native. Model pickers also show whether the catalog is fresh, cached, or failed to refresh, along with the provider default and current selection mode.
 
 OMP requires its CLI to be installed and logged in separately. In **Settings → Oh My Claudian → OMP**, enable the provider, set the CLI path if it is not detected automatically, and use **Discover** to load available models.
 

--- a/src/core/execution/ProviderExecutionOutcome.ts
+++ b/src/core/execution/ProviderExecutionOutcome.ts
@@ -1,0 +1,90 @@
+import type {
+  ProviderCancelledEvent,
+  ProviderExecutionErrorEvent,
+  ProviderTurnCompletedEvent,
+} from './ProviderExecutionEvent';
+
+export type ProviderExecutionTerminalEvent =
+  | ProviderTurnCompletedEvent
+  | ProviderCancelledEvent
+  | ProviderExecutionErrorEvent;
+
+export type ProviderExecutionOutcomeStatus =
+  | 'completed'
+  | 'cancelled'
+  | 'error'
+  | 'invalidated';
+
+export interface ProviderExecutionOutcome {
+  readonly status: ProviderExecutionOutcomeStatus;
+  readonly accepted: boolean;
+  readonly planCompleted: boolean;
+  readonly nativeUserMessageId?: string;
+  readonly nativeAssistantMessageId?: string;
+  readonly nativeCheckpointId?: string;
+  readonly error?: ProviderExecutionErrorEvent;
+  readonly recoverable?: boolean;
+}
+
+export interface ProviderExecutionOutcomeInput {
+  readonly accepted: boolean;
+  readonly terminal?: ProviderExecutionTerminalEvent;
+  readonly interruption?: Extract<ProviderExecutionOutcomeStatus, 'cancelled' | 'invalidated'>;
+  readonly nativeUserMessageId?: string;
+  readonly nativeAssistantMessageId?: string;
+  readonly nativeCheckpointId?: string;
+}
+
+/**
+ * Converts one requested execution's terminal state into the provider-neutral
+ * result consumed by conversation and feature orchestration.
+ */
+export function createProviderExecutionOutcome(
+  input: ProviderExecutionOutcomeInput,
+): ProviderExecutionOutcome {
+  if (input.interruption) {
+    return {
+      status: input.interruption,
+      accepted: input.accepted,
+      planCompleted: false,
+      nativeUserMessageId: input.nativeUserMessageId,
+      nativeAssistantMessageId: input.nativeAssistantMessageId,
+      nativeCheckpointId: input.nativeCheckpointId,
+    };
+  }
+
+  const terminal = input.terminal;
+  if (!terminal || terminal.type === 'cancelled') {
+    return {
+      status: 'cancelled',
+      accepted: input.accepted,
+      planCompleted: false,
+      nativeUserMessageId: input.nativeUserMessageId,
+      nativeAssistantMessageId: input.nativeAssistantMessageId,
+      nativeCheckpointId: input.nativeCheckpointId,
+    };
+  }
+
+  if (terminal.type === 'turn_completed') {
+    return {
+      status: 'completed',
+      accepted: input.accepted,
+      planCompleted: terminal.planCompleted === true,
+      nativeUserMessageId: input.nativeUserMessageId,
+      nativeAssistantMessageId:
+        terminal.nativeAssistantId ?? input.nativeAssistantMessageId,
+      nativeCheckpointId: terminal.nativeCheckpointId ?? input.nativeCheckpointId,
+    };
+  }
+
+  return {
+    status: 'error',
+    accepted: input.accepted,
+    planCompleted: false,
+    nativeUserMessageId: input.nativeUserMessageId,
+    nativeAssistantMessageId: input.nativeAssistantMessageId,
+    nativeCheckpointId: input.nativeCheckpointId,
+    error: terminal,
+    recoverable: terminal.recoverable,
+  };
+}

--- a/src/core/execution/index.ts
+++ b/src/core/execution/index.ts
@@ -52,6 +52,13 @@ export {
   type ProviderExecutionTransitionScope,
 } from './ProviderExecutionLifecycleRegistry';
 export {
+  createProviderExecutionOutcome,
+  type ProviderExecutionOutcome,
+  type ProviderExecutionOutcomeInput,
+  type ProviderExecutionOutcomeStatus,
+  type ProviderExecutionTerminalEvent,
+} from './ProviderExecutionOutcome';
+export {
   type ProviderCurrentNoteContext,
   type ProviderExecutionConfiguration,
   type ProviderExecutionContext,

--- a/src/core/providers/modelCatalog.ts
+++ b/src/core/providers/modelCatalog.ts
@@ -1,0 +1,24 @@
+export type ProviderModelCatalogStatus = 'empty' | 'ready' | 'stale' | 'failed';
+
+export interface ProviderModelCatalogStatusInput {
+  readonly modelCount: number;
+  readonly now?: number;
+  readonly refreshedAt?: number;
+  readonly refreshFailed?: boolean;
+  readonly ttlMs?: number;
+}
+
+const DEFAULT_CATALOG_TTL_MS = 5 * 60 * 1000;
+
+export function deriveProviderModelCatalogStatus(
+  input: ProviderModelCatalogStatusInput,
+): ProviderModelCatalogStatus {
+  if (input.modelCount <= 0) return 'empty';
+  if (input.refreshFailed) return 'failed';
+  if (input.refreshedAt === undefined) return 'stale';
+
+  const now = input.now ?? Date.now();
+  const ttlMs = input.ttlMs ?? DEFAULT_CATALOG_TTL_MS;
+  return now - input.refreshedAt > ttlMs ? 'stale' : 'ready';
+}
+

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -238,6 +238,10 @@ export class InputController {
   }
 
   async handleExecutionEvent(event: ProviderExecutionEvent): Promise<void> {
+    if (event.type === 'usage_updated') {
+      this.deps.streamController.updateUsage(event.usage);
+      return;
+    }
     const assistant = this.activeStreamingAssistantMessage;
     if (!assistant) return;
     if (event.type === 'user_message_started') {

--- a/src/features/chat/controllers/StreamController.ts
+++ b/src/features/chat/controllers/StreamController.ts
@@ -35,6 +35,7 @@ import type {
   StreamChunk,
   SubagentInfo,
   ToolCallInfo,
+  UsageInfo,
 } from '../../../core/types';
 import type { SDKToolUseResult } from '../../../core/types/diff';
 import {
@@ -300,25 +301,7 @@ export class StreamController {
       }
 
       case 'usage': {
-        // Skip usage updates from other sessions or when flagged (during session reset)
-        const currentSessionId = this.deps.getProviderSessionId?.() ?? null;
-        const chunkSessionId = chunk.sessionId ?? null;
-        if (
-          (chunkSessionId && currentSessionId && chunkSessionId !== currentSessionId) ||
-          (chunkSessionId && !currentSessionId)
-        ) {
-          break;
-        }
-        // Skip usage updates when subagents ran (SDK reports cumulative usage including subagents)
-        if (this.deps.subagentManager.subagentsSpawnedThisStream > 0) {
-          break;
-        }
-        if (!state.ignoreUsageUpdates) {
-          const activeModel = this.getActiveProviderModel();
-          state.usage = activeModel && !chunk.usage.model
-            ? { ...chunk.usage, model: activeModel }
-            : chunk.usage;
-        }
+        this.updateUsage(chunk.usage, chunk.sessionId ?? undefined);
         break;
       }
 
@@ -327,6 +310,25 @@ export class StreamController {
     }
 
     this.scrollToBottom();
+  }
+
+  updateUsage(usage: UsageInfo, sessionId?: string): void {
+    const state = this.deps.state;
+    const currentSessionId = this.deps.getProviderSessionId?.() ?? null;
+    const chunkSessionId = sessionId ?? null;
+    if (
+      (chunkSessionId && currentSessionId && chunkSessionId !== currentSessionId) ||
+      (chunkSessionId && !currentSessionId)
+    ) {
+      return;
+    }
+    if (this.deps.subagentManager.subagentsSpawnedThisStream > 0) return;
+    if (state.ignoreUsageUpdates) return;
+
+    const activeModel = this.getActiveProviderModel();
+    state.usage = activeModel && !usage.model
+      ? { ...usage, model: activeModel }
+      : usage;
   }
 
   // ============================================

--- a/src/features/chat/execution/ChatExecutionCoordinator.ts
+++ b/src/features/chat/execution/ChatExecutionCoordinator.ts
@@ -3,29 +3,29 @@ import {
   CONVERSATION_INPUT_LEDGER_SCHEMA_VERSION,
   type ConversationInputRecord,
 } from '@/core/bootstrap/ConversationInputLedgerStorage';
-import type {
-  ChatRewindMode,
-  ChatRewindPreview,
-  ChatRewindResult,
-  ProviderExecutionBackend,
-  ProviderExecutionConfiguration,
-  ProviderExecutionEvent,
-  ProviderExecutionInvalidationReason,
-  ProviderExecutionLifecycleRegistry,
-  ProviderExecutionRequest,
-  ProviderExecutionRun,
-  ProviderExecutionSession,
-  ProviderInteractionDismissReason,
-  ProviderInteractionPort,
-  ProviderNativeResumeSeed,
-  ProviderSessionEvent,
-  ProviderSessionSnapshot,
-  ProviderToolPolicy,
-} from '@/core/execution';
 import {
+  type ChatRewindMode,
+  type ChatRewindPreview,
+  type ChatRewindResult,
+  createProviderExecutionOutcome,
   isModeConfigurableExecutionSession,
   isRewindableExecutionSession,
   isSteerableExecutionSession,
+  type ProviderExecutionBackend,
+  type ProviderExecutionConfiguration,
+  type ProviderExecutionEvent,
+  type ProviderExecutionInvalidationReason,
+  type ProviderExecutionLifecycleRegistry,
+  type ProviderExecutionOutcome,
+  type ProviderExecutionRequest,
+  type ProviderExecutionRun,
+  type ProviderExecutionSession,
+  type ProviderInteractionDismissReason,
+  type ProviderInteractionPort,
+  type ProviderNativeResumeSeed,
+  type ProviderSessionEvent,
+  type ProviderSessionSnapshot,
+  type ProviderToolPolicy,
 } from '@/core/execution';
 import type {
   ChatMessage,
@@ -147,21 +147,12 @@ export interface ChatExecutionCoordinatorDeps {
   readonly onError?: (error: unknown) => void;
 }
 
-export interface ChatExecutionResult {
-  readonly status:
-    | 'completed'
-    | 'cancelled'
-    | 'error'
-    | 'missing-session'
-    | 'invalidated';
-  readonly accepted: boolean;
-  readonly planCompleted: boolean;
-  readonly nativeUserMessageId?: string;
-  readonly nativeAssistantMessageId?: string;
-  readonly nativeCheckpointId?: string;
-  readonly error?: Extract<ProviderExecutionEvent, { type: 'execution_error' }>;
+export interface ChatMissingSessionResult extends Omit<ProviderExecutionOutcome, 'status'> {
+  readonly status: 'missing-session';
   readonly missingSessionResolution?: MissingProviderSessionResolution;
 }
+
+export type ChatExecutionResult = ProviderExecutionOutcome | ChatMissingSessionResult;
 
 interface SessionBinding {
   readonly conversation: ChatExecutionConversationBinding;
@@ -479,6 +470,10 @@ export class ChatExecutionCoordinator {
     assistantMessageId: string | undefined,
     mode?: ChatRewindMode,
   ): Promise<ChatRewindPreview> {
+    const activeExecutionError = this.getActiveExecutionMutationError('rewind');
+    if (activeExecutionError) {
+      return { canRewind: false, error: activeExecutionError };
+    }
     await this.prepare();
     const session = this.requireCurrentSessionBinding().session;
     if (!isRewindableExecutionSession(session)) {
@@ -488,6 +483,7 @@ export class ChatExecutionCoordinator {
   }
 
   async setMode(mode: string): Promise<boolean> {
+    if (this.getActiveExecutionMutationError('change execution mode')) return false;
     await this.prepare();
     const binding = this.requireCurrentSessionBinding();
     if (!isModeConfigurableExecutionSession(binding.session)) return false;
@@ -502,6 +498,10 @@ export class ChatExecutionCoordinator {
     assistantMessageId: string | undefined,
     mode?: ChatRewindMode,
   ): Promise<ChatRewindResult> {
+    const activeExecutionError = this.getActiveExecutionMutationError('rewind');
+    if (activeExecutionError) {
+      return { canRewind: false, error: activeExecutionError };
+    }
     await this.prepare();
     const binding = this.requireCurrentSessionBinding();
     if (!isRewindableExecutionSession(binding.session)) {
@@ -566,7 +566,6 @@ export class ChatExecutionCoordinator {
   ): Promise<ChatExecutionResult> {
     let lastSequence = 0;
     let accepted = false;
-    let planCompleted = false;
     let nativeUserMessageId: string | undefined;
     let nativeAssistantMessageId: string | undefined;
     let nativeCheckpointId: string | undefined;
@@ -615,7 +614,6 @@ export class ChatExecutionCoordinator {
         await this.persistSnapshot(active.binding, event.snapshot);
       } else if (event.type === 'turn_completed') {
         terminal = event;
-        planCompleted = event.planCompleted === true;
         nativeAssistantMessageId =
           event.nativeAssistantId ?? nativeAssistantMessageId;
         nativeCheckpointId =
@@ -678,34 +676,35 @@ export class ChatExecutionCoordinator {
     }
 
     if (active.terminationOverride) {
-      return createInterruptedResult(active.terminationOverride, accepted);
-    }
-    if (!this.isBindingCurrent(active.binding)) {
-      return createInterruptedResult('invalidated', accepted);
-    }
-    if (!terminal) {
-      return createInterruptedResult('cancelled', accepted);
-    }
-    if (terminal.type === 'turn_completed') {
-      return {
-        status: 'completed',
+      return createProviderExecutionOutcome({
+        interruption: active.terminationOverride,
         accepted,
-        planCompleted,
         nativeUserMessageId,
         nativeAssistantMessageId,
         nativeCheckpointId,
-      };
+      });
     }
-    if (terminal.type === 'cancelled') {
-      return {
-        status: 'cancelled',
+    if (!this.isBindingCurrent(active.binding)) {
+      return createProviderExecutionOutcome({
+        interruption: 'invalidated',
         accepted,
-        planCompleted: false,
         nativeUserMessageId,
         nativeAssistantMessageId,
-      };
+        nativeCheckpointId,
+      });
     }
-    if (terminal.category === 'provider-session-missing') {
+    if (!terminal) {
+      return createProviderExecutionOutcome({
+        accepted,
+        nativeUserMessageId,
+        nativeAssistantMessageId,
+        nativeCheckpointId,
+      });
+    }
+    if (
+      terminal.type === 'execution_error'
+      && terminal.category === 'provider-session-missing'
+    ) {
       let resolution: MissingProviderSessionResolution;
       try {
         resolution = await this.deps.resolveMissingProviderSession(
@@ -723,7 +722,13 @@ export class ChatExecutionCoordinator {
           !== active.binding.conversation.conversationId
       ) {
         if (terminalSinkFailure) throw terminalSinkFailure.error;
-        return createInterruptedResult('invalidated', accepted);
+        return createProviderExecutionOutcome({
+          interruption: 'invalidated',
+          accepted,
+          nativeUserMessageId,
+          nativeAssistantMessageId,
+          nativeCheckpointId,
+        });
       }
       try {
         if (this.sessionBinding === active.binding) {
@@ -760,14 +765,13 @@ export class ChatExecutionCoordinator {
         missingSessionResolution: resolution,
       };
     }
-    return {
-      status: 'error',
+    return createProviderExecutionOutcome({
+      terminal,
       accepted,
-      planCompleted: false,
       nativeUserMessageId,
       nativeAssistantMessageId,
-      error: terminal,
-    };
+      nativeCheckpointId,
+    });
   }
 
   private handleSessionEvent(event: ProviderSessionEvent): void {
@@ -807,6 +811,12 @@ export class ChatExecutionCoordinator {
       binding.backgroundSequences.delete(event.scope.turnId);
       binding.completedBackgroundTurns.add(event.scope.turnId);
     }
+  }
+
+  private getActiveExecutionMutationError(operation: string): string | null {
+    return this.activeExecution
+      ? `Cannot ${operation} while a chat execution is active.`
+      : null;
   }
 
   private async persistSnapshot(
@@ -1126,17 +1136,6 @@ function sameConversationBinding(
     && left.providerId === right.providerId
     && JSON.stringify(left.resumeSeed) === JSON.stringify(right.resumeSeed)
   );
-}
-
-function createInterruptedResult(
-  status: 'cancelled' | 'invalidated',
-  accepted: boolean,
-): ChatExecutionResult {
-  return {
-    status,
-    accepted,
-    planCompleted: false,
-  };
 }
 
 function isDefinitePreHandoffRejection(

--- a/src/providers/claude/ui/ClaudeSettingsTab.ts
+++ b/src/providers/claude/ui/ClaudeSettingsTab.ts
@@ -32,7 +32,7 @@ export const claudeSettingsTabRenderer: ProviderSettingsTabRenderer = {
     const settingsBag = context.plugin.settings as unknown as Record<string, unknown>;
     const claudeSettings = getClaudeProviderSettings(settingsBag);
 
-    renderProviderReadinessPanel({
+    const readinessPanel = renderProviderReadinessPanel({
       container,
       providerName: 'Claude',
       async getSnapshot() {
@@ -99,6 +99,7 @@ export const claudeSettingsTabRenderer: ProviderSettingsTabRenderer = {
         } else {
           lastProviderWarning.showFor();
         }
+        await readinessPanel.refresh();
         context.notifyProviderModelOptionsChanged('claude');
       },
     });

--- a/src/providers/codex/ui/CodexModelPicker.ts
+++ b/src/providers/codex/ui/CodexModelPicker.ts
@@ -1,5 +1,6 @@
 import { Notice } from 'obsidian';
 
+import { deriveProviderModelCatalogStatus } from '../../../core/providers/modelCatalog';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type { ProviderSettingsTabRendererContext } from '../../../core/providers/types';
 import {
@@ -11,6 +12,7 @@ import {
 import type { CodexWorkspaceServices } from '../app/CodexWorkspaceServices';
 import {
   getCodexModelsInPickerOrder,
+  getDefaultCodexModel,
   isCodexModelAvailable,
 } from '../models';
 import {
@@ -82,8 +84,15 @@ export function renderCodexModelPicker(
 
     return {
       aliases: current.modelAliases,
+      catalogRefreshedAt: current.catalogTimestamp,
+      catalogStatus: deriveProviderModelCatalogStatus({
+        modelCount: current.discoveredModels.length,
+        refreshedAt: current.catalogTimestamp || undefined,
+      }),
+      defaultModelId: getDefaultCodexModel(current.discoveredModels)?.model,
       discoveredCount: current.discoveredModels.length,
       models,
+      selectionMode: current.visibleModels === null ? 'all' : 'explicit',
       selectedIds,
     };
   };

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -42,7 +42,7 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
       }
     };
 
-    renderProviderReadinessPanel({
+    const readinessPanel = renderProviderReadinessPanel({
       container,
       providerName: 'Codex',
       async getSnapshot() {
@@ -93,6 +93,7 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
         } else {
           lastProviderWarning.showFor();
         }
+        await readinessPanel.refresh();
         modelWarning.context.notifyProviderModelOptionsChanged('codex');
       },
     });

--- a/src/providers/grok/ui/GrokSettingsTab.ts
+++ b/src/providers/grok/ui/GrokSettingsTab.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 
 import { Notice, Setting } from 'obsidian';
 
+import { deriveProviderModelCatalogStatus } from '../../../core/providers/modelCatalog';
 import { assessProviderReadiness } from '../../../core/providers/ProviderReadiness';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
@@ -58,7 +59,7 @@ export const grokSettingsTabRenderer: ProviderSettingsTabRenderer = {
         : 'empty';
     };
 
-    renderProviderReadinessPanel({
+    const readinessPanel = renderProviderReadinessPanel({
       container,
       providerName: 'Grok',
       async getSnapshot() {
@@ -110,6 +111,7 @@ export const grokSettingsTabRenderer: ProviderSettingsTabRenderer = {
         } else {
           lastProviderWarning.showFor();
         }
+        await readinessPanel.refresh();
         modelWarning.context.notifyProviderModelOptionsChanged(GROK_PROVIDER_ID);
       },
     });
@@ -210,8 +212,19 @@ function renderGrokModelPicker(
     const selectedIds = settings.visibleModels ?? catalogModels.map(model => model.rawId);
     return {
       aliases: settings.modelAliases,
+      catalogRefreshedAt: settings.currentCatalog?.refreshedAt,
+      catalogStatus: deriveProviderModelCatalogStatus({
+        modelCount: catalogModels.length,
+        refreshedAt: settings.currentCatalog?.refreshedAt,
+      }),
+      defaultModelId: settings.currentCatalog?.defaultModelId ?? undefined,
       discoveredCount: catalogModels.length,
-      models: buildGrokPickerModels(catalogModels, selectedIds),
+      models: buildGrokPickerModels(
+        catalogModels,
+        selectedIds,
+        settings.currentCatalog?.defaultModelId ?? undefined,
+      ),
+      selectionMode: settings.visibleModels === null ? 'all' : 'explicit',
       selectedIds,
     };
   };
@@ -254,8 +267,10 @@ function renderGrokModelPicker(
 function buildGrokPickerModels(
   catalogModels: GrokDiscoveredModel[],
   selectedIds: string[],
+  defaultModelId?: string,
 ): ProviderModelPickerModel[] {
   const models: ProviderModelPickerModel[] = catalogModels.map(model => ({
+    ...(model.rawId === defaultModelId ? { catalogBadge: 'Default' } : {}),
     description: model.description,
     id: model.rawId,
     isAvailable: true,

--- a/src/providers/omp/app/OmpWorkspaceServices.ts
+++ b/src/providers/omp/app/OmpWorkspaceServices.ts
@@ -25,6 +25,7 @@ export const ompWorkspaceRegistration: ProviderWorkspaceRegistration<OmpWorkspac
           await plugin.mutateSettings(settings => {
             updateOmpProviderSettings(settings, {
               discoveredModels: catalog.models,
+              catalogTimestamp: Date.now(),
               ...(catalog.thinking ? { thinking: catalog.thinking } : {}),
             });
           });

--- a/src/providers/omp/settings.ts
+++ b/src/providers/omp/settings.ts
@@ -18,6 +18,7 @@ export interface OmpProviderSettings {
   environmentVariables: string;
   thinking: OmpThinkingConfig | null;
   discoveredModels: OmpDiscoveredModel[];
+  catalogTimestamp: number;
   visibleModels: string[];
 }
 
@@ -29,6 +30,7 @@ export const DEFAULT_OMP_PROVIDER_SETTINGS: Readonly<OmpProviderSettings> = Obje
   environmentVariables: '',
   thinking: null,
   discoveredModels: [],
+  catalogTimestamp: 0,
   visibleModels: [],
 });
 
@@ -45,6 +47,7 @@ export function getOmpProviderSettings(settings: Record<string, unknown>): OmpPr
       : getProviderEnvironmentVariables(settings, 'omp') ?? '',
     thinking: normalizeOmpThinkingConfig(config.thinking),
     discoveredModels,
+    catalogTimestamp: typeof config.catalogTimestamp === 'number' ? config.catalogTimestamp : 0,
     visibleModels: normalizeOmpVisibleModels(config.visibleModels, discoveredModels),
   };
 }

--- a/src/providers/omp/ui/OmpSettingsTab.ts
+++ b/src/providers/omp/ui/OmpSettingsTab.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 
 import { Notice, Setting } from 'obsidian';
 
+import { deriveProviderModelCatalogStatus } from '../../../core/providers/modelCatalog';
 import { assessProviderReadiness } from '../../../core/providers/ProviderReadiness';
 import type {
   ProviderSettingsTabRenderer,
@@ -29,7 +30,7 @@ export const ompSettingsTabRenderer: ProviderSettingsTabRenderer = {
     const settings = context.plugin.settings as unknown as Record<string, unknown>;
     const workspace = maybeGetOmpWorkspaceServices();
     const hostnameKey = getHostnameKey();
-    renderProviderReadinessPanel({
+    const readinessPanel = renderProviderReadinessPanel({
       container,
       providerName: 'OMP',
       async getSnapshot() {
@@ -61,6 +62,7 @@ export const ompSettingsTabRenderer: ProviderSettingsTabRenderer = {
         await context.plugin.mutateSettings(target => {
           updateOmpProviderSettings(target, { enabled });
         });
+        await readinessPanel.refresh();
         context.notifyProviderModelOptionsChanged('omp');
       },
     });
@@ -102,8 +104,15 @@ function renderOmpModelPicker(
     const provider = getOmpProviderSettings(settings);
     return {
       aliases: {},
+      catalogRefreshedAt: provider.catalogTimestamp || undefined,
+      catalogStatus: deriveProviderModelCatalogStatus({
+        modelCount: provider.discoveredModels.length,
+        refreshedAt: provider.catalogTimestamp || undefined,
+      }),
+      defaultModelId: provider.visibleModels[0],
       discoveredCount: provider.discoveredModels.length,
       models: provider.discoveredModels.map(toPickerModel),
+      selectionMode: 'explicit',
       selectedIds: provider.visibleModels,
     };
   };

--- a/src/providers/opencode/discoveryState.ts
+++ b/src/providers/opencode/discoveryState.ts
@@ -14,6 +14,7 @@ const OPENCODE_DISCOVERY_STATE = Symbol('opencodeDiscoveryState');
 
 interface OpencodeDiscoveryState {
   availableModes: OpencodeMode[];
+  refreshedAt: number;
   discoveredModels: OpencodeDiscoveredModel[];
   thinkingOptionsByModel: OpencodeThinkingOptionsByModel;
 }
@@ -26,6 +27,7 @@ function ensureDiscoveryState(settings: Record<string, unknown>): OpencodeDiscov
   if (existing && typeof existing === 'object' && !Array.isArray(existing)) {
     const state = existing as Partial<OpencodeDiscoveryState>;
     state.availableModes ??= [];
+    state.refreshedAt ??= 0;
     state.discoveredModels ??= [];
     state.thinkingOptionsByModel ??= {};
     return state as OpencodeDiscoveryState;
@@ -33,6 +35,7 @@ function ensureDiscoveryState(settings: Record<string, unknown>): OpencodeDiscov
 
   const next: OpencodeDiscoveryState = {
     availableModes: [],
+    refreshedAt: 0,
     discoveredModels: [],
     thinkingOptionsByModel: {},
   };
@@ -63,6 +66,7 @@ export function getOpencodeDiscoveryState(settings: Record<string, unknown>): Op
   const state = ensureDiscoveryState(settings);
   return {
     availableModes: cloneModes(state.availableModes),
+    refreshedAt: state.refreshedAt,
     discoveredModels: cloneDiscoveredModels(state.discoveredModels),
     thinkingOptionsByModel: cloneThinkingOptionsByModel(state.thinkingOptionsByModel),
   };
@@ -82,15 +86,20 @@ export function updateOpencodeDiscoveryState(
   const nextThinkingOptionsByModel = 'thinkingOptionsByModel' in updates
     ? normalizeOpencodeThinkingOptionsByModel(updates.thinkingOptionsByModel, nextDiscoveredModels)
     : state.thinkingOptionsByModel;
+  const nextRefreshedAt = 'refreshedAt' in updates
+    ? (typeof updates.refreshedAt === 'number' ? updates.refreshedAt : 0)
+    : state.refreshedAt;
   const changed = !sameModes(state.availableModes, nextAvailableModes)
     || !sameDiscoveredModels(state.discoveredModels, nextDiscoveredModels)
-    || !sameThinkingOptionsByModel(state.thinkingOptionsByModel, nextThinkingOptionsByModel);
+    || !sameThinkingOptionsByModel(state.thinkingOptionsByModel, nextThinkingOptionsByModel)
+    || state.refreshedAt !== nextRefreshedAt;
 
   if (!changed) {
     return false;
   }
 
   state.availableModes = cloneModes(nextAvailableModes);
+  state.refreshedAt = nextRefreshedAt;
   state.discoveredModels = cloneDiscoveredModels(nextDiscoveredModels);
   state.thinkingOptionsByModel = cloneThinkingOptionsByModel(nextThinkingOptionsByModel);
   return true;
@@ -101,12 +110,14 @@ export function clearOpencodeDiscoveryState(settings: Record<string, unknown>): 
   if (
     state.availableModes.length === 0
     && state.discoveredModels.length === 0
+    && state.refreshedAt === 0
     && Object.keys(state.thinkingOptionsByModel).length === 0
   ) {
     return false;
   }
 
   state.availableModes = [];
+  state.refreshedAt = 0;
   state.discoveredModels = [];
   state.thinkingOptionsByModel = {};
   return true;
@@ -130,6 +141,9 @@ export function seedOpencodeDiscoveryStateFromLegacyConfig(
   return updateOpencodeDiscoveryState(settings, {
     availableModes: nextAvailableModes,
     discoveredModels: nextDiscoveredModels,
+    refreshedAt: typeof legacyConfig.catalogTimestamp === 'number'
+      ? legacyConfig.catalogTimestamp
+      : 0,
     thinkingOptionsByModel: nextThinkingOptionsByModel,
   });
 }

--- a/src/providers/opencode/settings.ts
+++ b/src/providers/opencode/settings.ts
@@ -29,6 +29,7 @@ import {
 } from './modes';
 
 export interface PersistedOpencodeProviderSettings {
+  catalogTimestamp?: number;
   cliPath: string;
   cliPathsByHost: HostnameCliPaths;
   enabled: boolean;
@@ -43,12 +44,14 @@ export interface PersistedOpencodeProviderSettings {
 
 export interface OpencodeProviderSettings extends PersistedOpencodeProviderSettings {
   availableModes: OpencodeMode[];
+  catalogTimestamp: number;
   discoveredModels: OpencodeDiscoveredModel[];
 }
 
 export const OPENCODE_DEFAULT_ENVIRONMENT_VARIABLES = 'OPENCODE_ENABLE_EXA=1';
 
 export const DEFAULT_OPENCODE_PROVIDER_SETTINGS: Readonly<PersistedOpencodeProviderSettings> = Object.freeze({
+  catalogTimestamp: 0,
   cliPath: '',
   cliPathsByHost: {},
   enabled: false,
@@ -167,6 +170,7 @@ export function getOpencodeProviderSettings(
 
   return {
     availableModes,
+    catalogTimestamp: discoveryState.refreshedAt,
     cliPath: (config.cliPath as string | undefined)
       ?? DEFAULT_OPENCODE_PROVIDER_SETTINGS.cliPath,
     cliPathsByHost,
@@ -195,6 +199,7 @@ export function updateOpencodeProviderSettings(
 ): OpencodeProviderSettings {
   const current = getOpencodeProviderSettings(settings);
   const hostnameKey = getHostnameKey();
+  const refreshRequested = 'discoveredModels' in updates || 'catalogTimestamp' in updates;
   if ('availableModes' in updates || 'discoveredModels' in updates || 'thinkingOptionsByModel' in updates) {
     updateOpencodeDiscoveryState(settings, {
       ...(updates.availableModes !== undefined ? { availableModes: updates.availableModes } : {}),
@@ -202,6 +207,13 @@ export function updateOpencodeProviderSettings(
       ...(updates.thinkingOptionsByModel !== undefined
         ? { thinkingOptionsByModel: updates.thinkingOptionsByModel }
         : {}),
+      ...(refreshRequested
+        ? { refreshedAt: updates.catalogTimestamp ?? Date.now() }
+        : {}),
+    });
+  } else if (refreshRequested) {
+    updateOpencodeDiscoveryState(settings, {
+      refreshedAt: updates.catalogTimestamp ?? Date.now(),
     });
   }
   const discoveryState = getOpencodeDiscoveryState(settings);
@@ -253,6 +265,7 @@ export function updateOpencodeProviderSettings(
     ...current,
     ...updates,
     availableModes: nextAvailableModes,
+    catalogTimestamp: discoveryState.refreshedAt,
     cliPath: nextCliPath,
     cliPathsByHost: nextCliPathsByHost,
     discoveredModels: nextDiscoveredModels,
@@ -276,6 +289,7 @@ export function updateOpencodeProviderSettings(
   );
 
   setProviderConfig(settings, 'opencode', {
+    catalogTimestamp: next.catalogTimestamp,
     cliPath: next.cliPath,
     cliPathsByHost: next.cliPathsByHost,
     enabled: next.enabled,

--- a/src/providers/opencode/ui/OpencodeSettingsTab.ts
+++ b/src/providers/opencode/ui/OpencodeSettingsTab.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import { Setting } from 'obsidian';
 
+import { deriveProviderModelCatalogStatus } from '../../../core/providers/modelCatalog';
 import { assessProviderReadiness } from '../../../core/providers/ProviderReadiness';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type {
@@ -48,7 +49,7 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
     const settingsBag = context.plugin.settings as unknown as Record<string, unknown>;
     const hostnameKey = getHostnameKey();
 
-    renderProviderReadinessPanel({
+    const readinessPanel = renderProviderReadinessPanel({
       container,
       providerName: 'OpenCode',
       async getSnapshot() {
@@ -96,6 +97,7 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
         } else {
           lastProviderWarning.showFor();
         }
+        await readinessPanel.refresh();
         modelWarning.context.notifyProviderModelOptionsChanged('opencode');
       },
     });
@@ -205,8 +207,15 @@ function renderOpencodeModelPicker(
     const current = getOpencodeProviderSettings(settingsBag);
     return {
       aliases: current.modelAliases,
+      catalogRefreshedAt: current.catalogTimestamp || undefined,
+      catalogStatus: deriveProviderModelCatalogStatus({
+        modelCount: current.discoveredModels.length,
+        refreshedAt: current.catalogTimestamp || undefined,
+      }),
+      defaultModelId: current.visibleModels[0],
       discoveredCount: current.discoveredModels.length,
       models: buildOpencodePickerModels(current.discoveredModels, current.visibleModels),
+      selectionMode: 'explicit',
       selectedIds: current.visibleModels,
     };
   };

--- a/src/providers/pi/settings.ts
+++ b/src/providers/pi/settings.ts
@@ -25,6 +25,7 @@ export type PiToolMode = 'all' | 'readonly';
 export interface PersistedPiProviderSettings {
   cliPath: string;
   cliPathsByHost: HostnameCliPaths;
+  catalogTimestamp?: number;
   discoveredModels: PiDiscoveredModel[];
   enabled: boolean;
   environmentHash: string;
@@ -40,6 +41,7 @@ export type PiProviderSettings = PersistedPiProviderSettings;
 export const DEFAULT_PI_PROVIDER_SETTINGS: Readonly<PersistedPiProviderSettings> = Object.freeze({
   cliPath: '',
   cliPathsByHost: {},
+  catalogTimestamp: 0,
   discoveredModels: [],
   enabled: false,
   environmentHash: '',
@@ -139,6 +141,7 @@ export function getPiProviderSettings(settings: Record<string, unknown>): PiProv
     cliPath: (config.cliPath as string | undefined)
       ?? DEFAULT_PI_PROVIDER_SETTINGS.cliPath,
     cliPathsByHost,
+    catalogTimestamp: typeof config.catalogTimestamp === 'number' ? config.catalogTimestamp : 0,
     discoveredModels,
     enabled: (config.enabled as boolean | undefined)
       ?? DEFAULT_PI_PROVIDER_SETTINGS.enabled,

--- a/src/providers/pi/ui/PiSettingsTab.ts
+++ b/src/providers/pi/ui/PiSettingsTab.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 
 import { Notice, Setting } from 'obsidian';
 
+import { deriveProviderModelCatalogStatus } from '../../../core/providers/modelCatalog';
 import { assessProviderReadiness } from '../../../core/providers/ProviderReadiness';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type {
@@ -40,7 +41,7 @@ export const piSettingsTabRenderer: ProviderSettingsTabRenderer = {
     const hostnameKey = getHostnameKey();
     const workspace = maybeGetPiWorkspaceServices();
 
-    renderProviderReadinessPanel({
+    const readinessPanel = renderProviderReadinessPanel({
       container,
       providerName: 'Pi',
       async getSnapshot() {
@@ -88,6 +89,7 @@ export const piSettingsTabRenderer: ProviderSettingsTabRenderer = {
         } else {
           lastProviderWarning.showFor();
         }
+        await readinessPanel.refresh();
         modelWarning.context.notifyProviderModelOptionsChanged('pi');
       },
     });
@@ -168,8 +170,15 @@ function renderPiModelPicker(
     const current = getPiProviderSettings(settingsBag);
     return {
       aliases: current.modelAliases,
+      catalogRefreshedAt: current.catalogTimestamp || undefined,
+      catalogStatus: deriveProviderModelCatalogStatus({
+        modelCount: current.discoveredModels.length,
+        refreshedAt: current.catalogTimestamp || undefined,
+      }),
+      defaultModelId: current.visibleModels[0],
       discoveredCount: current.discoveredModels.length,
       models: buildPiPickerModels(current.discoveredModels, current.visibleModels),
+      selectionMode: 'explicit',
       selectedIds: current.visibleModels,
     };
   };
@@ -197,6 +206,7 @@ function renderPiModelPicker(
         await context.plugin.mutateSettings((settings) => {
           updatePiProviderSettings(settings, {
             discoveredModels: result.models,
+            catalogTimestamp: Date.now(),
             visibleModels: normalizedVisibleModels,
           });
         });

--- a/src/shared/settings/ProviderModelPicker.ts
+++ b/src/shared/settings/ProviderModelPicker.ts
@@ -1,5 +1,7 @@
 import { Setting } from 'obsidian';
 
+import type { ProviderModelCatalogStatus } from '../../core/providers/modelCatalog';
+
 const ALL_PROVIDERS_KEY = 'all';
 const VISIBLE_MODELS_DESCRIPTION = 'Choose which models are available in the chat selector. Select at least one model to use this provider.';
 
@@ -18,8 +20,12 @@ export interface ProviderModelPickerModel {
 
 export interface ProviderModelPickerState {
   aliases: Record<string, string>;
+  catalogStatus?: ProviderModelCatalogStatus;
+  catalogRefreshedAt?: number;
+  defaultModelId?: string;
   discoveredCount: number;
   models: ProviderModelPickerModel[];
+  selectionMode?: 'all' | 'explicit';
   selectedIds: string[];
 }
 
@@ -114,6 +120,14 @@ export function renderProviderModelPicker(
   const renderSummary = (): void => {
     summaryEl.empty();
     const state = options.getState();
+    const catalogStatus = catalogLoadFailed
+      ? 'failed'
+      : state.catalogStatus
+      ?? (state.discoveredCount > 0 ? 'ready' : 'empty');
+    pickerEl.setAttribute('data-catalog-status', catalogStatus);
+    catalogSummaryEl.title = state.catalogRefreshedAt
+      ? `Last refreshed ${new Date(state.catalogRefreshedAt).toLocaleString()}`
+      : '';
     const providerCount = new Set(
       state.models.map(model => model.providerKey).filter((key): key is string => Boolean(key)),
     ).size;
@@ -121,17 +135,28 @@ export function renderProviderModelPicker(
     summaryEl.createSpan({ text: 'Visible: ' });
     summaryEl.createSpan({
       cls: 'claudian-provider-model-picker-summary-value',
-      text: String(state.selectedIds.length),
+      text: state.selectionMode === 'all' ? 'All' : String(state.selectedIds.length),
     });
     summaryEl.createSpan({
       text: providerCount > 0
         ? ` of ${state.discoveredCount} discovered | ${providerCount} ${providerCount === 1 ? 'provider' : 'providers'}`
         : ` of ${state.discoveredCount} discovered`,
     });
+    if (state.defaultModelId) {
+      const defaultModel = state.models.find(model => model.id === state.defaultModelId);
+      summaryEl.createSpan({
+        cls: 'claudian-provider-model-picker-summary-default',
+        text: `Default: ${defaultModel?.name ?? state.defaultModelId}`,
+      });
+    }
 
     catalogSummaryCountEl.setText(
       loadingCatalog
         ? 'Loading models...'
+        : catalogLoadFailed
+        ? `${state.discoveredCount} cached · refresh failed`
+        : catalogStatus === 'stale'
+        ? `${state.discoveredCount} cached · refresh recommended`
         : state.discoveredCount > 0
         ? `${state.discoveredCount} available`
         : 'No models discovered yet',

--- a/src/shared/settings/ProviderReadinessPanel.ts
+++ b/src/shared/settings/ProviderReadinessPanel.ts
@@ -14,9 +14,13 @@ export interface ProviderReadinessPanelOptions {
   onRefresh?: () => Promise<void>;
 }
 
+export interface ProviderReadinessPanelController {
+  refresh(): Promise<void>;
+}
+
 export function renderProviderReadinessPanel(
   options: ProviderReadinessPanelOptions,
-): void {
+): ProviderReadinessPanelController {
   const root = options.container.createDiv({ cls: 'claudian-provider-readiness' });
   new Setting(root)
     .setName(t('settings.providerReadiness.title'))
@@ -57,6 +61,7 @@ export function renderProviderReadinessPanel(
   };
 
   void refresh();
+  return { refresh };
 }
 
 function renderCheck(container: HTMLElement, check: ProviderReadinessCheck): void {

--- a/src/style/settings/provider-model-picker.css
+++ b/src/style/settings/provider-model-picker.css
@@ -27,6 +27,11 @@
   font-weight: var(--font-medium);
 }
 
+.claudian-provider-model-picker-summary-default {
+  color: var(--text-muted);
+  font-size: var(--font-ui-smaller);
+}
+
 .claudian-provider-model-picker-selected {
   display: flex;
   flex-direction: column;
@@ -255,6 +260,11 @@
   font-size: var(--font-ui-smaller);
   color: var(--text-muted);
   margin-left: auto;
+}
+
+.claudian-provider-model-picker[data-catalog-status="stale"] .claudian-provider-model-picker-catalog-count,
+.claudian-provider-model-picker[data-catalog-status="failed"] .claudian-provider-model-picker-catalog-count {
+  color: var(--text-warning);
 }
 
 .claudian-provider-model-picker-controls {

--- a/tests/unit/core/execution/ProviderExecutionOutcome.test.ts
+++ b/tests/unit/core/execution/ProviderExecutionOutcome.test.ts
@@ -1,0 +1,88 @@
+import type {
+  ProviderExecutionErrorEvent,
+  ProviderTurnCompletedEvent,
+} from '@/core/execution';
+import { createProviderExecutionOutcome } from '@/core/execution/ProviderExecutionOutcome';
+
+const scope = {
+  kind: 'requested' as const,
+  sessionInstanceId: 'session-1',
+  executionId: 'execution-1',
+  turnId: 'turn-1',
+  sequence: 1,
+};
+
+function completedEvent(): ProviderTurnCompletedEvent {
+  return {
+    type: 'turn_completed',
+    scope,
+    reason: 'completed',
+    nativeAssistantId: 'assistant-1',
+    nativeCheckpointId: 'checkpoint-1',
+    planCompleted: true,
+  };
+}
+
+function errorEvent(): ProviderExecutionErrorEvent {
+  return {
+    type: 'execution_error',
+    scope,
+    category: 'transport',
+    message: 'Connection closed',
+    recoverable: true,
+  };
+}
+
+describe('ProviderExecutionOutcome', () => {
+  it('preserves terminal completion metadata behind a provider-neutral outcome', () => {
+    expect(createProviderExecutionOutcome({
+      terminal: completedEvent(),
+      accepted: true,
+    })).toEqual({
+      status: 'completed',
+      accepted: true,
+      planCompleted: true,
+      nativeAssistantMessageId: 'assistant-1',
+      nativeCheckpointId: 'checkpoint-1',
+    });
+  });
+
+  it('classifies recoverable provider errors without losing the provider error event', () => {
+    const terminal = errorEvent();
+
+    expect(createProviderExecutionOutcome({
+      terminal,
+      accepted: true,
+    })).toEqual({
+      status: 'error',
+      accepted: true,
+      planCompleted: false,
+      error: terminal,
+      recoverable: true,
+    });
+  });
+
+  it('represents cancellation and invalidation without requiring a provider terminal event', () => {
+    expect(createProviderExecutionOutcome({
+      interruption: 'cancelled',
+      accepted: false,
+      nativeUserMessageId: 'user-1',
+      nativeAssistantMessageId: 'assistant-1',
+    })).toEqual({
+      status: 'cancelled',
+      accepted: false,
+      planCompleted: false,
+      nativeUserMessageId: 'user-1',
+      nativeAssistantMessageId: 'assistant-1',
+    });
+
+    expect(createProviderExecutionOutcome({
+      interruption: 'invalidated',
+      accepted: true,
+    })).toEqual({
+      status: 'invalidated',
+      accepted: true,
+      planCompleted: false,
+    });
+  });
+});

--- a/tests/unit/core/providers/modelCatalog.test.ts
+++ b/tests/unit/core/providers/modelCatalog.test.ts
@@ -1,0 +1,41 @@
+import {
+  deriveProviderModelCatalogStatus,
+} from '@/core/providers/modelCatalog';
+
+describe('deriveProviderModelCatalogStatus', () => {
+  it('reports an empty catalog when no models have been discovered', () => {
+    expect(deriveProviderModelCatalogStatus({
+      modelCount: 0,
+      now: 10_000,
+      refreshedAt: 9_000,
+    })).toBe('empty');
+  });
+
+  it('reports a ready catalog within the freshness window', () => {
+    expect(deriveProviderModelCatalogStatus({
+      modelCount: 2,
+      now: 10_000,
+      refreshedAt: 9_000,
+      ttlMs: 5_000,
+    })).toBe('ready');
+  });
+
+  it('reports stale cached data after the freshness window', () => {
+    expect(deriveProviderModelCatalogStatus({
+      modelCount: 2,
+      now: 16_000,
+      refreshedAt: 9_000,
+      ttlMs: 5_000,
+    })).toBe('stale');
+  });
+
+  it('reports refresh failure without discarding a usable cached catalog', () => {
+    expect(deriveProviderModelCatalogStatus({
+      modelCount: 2,
+      now: 10_000,
+      refreshedAt: 9_000,
+      refreshFailed: true,
+    })).toBe('failed');
+  });
+});
+

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -141,6 +141,7 @@ function createFixture(overrides: Record<string, unknown> = {}) {
       handleStreamChunk: jest.fn(),
       hideThinkingIndicator: jest.fn(),
       showThinkingIndicator: jest.fn(),
+      updateUsage: jest.fn(),
     },
     selectionController: {
       getContext: jest.fn().mockReturnValue(null),
@@ -492,6 +493,40 @@ describe('InputController coordinator execution', () => {
     expect(fixture.deps.streamController.handleStreamChunk).toHaveBeenCalledWith(
       { content: 'world', type: 'text' },
       expect.objectContaining({ role: 'assistant' }),
+    );
+  });
+
+  it('routes usage updates after the assistant stream has finished', async () => {
+    const fixture = createFixture();
+    fixture.coordinator.execute.mockResolvedValueOnce({
+      accepted: true,
+      planCompleted: false,
+      status: 'completed',
+    });
+
+    await fixture.controller.sendMessage({ content: 'hello' });
+    await fixture.controller.handleExecutionEvent({
+      scope: {
+        executionId: 'execution-1',
+        kind: 'requested',
+        sequence: 1,
+        sessionInstanceId: 'session-1',
+        turnId: 'turn-1',
+      },
+      type: 'usage_updated',
+      usage: {
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        contextTokens: 50_000,
+        contextWindow: 200_000,
+        inputTokens: 50_000,
+        model: 'claude-model',
+        percentage: 25,
+      },
+    });
+
+    expect(fixture.deps.streamController.updateUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ contextTokens: 50_000 }),
     );
   });
 

--- a/tests/unit/features/chat/execution/ChatExecutionCoordinator.test.ts
+++ b/tests/unit/features/chat/execution/ChatExecutionCoordinator.test.ts
@@ -718,6 +718,33 @@ describe('ChatExecutionCoordinator', () => {
     await expect(resultPromise).resolves.toMatchObject({ status: 'cancelled' });
   });
 
+  it('blocks rewind while a turn is active so recovery cannot race streaming', async () => {
+    const harness = createHarness();
+    const { session, resultPromise } = await beginExecution(harness);
+    const rewind = jest.spyOn(session, 'rewind');
+
+    await expect(harness.coordinator.previewRewind(
+      'user-1',
+      'assistant-1',
+    )).resolves.toEqual({
+      canRewind: false,
+      error: 'Cannot rewind while a chat execution is active.',
+    });
+    await expect(harness.coordinator.rewind(
+      'user-1',
+      'assistant-1',
+    )).resolves.toEqual({
+      canRewind: false,
+      error: 'Cannot rewind while a chat execution is active.',
+    });
+    expect(rewind).not.toHaveBeenCalled();
+    await expect(harness.coordinator.setMode('plan')).resolves.toBe(false);
+    expect(session.modes).toEqual([]);
+
+    harness.coordinator.cancel();
+    await resultPromise;
+  });
+
   it('stages and accepts steer input only when the current session supports and accepts it', async () => {
     const harness = createHarness();
     const { session, run, resultPromise } = await beginExecution(harness);

--- a/tests/unit/providers/opencode/OpencodeSettingsReconciler.test.ts
+++ b/tests/unit/providers/opencode/OpencodeSettingsReconciler.test.ts
@@ -51,6 +51,7 @@ describe('opencodeSettingsReconciler.handleEnvironmentChange', () => {
     expect(getOpencodeDiscoveryState(settings)).toEqual({
       availableModes: [],
       discoveredModels: [],
+      refreshedAt: 0,
       thinkingOptionsByModel: {},
     });
   });

--- a/tests/unit/providers/opencode/settings.test.ts
+++ b/tests/unit/providers/opencode/settings.test.ts
@@ -264,6 +264,40 @@ describe('OpenCode settings normalization', () => {
     expect((settings.providerConfigs as Record<string, any>).opencode.discoveredModels).toBeUndefined();
   });
 
+  it('preserves the catalog refresh time across reads and persists a refresh with unchanged models', () => {
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        opencode: {
+          catalogTimestamp: 1_000,
+          discoveredModels,
+          visibleModels: ['anthropic/claude-sonnet-4'],
+        },
+      },
+    };
+
+    expect(getOpencodeProviderSettings(settings).catalogTimestamp).toBe(1_000);
+
+    const next = updateOpencodeProviderSettings(settings, {
+      catalogTimestamp: 2_000,
+      discoveredModels,
+    });
+
+    expect(next.catalogTimestamp).toBe(2_000);
+    expect((settings.providerConfigs as Record<string, any>).opencode.catalogTimestamp).toBe(2_000);
+  });
+
+  it('does not treat legacy discovered models as freshly refreshed when no timestamp exists', () => {
+    const settings = {
+      providerConfigs: {
+        opencode: {
+          discoveredModels,
+        },
+      },
+    } as Record<string, unknown>;
+
+    expect(getOpencodeProviderSettings(settings).catalogTimestamp).toBe(0);
+  });
+
   it('persists thinking options only for visible or selected OpenCode models', () => {
     const settings: Record<string, unknown> = {
       model: 'opencode:google/gemini-2.5-pro',

--- a/tests/unit/providers/pi/ui/PiSettingsTab.test.ts
+++ b/tests/unit/providers/pi/ui/PiSettingsTab.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 const mockRenderEnvironmentSettingsSection = jest.fn();
 const mockCliResolverReset = jest.fn();
 const mockDiscoverModels = jest.fn();
+const mockRefreshReadiness = jest.fn().mockResolvedValue(undefined);
 const mockNotices: string[] = [];
 
 jest.mock('@/core/providers/ProviderSettingsCoordinator', () => ({
@@ -124,6 +125,9 @@ jest.mock('obsidian', () => ({
 }));
 jest.mock('@/shared/settings/EnvironmentSettingsSection', () => ({
   renderEnvironmentSettingsSection: (...args: unknown[]) => mockRenderEnvironmentSettingsSection(...args),
+}));
+jest.mock('@/shared/settings/ProviderReadinessPanel', () => ({
+  renderProviderReadinessPanel: jest.fn(() => ({ refresh: mockRefreshReadiness })),
 }));
 jest.mock('@/providers/pi/app/PiWorkspaceServices', () => ({
   maybeGetPiWorkspaceServices: jest.fn(() => ({
@@ -431,6 +435,7 @@ describe('PiSettingsTab', () => {
     await enableSetting.toggleComponents[0].onChangeCallback?.(true);
 
     expect(getPiProviderSettings(settings).enabled).toBe(true);
+    expect(mockRefreshReadiness).toHaveBeenCalled();
     expect(context.plugin.saveSettings).toHaveBeenCalled();
     expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledWith('pi');
   });

--- a/tests/unit/shared/settings/ProviderModelPicker.dom.test.ts
+++ b/tests/unit/shared/settings/ProviderModelPicker.dom.test.ts
@@ -1,0 +1,63 @@
+/** @jest-environment jsdom */
+
+jest.mock('obsidian', () => ({
+  Setting: class MockSetting {
+    settingEl = { addClass(): void {} };
+    setDesc(): this { return this; }
+    setName(): this { return this; }
+  },
+}));
+
+import { renderProviderModelPicker } from '@/shared/settings/ProviderModelPicker';
+
+describe('ProviderModelPicker catalog status', () => {
+  beforeAll(() => {
+    const prototype = HTMLElement.prototype as HTMLElement & {
+      empty(): void;
+      setText(value: string): void;
+      toggleClass(className: string, force: boolean): void;
+    };
+    prototype.empty = function empty(): void {
+      this.replaceChildren();
+    };
+    prototype.setText = function setText(value: string): void {
+      this.textContent = value;
+    };
+    prototype.toggleClass = function toggleClass(className: string, force: boolean): void {
+      this.classList.toggle(className, force);
+    };
+  });
+
+  it('marks the picker as failed when refreshing a cached catalog fails', async () => {
+    const container = document.createElement('div');
+    const picker = renderProviderModelPicker({
+      container,
+      emptyCatalogText: 'empty',
+      failedCatalogText: 'failed',
+      getState: () => ({
+        aliases: {},
+        catalogStatus: 'ready',
+        discoveredCount: 1,
+        models: [{ id: 'model-1', name: 'Model 1' }],
+        selectedIds: ['model-1'],
+      }),
+      loadCatalog: async () => 'failed',
+      loadingCatalogText: 'loading',
+      modifier: 'test',
+      onAliasesChange: async () => {},
+      onSelectedIdsChange: async () => {},
+      providerName: 'Test',
+    });
+
+    const refreshButton = container.querySelector<HTMLButtonElement>(
+      '.claudian-provider-model-picker-action',
+    );
+    refreshButton?.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(container.querySelector('.claudian-provider-model-picker')
+      ?.getAttribute('data-catalog-status')).toBe('failed');
+    picker.refresh();
+  });
+});


### PR DESCRIPTION
## Summary
- unify provider execution outcomes and preserve native message metadata across cancellation/invalidation
- block rewind and mode changes while a chat turn is active
- expose model catalog freshness, cached/failed states, default models, and selection mode across providers
- persist OpenCode catalog refresh timestamps and refresh readiness panels after provider enablement changes

## Verification
- `npm run typecheck`
- `npm run lint -- --no-fix`
- focused provider/core tests: 113 passed
- provider settings tests: 71 passed
- `npm run build`

The full local suite still has two sandbox-only failures involving writing under `/Users/lee/.claudian-*` and binding a local test port.