### PR TITLE
release: prepare 2.1.6

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claudian",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Coding agents embedded in an Obsidian sidebar, including Oh My Pi support",
   "main": "main.js",
   "engines": {


### PR DESCRIPTION
Prepare the 2.1.6 release after merging dual-pane session management in #13.\n\nAfter this PR is merged, create and push tag 2.1.6.