### PR TITLE
feat: add provider capability matrix

### DIFF
--- a/src/features/settings/ClaudianSettings.ts
+++ b/src/features/settings/ClaudianSettings.ts
@@ -8,7 +8,7 @@ import {
 import { ProviderRegistry } from '../../core/providers/ProviderRegistry';
 import { ProviderSettingsCoordinator } from '../../core/providers/ProviderSettingsCoordinator';
 import { ProviderWorkspaceRegistry } from '../../core/providers/ProviderWorkspaceRegistry';
-import type { ProviderId } from '../../core/providers/types';
+import type { ProviderCapabilities, ProviderId } from '../../core/providers/types';
 import { AgentSkillRepository } from '../../core/skills/AgentSkillRepository';
 import type { ChatViewPlacement, DualPaneSide } from '../../core/types/settings';
 import { getAvailableLocales, getLocaleDisplayName, setLocale, t } from '../../i18n/i18n';
@@ -25,6 +25,29 @@ import { AgentSkillManagementCoordinator } from './AgentSkillManagementCoordinat
 import { buildNavMappingText, parseNavMappings } from './keyboardNavigation';
 
 type SettingsTabId = string;
+type CapabilityMatrixKey = keyof Pick<
+  ProviderCapabilities,
+  | 'supportsPlanMode'
+  | 'supportsRewind'
+  | 'supportsFork'
+  | 'supportsProviderCommands'
+  | 'supportsImageAttachments'
+  | 'supportsMcpTools'
+  | 'supportsTurnSteer'
+>;
+
+const PROVIDER_CAPABILITY_ROWS: ReadonlyArray<{
+  key: CapabilityMatrixKey;
+  label: TranslationKey;
+}> = [
+  { key: 'supportsPlanMode', label: 'settings.capabilityMatrix.rows.planMode' },
+  { key: 'supportsRewind', label: 'settings.capabilityMatrix.rows.rewind' },
+  { key: 'supportsFork', label: 'settings.capabilityMatrix.rows.fork' },
+  { key: 'supportsProviderCommands', label: 'settings.capabilityMatrix.rows.providerCommands' },
+  { key: 'supportsImageAttachments', label: 'settings.capabilityMatrix.rows.imageAttachments' },
+  { key: 'supportsMcpTools', label: 'settings.capabilityMatrix.rows.mcpTools' },
+  { key: 'supportsTurnSteer', label: 'settings.capabilityMatrix.rows.turnSteer' },
+];
 type AppWithCommands = App & {
   commands?: {
     executeCommandById: (id: string) => boolean;
@@ -264,6 +287,29 @@ export class ClaudianSettingTab extends PluginSettingTab {
 
   private renderGeneralTab(container: HTMLElement): void {
     new Setting(container)
+      .setName(t('settings.language.name'))
+      .setDesc(t('settings.language.desc'))
+      .addDropdown((dropdown) => {
+        const locales = getAvailableLocales();
+        for (const locale of locales) {
+          dropdown.addOption(locale, getLocaleDisplayName(locale));
+        }
+        dropdown
+          .setValue(this.plugin.settings.locale)
+          .onChange(async (value) => {
+            const locale = value as Locale;
+            if (!setLocale(locale)) {
+              dropdown.setValue(this.plugin.settings.locale);
+              return;
+            }
+            await this.plugin.mutateSettings((settings) => {
+              settings.locale = locale;
+            });
+            this.display();
+          });
+      });
+
+    new Setting(container)
       .setName(t('settings.gettingStarted.title'))
       .setDesc(t('settings.gettingStarted.desc'))
       .setHeading();
@@ -287,31 +333,10 @@ export class ClaudianSettingTab extends PluginSettingTab {
           .onClick(() => {
             (this.plugin.app as AppWithCommands).commands
               ?.executeCommandById('oh-my-claudian:open-view');
-          });
-      });
+         });
+       });
 
-    new Setting(container)
-      .setName(t('settings.language.name'))
-      .setDesc(t('settings.language.desc'))
-      .addDropdown((dropdown) => {
-        const locales = getAvailableLocales();
-        for (const locale of locales) {
-          dropdown.addOption(locale, getLocaleDisplayName(locale));
-        }
-        dropdown
-          .setValue(this.plugin.settings.locale)
-          .onChange(async (value) => {
-            const locale = value as Locale;
-            if (!setLocale(locale)) {
-              dropdown.setValue(this.plugin.settings.locale);
-              return;
-            }
-            await this.plugin.mutateSettings((settings) => {
-              settings.locale = locale;
-            });
-            this.display();
-          });
-      });
+    this.renderProviderCapabilityMatrix(container);
 
     // --- Display ---
 
@@ -670,6 +695,36 @@ export class ClaudianSettingTab extends PluginSettingTab {
             }
           });
       });
+  }
+
+  private renderProviderCapabilityMatrix(container: HTMLElement): void {
+    new Setting(container)
+      .setName(t('settings.capabilityMatrix.title'))
+      .setDesc(t('settings.capabilityMatrix.desc'))
+      .setHeading();
+
+    const matrix = container.createDiv({ cls: 'claudian-provider-capability-matrix' });
+    const table = matrix.createEl('table');
+    const headRow = table.createEl('thead').createEl('tr');
+    headRow.createEl('th', { text: t('settings.capabilityMatrix.provider') });
+    for (const row of PROVIDER_CAPABILITY_ROWS) {
+      headRow.createEl('th', { text: t(row.label) });
+    }
+
+    const body = table.createEl('tbody');
+    for (const providerId of ProviderRegistry.getRegisteredProviderIds()) {
+      const bodyRow = body.createEl('tr');
+      bodyRow.createEl('th', { text: ProviderRegistry.getProviderDisplayName(providerId) });
+      const capabilities = ProviderRegistry.getCapabilities(providerId);
+      for (const row of PROVIDER_CAPABILITY_ROWS) {
+        bodyRow.createEl('td', {
+          cls: capabilities[row.key] ? 'claudian-capability-supported' : 'claudian-capability-unsupported',
+          text: capabilities[row.key]
+            ? t('settings.capabilityMatrix.supported')
+            : t('settings.capabilityMatrix.unsupported'),
+        });
+      }
+    }
   }
 
   private notifyProviderModelOptionsChanged(providerId: ProviderId): void {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -84,6 +84,22 @@
         "button": "Open chat"
       }
     },
+    "capabilityMatrix": {
+      "title": "Provider capabilities",
+      "desc": "Compare the provider features available in Claudian. This is informational; provider-native behavior remains unchanged.",
+      "provider": "Provider",
+      "supported": "Yes",
+      "unsupported": "—",
+      "rows": {
+        "planMode": "Plan mode",
+        "rewind": "Rewind",
+        "fork": "Fork",
+        "providerCommands": "Provider commands",
+        "imageAttachments": "Image attachments",
+        "mcpTools": "MCP tools",
+        "turnSteer": "Turn steering"
+      }
+    },
     "tabs": {
       "general": "Allgemein",
       "claude": "Claude",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -85,8 +85,8 @@
       }
     },
     "capabilityMatrix": {
-      "title": "Provider capabilities",
-      "desc": "Compare the provider features available in Claudian. This is informational; provider-native behavior remains unchanged.",
+      "title": "Claudian integration capabilities",
+      "desc": "Compare the capabilities currently integrated by Claudian. This is not a complete list of each provider's native features.",
       "provider": "Provider",
       "supported": "Yes",
       "unsupported": "—",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -85,8 +85,8 @@
       }
     },
     "capabilityMatrix": {
-      "title": "Provider capabilities",
-      "desc": "Compare the provider features available in Claudian. This is informational; provider-native behavior remains unchanged.",
+      "title": "Claudian integration capabilities",
+      "desc": "Compare the capabilities currently integrated by Claudian. This is not a complete list of each provider's native features.",
       "provider": "Provider",
       "supported": "Yes",
       "unsupported": "—",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -84,6 +84,22 @@
         "button": "Open chat"
       }
     },
+    "capabilityMatrix": {
+      "title": "Provider capabilities",
+      "desc": "Compare the provider features available in Claudian. This is informational; provider-native behavior remains unchanged.",
+      "provider": "Provider",
+      "supported": "Yes",
+      "unsupported": "—",
+      "rows": {
+        "planMode": "Plan mode",
+        "rewind": "Rewind",
+        "fork": "Fork",
+        "providerCommands": "Provider commands",
+        "imageAttachments": "Image attachments",
+        "mcpTools": "MCP tools",
+        "turnSteer": "Turn steering"
+      }
+    },
     "tabs": {
       "general": "General",
       "claude": "Claude",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -85,8 +85,8 @@
       }
     },
     "capabilityMatrix": {
-      "title": "Provider capabilities",
-      "desc": "Compare the provider features available in Claudian. This is informational; provider-native behavior remains unchanged.",
+      "title": "Claudian integration capabilities",
+      "desc": "Compare the capabilities currently integrated by Claudian. This is not a complete list of each provider's native features.",
       "provider": "Provider",
       "supported": "Yes",
       "unsupported": "—",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -84,6 +84,22 @@
         "button": "Open chat"
       }
     },
+    "capabilityMatrix": {
+      "title": "Provider capabilities",
+      "desc": "Compare the provider features available in Claudian. This is informational; provider-native behavior remains unchanged.",
+      "provider": "Provider",
+      "supported": "Yes",
+      "unsupported": "—",
+      "rows": {
+        "planMode": "Plan mode",
+        "rewind": "Rewind",
+        "fork": "Fork",
+        "providerCommands": "Provider commands",
+        "imageAttachments": "Image attachments",
+        "mcpTools": "MCP tools",
+        "turnSteer": "Turn steering"
+      }
+    },
     "tabs": {
       "general": "General",
       "claude": "Claude",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -84,6 +84,22 @@
         "button": "Open chat"
       }
     },
+    "capabilityMatrix": {
+      "title": "Provider capabilities",
+      "desc": "Compare the provider features available in Claudian. This is informational; provider-native behavior remains unchanged.",
+      "provider": "Provider",
+      "supported": "Yes",
+      "unsupported": "—",
+      "rows": {
+        "planMode": "Plan mode",
+        "rewind": "Rewind",
+        "fork": "Fork",
+        "providerCommands": "Provider commands",
+        "imageAttachments": "Image attachments",
+        "mcpTools": "MCP tools",
+        "turnSteer": "Turn steering"
+      }
+    },
     "tabs": {
       "general": "Général",
       "claude": "Claude",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -85,8 +85,8 @@
       }
     },
     "capabilityMatrix": {
-      "title": "Provider capabilities",
-      "desc": "Compare the provider features available in Claudian. This is informational; provider-native behavior remains unchanged.",
+      "title": "Claudian integration capabilities",
+      "desc": "Compare the capabilities currently integrated by Claudian. This is not a complete list of each provider's native features.",
       "provider": "Provider",
       "supported": "Yes",
       "unsupported": "—",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -84,6 +84,22 @@
         "button": "Open chat"
       }
     },
+    "capabilityMatrix": {
+      "title": "Provider capabilities",
+      "desc": "Compare the provider features available in Claudian. This is informational; provider-native behavior remains unchanged.",
+      "provider": "Provider",
+      "supported": "Yes",
+      "unsupported": "—",
+      "rows": {
+        "planMode": "Plan mode",
+        "rewind": "Rewind",
+        "fork": "Fork",
+        "providerCommands": "Provider commands",
+        "imageAttachments": "Image attachments",
+        "mcpTools": "MCP tools",
+        "turnSteer": "Turn steering"
+      }
+    },
     "tabs": {
       "general": "一般",
       "claude": "Claude",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -85,8 +85,8 @@
       }
     },
     "capabilityMatrix": {
-      "title": "Provider capabilities",
-      "desc": "Compare the provider features available in Claudian. This is informational; provider-native behavior remains unchanged.",
+      "title": "Claudian integration capabilities",
+      "desc": "Compare the capabilities currently integrated by Claudian. This is not a complete list of each provider's native features.",
       "provider": "Provider",
       "supported": "Yes",
       "unsupported": "—",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -85,8 +85,8 @@
       }
     },
     "capabilityMatrix": {
-      "title": "Provider capabilities",
-      "desc": "Compare the provider features available in Claudian. This is informational; provider-native behavior remains unchanged.",
+      "title": "Claudian integration capabilities",
+      "desc": "Compare the capabilities currently integrated by Claudian. This is not a complete list of each provider's native features.",
       "provider": "Provider",
       "supported": "Yes",
       "unsupported": "—",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -84,6 +84,22 @@
         "button": "Open chat"
       }
     },
+    "capabilityMatrix": {
+      "title": "Provider capabilities",
+      "desc": "Compare the provider features available in Claudian. This is informational; provider-native behavior remains unchanged.",
+      "provider": "Provider",
+      "supported": "Yes",
+      "unsupported": "—",
+      "rows": {
+        "planMode": "Plan mode",
+        "rewind": "Rewind",
+        "fork": "Fork",
+        "providerCommands": "Provider commands",
+        "imageAttachments": "Image attachments",
+        "mcpTools": "MCP tools",
+        "turnSteer": "Turn steering"
+      }
+    },
     "tabs": {
       "general": "일반",
       "claude": "Claude",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -85,8 +85,8 @@
       }
     },
     "capabilityMatrix": {
-      "title": "Provider capabilities",
-      "desc": "Compare the provider features available in Claudian. This is informational; provider-native behavior remains unchanged.",
+      "title": "Claudian integration capabilities",
+      "desc": "Compare the capabilities currently integrated by Claudian. This is not a complete list of each provider's native features.",
       "provider": "Provider",
       "supported": "Yes",
       "unsupported": "—",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -84,6 +84,22 @@
         "button": "Open chat"
       }
     },
+    "capabilityMatrix": {
+      "title": "Provider capabilities",
+      "desc": "Compare the provider features available in Claudian. This is informational; provider-native behavior remains unchanged.",
+      "provider": "Provider",
+      "supported": "Yes",
+      "unsupported": "—",
+      "rows": {
+        "planMode": "Plan mode",
+        "rewind": "Rewind",
+        "fork": "Fork",
+        "providerCommands": "Provider commands",
+        "imageAttachments": "Image attachments",
+        "mcpTools": "MCP tools",
+        "turnSteer": "Turn steering"
+      }
+    },
     "tabs": {
       "general": "Geral",
       "claude": "Claude",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -84,6 +84,22 @@
         "button": "Open chat"
       }
     },
+    "capabilityMatrix": {
+      "title": "Provider capabilities",
+      "desc": "Compare the provider features available in Claudian. This is informational; provider-native behavior remains unchanged.",
+      "provider": "Provider",
+      "supported": "Yes",
+      "unsupported": "—",
+      "rows": {
+        "planMode": "Plan mode",
+        "rewind": "Rewind",
+        "fork": "Fork",
+        "providerCommands": "Provider commands",
+        "imageAttachments": "Image attachments",
+        "mcpTools": "MCP tools",
+        "turnSteer": "Turn steering"
+      }
+    },
     "tabs": {
       "general": "Общие",
       "claude": "Claude",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -85,8 +85,8 @@
       }
     },
     "capabilityMatrix": {
-      "title": "Provider capabilities",
-      "desc": "Compare the provider features available in Claudian. This is informational; provider-native behavior remains unchanged.",
+      "title": "Claudian integration capabilities",
+      "desc": "Compare the capabilities currently integrated by Claudian. This is not a complete list of each provider's native features.",
       "provider": "Provider",
       "supported": "Yes",
       "unsupported": "—",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -84,6 +84,22 @@
         "button": "打开聊天"
       }
     },
+    "capabilityMatrix": {
+      "title": "Provider 能力",
+      "desc": "对比 Claudian 中各 Provider 可用的功能。此处仅供参考，不会改变 Provider 原生行为。",
+      "provider": "Provider",
+      "supported": "支持",
+      "unsupported": "—",
+      "rows": {
+        "planMode": "计划模式",
+        "rewind": "回退",
+        "fork": "分叉会话",
+        "providerCommands": "Provider 命令",
+        "imageAttachments": "图片附件",
+        "mcpTools": "MCP 工具",
+        "turnSteer": "回合控制"
+      }
+    },
     "tabs": {
       "general": "通用",
       "claude": "Claude",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -85,8 +85,8 @@
       }
     },
     "capabilityMatrix": {
-      "title": "Provider 能力",
-      "desc": "对比 Claudian 中各 Provider 可用的功能。此处仅供参考，不会改变 Provider 原生行为。",
+      "title": "Claudian 接入能力",
+      "desc": "对比 Claudian 当前接入的能力。此处不是各 Provider 原生功能的完整清单。",
       "provider": "Provider",
       "supported": "支持",
       "unsupported": "—",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -84,6 +84,22 @@
         "button": "開啟聊天"
       }
     },
+    "capabilityMatrix": {
+      "title": "Provider 能力",
+      "desc": "比較 Claudian 中各 Provider 可用的功能。此處僅供參考，不會改變 Provider 原生行為。",
+      "provider": "Provider",
+      "supported": "支援",
+      "unsupported": "—",
+      "rows": {
+        "planMode": "計劃模式",
+        "rewind": "回退",
+        "fork": "分叉工作階段",
+        "providerCommands": "Provider 指令",
+        "imageAttachments": "圖片附件",
+        "mcpTools": "MCP 工具",
+        "turnSteer": "回合控制"
+      }
+    },
     "tabs": {
       "general": "一般",
       "claude": "Claude",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -85,8 +85,8 @@
       }
     },
     "capabilityMatrix": {
-      "title": "Provider 能力",
-      "desc": "比較 Claudian 中各 Provider 可用的功能。此處僅供參考，不會改變 Provider 原生行為。",
+      "title": "Claudian 接入能力",
+      "desc": "比較 Claudian 目前接入的能力。此處不是各 Provider 原生功能的完整清單。",
       "provider": "Provider",
       "supported": "支援",
       "unsupported": "—",

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -59,6 +59,7 @@
 @import "./settings/provider-model-picker.css";
 @import "./settings/provider-readiness.css";
 @import "./settings/getting-started.css";
+@import "./settings/provider-capability-matrix.css";
 
 /* Accessibility */
 @import "./accessibility.css";

--- a/src/style/settings/provider-capability-matrix.css
+++ b/src/style/settings/provider-capability-matrix.css
@@ -1,0 +1,40 @@
+.claudian-provider-capability-matrix {
+  margin: -4px 12px 20px;
+  overflow-x: auto;
+}
+
+.claudian-provider-capability-matrix table {
+  border-collapse: collapse;
+  font-size: var(--font-ui-small);
+  min-width: 100%;
+  white-space: nowrap;
+}
+
+.claudian-provider-capability-matrix th,
+.claudian-provider-capability-matrix td {
+  border-bottom: 1px solid var(--background-modifier-border);
+  padding: 6px 8px;
+  text-align: center;
+}
+
+.claudian-provider-capability-matrix th:first-child,
+.claudian-provider-capability-matrix td:first-child {
+  text-align: left;
+}
+
+.claudian-provider-capability-matrix th {
+  color: var(--text-muted);
+  font-weight: var(--font-medium);
+}
+
+.claudian-provider-capability-matrix td {
+  font-weight: var(--font-semibold);
+}
+
+.claudian-provider-capability-matrix .claudian-capability-supported {
+  color: var(--text-success);
+}
+
+.claudian-provider-capability-matrix .claudian-capability-unsupported {
+  color: var(--text-faint);
+}

--- a/tests/unit/features/settings/ClaudianSettings.display.test.ts
+++ b/tests/unit/features/settings/ClaudianSettings.display.test.ts
@@ -141,7 +141,7 @@ function createTab(enableDualPane: boolean): {
 function createContainer(): Record<string, jest.Mock> {
   const element: Record<string, jest.Mock> = {
     createSpan: jest.fn(() => ({})),
-    createEl: jest.fn(() => ({ addEventListener: jest.fn() })),
+    createEl: jest.fn(() => createContainer()),
     addEventListener: jest.fn(),
     addClass: jest.fn(),
     removeClass: jest.fn(),
@@ -179,6 +179,23 @@ describe('ClaudianSettingTab display settings', () => {
 
     expect(mockRenderedSettingNames).toContain(t('settings.gettingStarted.title'));
     expect(mockRenderedSettingNames).toContain(t('settings.gettingStarted.openChat.name'));
+  });
+
+  it('renders the provider capability matrix in the general settings tab', () => {
+    const { tab } = createTab(true);
+
+    (tab as any).renderGeneralTab(createContainer());
+
+    expect(mockRenderedSettingNames).toContain(t('settings.capabilityMatrix.title'));
+  });
+
+  it('renders language settings before onboarding content', () => {
+    const { tab } = createTab(true);
+
+    (tab as any).renderGeneralTab(createContainer());
+
+    expect(mockRenderedSettingNames.indexOf(t('settings.language.name')))
+      .toBeLessThan(mockRenderedSettingNames.indexOf(t('settings.gettingStarted.title')));
   });
 
   it('rerenders display settings after dual-pane mode changes', async () => {


### PR DESCRIPTION
## Summary

- Add the remaining first-run workflow improvements that were not included in PR #19.
- Move the language selector before onboarding content in General settings.
- Add a read-only Claudian integration capability matrix for registered providers.
- Clarify that the matrix describes Claudian integration, not each provider's complete native feature set.
- Keep locale files structurally aligned.

## Context

PR #19 merged the initial getting-started checklist. This PR adds the later commits that were made on the old feature branch but did not reach `main`.

## Verification

- Focused settings and locale tests
- `npm run typecheck`
- `npm run lint`
