### PR TITLE
fix: prefer runtime PATH for Codex CLI

### DIFF
--- a/src/providers/codex/runtime/CodexBinaryLocator.ts
+++ b/src/providers/codex/runtime/CodexBinaryLocator.ts
@@ -39,6 +39,27 @@ export function findCodexBinaryPath(
     return preferredBinary;
   }
 
+  // Respect the runtime PATH before falling back to legacy user-local
+  // locations. Obsidian may inherit a newer Node/fnm Codex earlier on PATH,
+  // while ~/.local/bin still contains an older installation.
+  if (platform === process.platform) {
+    const runtimePathBinary = findCodexBinaryInDirs(
+      parsePathEntriesForPlatform(process.env.PATH, platform),
+      platform,
+    );
+    if (runtimePathBinary) {
+      return runtimePathBinary;
+    }
+  }
+
+  const userLocalBinary = findCodexBinaryInDirs(
+    getUserLocalCodexBinaryDirs(platform),
+    platform,
+  );
+  if (userLocalBinary) {
+    return userLocalBinary;
+  }
+
   return findCliBinaryPath('codex', additionalPath, platform);
 }
 
@@ -74,17 +95,18 @@ function getPreferredCodexBinaryDirs(platform: NodeJS.Platform): string[] {
       '/Applications/Codex.app/Contents/Resources',
       path.join(home, 'Applications', 'Codex.app', 'Contents', 'MacOS'),
       '/Applications/Codex.app/Contents/MacOS',
-      path.join(home, '.local', 'bin'),
-    ];
-  }
-
-  if (platform !== 'win32') {
-    return [
-      path.join(home, '.local', 'bin'),
     ];
   }
 
   return [];
+}
+
+function getUserLocalCodexBinaryDirs(platform: NodeJS.Platform): string[] {
+  if (platform === 'win32') {
+    return [];
+  }
+
+  return [path.join(getHomeDir(), '.local', 'bin')];
 }
 
 function getHomeDir(): string {

--- a/tests/unit/providers/codex/runtime/CodexBinaryLocator.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexBinaryLocator.test.ts
@@ -10,6 +10,7 @@ import {
 describe('CodexBinaryLocator', () => {
   let tempDir: string;
   const originalHome = process.env.HOME;
+  const originalPath = process.env.PATH;
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-binary-locator-'));
@@ -21,6 +22,11 @@ describe('CodexBinaryLocator', () => {
       delete process.env.HOME;
     } else {
       process.env.HOME = originalHome;
+    }
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
     }
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
@@ -66,14 +72,19 @@ describe('CodexBinaryLocator', () => {
     expect(findCodexBinaryPath(explicitDir, 'darwin')).toBe(explicitBinary);
   });
 
-  it('prefers a user-local Codex binary before generic Unix PATH auto-detection', () => {
+  it('prefers the current process PATH before a user-local Codex binary', () => {
     process.env.HOME = tempDir;
+    const pathDir = path.join(tempDir, 'runtime-bin');
+    const pathBinary = path.join(pathDir, 'codex');
     const localDir = path.join(tempDir, '.local', 'bin');
     const localBinary = path.join(localDir, 'codex');
+    fs.mkdirSync(pathDir, { recursive: true });
     fs.mkdirSync(localDir, { recursive: true });
+    fs.writeFileSync(pathBinary, '');
     fs.writeFileSync(localBinary, '');
+    process.env.PATH = pathDir;
 
-    expect(findCodexBinaryPath('', 'linux')).toBe(localBinary);
+    expect(findCodexBinaryPath('', 'darwin')).toBe(pathBinary);
   });
 
   it('prefers a hostname-specific configured path', () => {

--- a/tests/unit/providers/codex/runtime/CodexBinaryLocator.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexBinaryLocator.test.ts
@@ -84,7 +84,7 @@ describe('CodexBinaryLocator', () => {
     fs.writeFileSync(localBinary, '');
     process.env.PATH = pathDir;
 
-    expect(findCodexBinaryPath('', 'darwin')).toBe(pathBinary);
+    expect(findCodexBinaryPath('', process.platform)).toBe(pathBinary);
   });
 
   it('prefers a hostname-specific configured path', () => {


### PR DESCRIPTION
## Summary

- Prefer the current runtime PATH when resolving Codex without an explicit CLI path.
- Keep macOS Codex.app locations ahead of PATH and retain `~/.local/bin` as a fallback.
- Prevent Obsidian from selecting an older user-local Codex installation when a newer fnm/runtime installation is active.

## Root cause

The resolver searched `~/.local/bin` before the process PATH. In this environment that selected Codex CLI 0.142.5, while the active PATH contained 0.145.0 with GPT-5.6 models.

## Verification

- Codex unit tests: 36 suites, 619 tests passed
- `npm run typecheck`
- `npm run lint`
