### PR TITLE
feat: add first-run chat checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Then enable the plugin in Obsidian under **Settings → Community plugins**.
 
 Open the chat sidebar from the ribbon icon or command palette. Select text and use the inline-edit hotkey to edit notes with a diff preview. Use `/` for commands and skills, `@` to reference vault files or provider resources, and the provider selector to choose Claude, Codex, Grok, OMP, OpenCode, or Pi.
 
+### First run
+
+1. Open **Settings → Oh My Claudian** and choose a provider tab.
+2. Enable the provider, confirm its **Readiness** checks, and select a chat model.
+3. Open the chat view and send your first message. Use the **Open chat** button in the General settings tab whenever you need to return to the chat.
+
 Each provider has a readiness panel in its settings tab. Use it to see whether the provider is enabled, its CLI is available, models have been discovered, and a chat model is selected. The panel refreshes after enablement changes and lets you recheck the current provider state; installation and authentication remain provider-native. Model pickers also show whether the catalog is fresh, cached, or failed to refresh, along with the provider default and current selection mode.
 
 OMP requires its CLI to be installed and logged in separately. In **Settings → Oh My Claudian → OMP**, enable the provider, set the CLI path if it is not detected automatically, and use **Discover** to load available models.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claudian",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Coding agents embedded in an Obsidian sidebar, including Oh My Pi support",
   "main": "main.js",
   "engines": {

--- a/src/features/settings/ClaudianSettings.ts
+++ b/src/features/settings/ClaudianSettings.ts
@@ -25,6 +25,11 @@ import { AgentSkillManagementCoordinator } from './AgentSkillManagementCoordinat
 import { buildNavMappingText, parseNavMappings } from './keyboardNavigation';
 
 type SettingsTabId = string;
+type AppWithCommands = App & {
+  commands?: {
+    executeCommandById: (id: string) => boolean;
+  };
+};
 type ObsidianHotkey = { modifiers: string[]; key: string };
 type ObsidianHotkeyManager = {
   customKeys?: Record<string, ObsidianHotkey[] | undefined>;
@@ -258,6 +263,33 @@ export class ClaudianSettingTab extends PluginSettingTab {
   }
 
   private renderGeneralTab(container: HTMLElement): void {
+    new Setting(container)
+      .setName(t('settings.gettingStarted.title'))
+      .setDesc(t('settings.gettingStarted.desc'))
+      .setHeading();
+
+    container.createDiv({
+      cls: 'claudian-getting-started-steps',
+      text: [
+        t('settings.gettingStarted.stepProvider'),
+        t('settings.gettingStarted.stepReadiness'),
+        t('settings.gettingStarted.stepChat'),
+      ].map((step, index) => `${index + 1}. ${step}`).join('\n'),
+    });
+
+    new Setting(container)
+      .setName(t('settings.gettingStarted.openChat.name'))
+      .setDesc(t('settings.gettingStarted.openChat.desc'))
+      .addButton((button) => {
+        button
+          .setButtonText(t('settings.gettingStarted.openChat.button'))
+          .setCta()
+          .onClick(() => {
+            (this.plugin.app as AppWithCommands).commands
+              ?.executeCommandById('oh-my-claudian:open-view');
+          });
+      });
+
     new Setting(container)
       .setName(t('settings.language.name'))
       .setDesc(t('settings.language.desc'))

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -72,6 +72,18 @@
   },
   "settings": {
     "title": "Oh My Claudian Einstellungen",
+    "gettingStarted": {
+      "title": "Get started",
+      "desc": "Follow these three steps to send your first provider-backed chat.",
+      "stepProvider": "Choose a provider tab and enable a provider.",
+      "stepReadiness": "Use the Readiness panel to confirm the CLI, model catalog, and model selection are ready.",
+      "stepChat": "Open the chat view and send your first message.",
+      "openChat": {
+        "name": "Open chat",
+        "desc": "Open the Claudian chat view whenever you are ready to start.",
+        "button": "Open chat"
+      }
+    },
     "tabs": {
       "general": "Allgemein",
       "claude": "Claude",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -72,6 +72,18 @@
   },
   "settings": {
     "title": "Oh My Claudian Settings",
+    "gettingStarted": {
+      "title": "Get started",
+      "desc": "Follow these three steps to send your first provider-backed chat.",
+      "stepProvider": "Choose a provider tab and enable a provider.",
+      "stepReadiness": "Use the Readiness panel to confirm the CLI, model catalog, and model selection are ready.",
+      "stepChat": "Open the chat view and send your first message.",
+      "openChat": {
+        "name": "Open chat",
+        "desc": "Open the Claudian chat view whenever you are ready to start.",
+        "button": "Open chat"
+      }
+    },
     "tabs": {
       "general": "General",
       "claude": "Claude",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -72,6 +72,18 @@
   },
   "settings": {
     "title": "Configuración de Oh My Claudian",
+    "gettingStarted": {
+      "title": "Get started",
+      "desc": "Follow these three steps to send your first provider-backed chat.",
+      "stepProvider": "Choose a provider tab and enable a provider.",
+      "stepReadiness": "Use the Readiness panel to confirm the CLI, model catalog, and model selection are ready.",
+      "stepChat": "Open the chat view and send your first message.",
+      "openChat": {
+        "name": "Open chat",
+        "desc": "Open the Claudian chat view whenever you are ready to start.",
+        "button": "Open chat"
+      }
+    },
     "tabs": {
       "general": "General",
       "claude": "Claude",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -72,6 +72,18 @@
   },
   "settings": {
     "title": "Paramètres Oh My Claudian",
+    "gettingStarted": {
+      "title": "Get started",
+      "desc": "Follow these three steps to send your first provider-backed chat.",
+      "stepProvider": "Choose a provider tab and enable a provider.",
+      "stepReadiness": "Use the Readiness panel to confirm the CLI, model catalog, and model selection are ready.",
+      "stepChat": "Open the chat view and send your first message.",
+      "openChat": {
+        "name": "Open chat",
+        "desc": "Open the Claudian chat view whenever you are ready to start.",
+        "button": "Open chat"
+      }
+    },
     "tabs": {
       "general": "Général",
       "claude": "Claude",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -72,6 +72,18 @@
   },
   "settings": {
     "title": "Oh My Claudian 設定",
+    "gettingStarted": {
+      "title": "Get started",
+      "desc": "Follow these three steps to send your first provider-backed chat.",
+      "stepProvider": "Choose a provider tab and enable a provider.",
+      "stepReadiness": "Use the Readiness panel to confirm the CLI, model catalog, and model selection are ready.",
+      "stepChat": "Open the chat view and send your first message.",
+      "openChat": {
+        "name": "Open chat",
+        "desc": "Open the Claudian chat view whenever you are ready to start.",
+        "button": "Open chat"
+      }
+    },
     "tabs": {
       "general": "一般",
       "claude": "Claude",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -72,6 +72,18 @@
   },
   "settings": {
     "title": "Oh My Claudian 설정",
+    "gettingStarted": {
+      "title": "Get started",
+      "desc": "Follow these three steps to send your first provider-backed chat.",
+      "stepProvider": "Choose a provider tab and enable a provider.",
+      "stepReadiness": "Use the Readiness panel to confirm the CLI, model catalog, and model selection are ready.",
+      "stepChat": "Open the chat view and send your first message.",
+      "openChat": {
+        "name": "Open chat",
+        "desc": "Open the Claudian chat view whenever you are ready to start.",
+        "button": "Open chat"
+      }
+    },
     "tabs": {
       "general": "일반",
       "claude": "Claude",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -72,6 +72,18 @@
   },
   "settings": {
     "title": "Configurações do Oh My Claudian",
+    "gettingStarted": {
+      "title": "Get started",
+      "desc": "Follow these three steps to send your first provider-backed chat.",
+      "stepProvider": "Choose a provider tab and enable a provider.",
+      "stepReadiness": "Use the Readiness panel to confirm the CLI, model catalog, and model selection are ready.",
+      "stepChat": "Open the chat view and send your first message.",
+      "openChat": {
+        "name": "Open chat",
+        "desc": "Open the Claudian chat view whenever you are ready to start.",
+        "button": "Open chat"
+      }
+    },
     "tabs": {
       "general": "Geral",
       "claude": "Claude",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -72,6 +72,18 @@
   },
   "settings": {
     "title": "Настройки Oh My Claudian",
+    "gettingStarted": {
+      "title": "Get started",
+      "desc": "Follow these three steps to send your first provider-backed chat.",
+      "stepProvider": "Choose a provider tab and enable a provider.",
+      "stepReadiness": "Use the Readiness panel to confirm the CLI, model catalog, and model selection are ready.",
+      "stepChat": "Open the chat view and send your first message.",
+      "openChat": {
+        "name": "Open chat",
+        "desc": "Open the Claudian chat view whenever you are ready to start.",
+        "button": "Open chat"
+      }
+    },
     "tabs": {
       "general": "Общие",
       "claude": "Claude",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -72,6 +72,18 @@
   },
   "settings": {
     "title": "Oh My Claudian 设置",
+    "gettingStarted": {
+      "title": "开始使用",
+      "desc": "按以下三个步骤发送第一条由 Provider 驱动的聊天消息。",
+      "stepProvider": "选择一个 Provider 标签页并启用 Provider。",
+      "stepReadiness": "使用就绪状态面板确认 CLI、模型目录和模型选择均已准备好。",
+      "stepChat": "打开聊天视图并发送第一条消息。",
+      "openChat": {
+        "name": "打开聊天",
+        "desc": "准备好开始时，打开 Claudian 聊天视图。",
+        "button": "打开聊天"
+      }
+    },
     "tabs": {
       "general": "通用",
       "claude": "Claude",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -72,6 +72,18 @@
   },
   "settings": {
     "title": "Oh My Claudian 設定",
+    "gettingStarted": {
+      "title": "開始使用",
+      "desc": "依照以下三個步驟傳送第一則由 Provider 驅動的聊天訊息。",
+      "stepProvider": "選擇一個 Provider 分頁並啟用 Provider。",
+      "stepReadiness": "使用就緒狀態面板確認 CLI、模型目錄和模型選擇都已準備好。",
+      "stepChat": "開啟聊天檢視並傳送第一則訊息。",
+      "openChat": {
+        "name": "開啟聊天",
+        "desc": "準備好開始時，開啟 Claudian 聊天檢視。",
+        "button": "開啟聊天"
+      }
+    },
     "tabs": {
       "general": "一般",
       "claude": "Claude",

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -58,6 +58,7 @@
 @import "./settings/agent-skills.css";
 @import "./settings/provider-model-picker.css";
 @import "./settings/provider-readiness.css";
+@import "./settings/getting-started.css";
 
 /* Accessibility */
 @import "./accessibility.css";

--- a/src/style/settings/getting-started.css
+++ b/src/style/settings/getting-started.css
@@ -1,0 +1,7 @@
+.claudian-getting-started-steps {
+  margin: -4px 12px 18px;
+  color: var(--text-muted);
+  font-size: var(--font-ui-small);
+  line-height: 1.6;
+  white-space: pre-line;
+}

--- a/tests/unit/features/settings/ClaudianSettings.display.test.ts
+++ b/tests/unit/features/settings/ClaudianSettings.display.test.ts
@@ -58,6 +58,11 @@ jest.mock('obsidian', () => {
       callback(createChainableComponent());
       return this;
     }
+
+    addButton(callback: (button: MockChainableComponent) => void): this {
+      callback(createChainableComponent());
+      return this;
+    }
   }
 
   function createChainableComponent(): MockChainableComponent {
@@ -69,6 +74,9 @@ jest.mock('obsidian', () => {
       'setPlaceholder',
       'setLimits',
       'setDynamicTooltip',
+      'setButtonText',
+      'setCta',
+      'onClick',
     ]) {
       component[method] = jest.fn(() => component);
     }
@@ -162,6 +170,15 @@ describe('ClaudianSettingTab display settings', () => {
     (disabled.tab as any).renderGeneralTab(createContainer());
 
     expect(mockRenderedSettingNames).not.toContain(t('settings.dualPaneSide.name'));
+  });
+
+  it('renders a first-run getting started checklist with an open-chat action', () => {
+    const { tab } = createTab(true);
+
+    (tab as any).renderGeneralTab(createContainer());
+
+    expect(mockRenderedSettingNames).toContain(t('settings.gettingStarted.title'));
+    expect(mockRenderedSettingNames).toContain(t('settings.gettingStarted.openChat.name'));
   });
 
   it('rerenders display settings after dual-pane mode changes', async () => {


### PR DESCRIPTION
## Summary

- Add a three-step getting-started checklist to the General settings tab.
- Add an Open chat action for returning to the Claudian chat view.
- Document the first-run workflow in README.md.
- Keep all locale files structurally aligned with translated onboarding copy.

## Verification

- `npm run typecheck`
- `npm run lint`
- Focused settings and locale tests
- `npm run build`

The full test suite still has sandbox-dependent failures for local port binding and user-directory temp-file creation; the affected tests are unrelated to this change.
