### PR TITLE
release: prepare 2.1.8

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claudian",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "Coding agents embedded in an Obsidian sidebar, including Oh My Pi support",
   "main": "main.js",
   "engines": {


### PR DESCRIPTION
## Summary

- Bump the Obsidian plugin and package versions from 2.1.7 to 2.1.8.
- Prepare the release metadata for the already merged 2.1.8 changes from PRs #19–#21: first-run chat guidance, provider capability visibility, and Codex CLI resolution.

## Validation

- `git diff --check`
- Full CI runs on this PR.