### PR TITLE
release: prepare 2.1.7

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claudian",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Coding agents embedded in an Obsidian sidebar, including Oh My Pi support",
   "main": "main.js",
   "engines": {


### PR DESCRIPTION
Prepare the 2.1.7 release after merging the OMP usage reset fix in #17.\n\nAfter this PR is merged, create and push tag 2.1.7.