### PR TITLE
fix: recover Codex completions and warn on hidden commands

### DIFF
--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -62,6 +62,10 @@ import {
   providerOutputEventToStreamChunk,
   type StreamController,
 } from './StreamController';
+import {
+  hasSuspiciousCommandText,
+  SUSPICIOUS_COMMAND_WARNING,
+} from './suspiciousCommandText';
 import type { ActiveTurnOwner } from './TurnCoordinator';
 import { TurnCoordinator } from './TurnCoordinator';
 
@@ -1828,7 +1832,7 @@ export class InputController {
 
   async handleApprovalRequest(
     toolName: string,
-    _input: Record<string, unknown>,
+    approvalInput: Record<string, unknown>,
     description: string,
     approvalOptions?: ApprovalCallbackOptions,
   ): Promise<ApprovalDecision> {
@@ -1856,6 +1860,16 @@ export class InputController {
     }
     if (approvalOptions?.agentID) {
       headerEl.createDiv({ text: `Agent: ${approvalOptions.agentID}`, cls: 'claudian-ask-approval-agent' });
+    }
+
+    const command = typeof approvalInput.command === 'string'
+      ? approvalInput.command
+      : description;
+    if (hasSuspiciousCommandText(command)) {
+      headerEl.createDiv({
+        text: SUSPICIOUS_COMMAND_WARNING,
+        cls: 'claudian-ask-approval-warning',
+      });
     }
 
     headerEl.createDiv({ text: description, cls: 'claudian-ask-approval-desc' });

--- a/src/features/chat/controllers/suspiciousCommandText.ts
+++ b/src/features/chat/controllers/suspiciousCommandText.ts
@@ -1,0 +1,32 @@
+/**
+ * Detects invisible, control, and bidirectional-spoofing characters in a
+ * command string so the approval UI can warn before the user approves.
+ *
+ * This is a display safeguard only. It never parses shell syntax or changes
+ * what gets executed.
+ */
+export const SUSPICIOUS_COMMAND_WARNING =
+  'This command contains invisible or bidirectional control characters. Review the command carefully.';
+
+export function hasSuspiciousCommandText(text: string): boolean {
+  return Array.from(text).some(isSuspiciousCommandCharacter);
+}
+
+export function isSuspiciousCommandCharacter(character: string): boolean {
+  const codePoint = character.codePointAt(0);
+  if (codePoint === undefined) return false;
+
+  return (
+    codePoint <= 0x08
+    || codePoint === 0x0b
+    || codePoint === 0x0c
+    || (codePoint >= 0x0e && codePoint <= 0x1f)
+    || (codePoint >= 0x7f && codePoint <= 0x9f)
+    || codePoint === 0x061c
+    || (codePoint >= 0x200b && codePoint <= 0x200f)
+    || (codePoint >= 0x202a && codePoint <= 0x202e)
+    || codePoint === 0x2060
+    || (codePoint >= 0x2066 && codePoint <= 0x2069)
+    || codePoint === 0xfeff
+  );
+}

--- a/src/providers/codex/execution/CodexExecutionSession.ts
+++ b/src/providers/codex/execution/CodexExecutionSession.ts
@@ -56,9 +56,11 @@ import type {
   ServerRequestResolvedNotification,
   ThreadCompactStartResult,
   ThreadForkResult,
+  ThreadReadResult,
   ThreadResumeResult,
   ThreadRollbackResult,
   ThreadStartResult,
+  ThreadStatusChangedNotification,
   TurnCompletedNotification,
   TurnStartedNotification,
   TurnStartResult,
@@ -99,6 +101,8 @@ const PASSIVE_INSTRUCTIONS =
 const LEGACY_WORKSPACE_DEPENDENCY_INSTRUCTIONS =
   'This thread predates Claudian client-hosted workspace dependency tools. Do not emulate load_workspace_dependencies or install replacement dependencies.';
 const CODEX_SUPPORTS_EXACT_BUILT_IN_TOOL_ALLOW_LIST = false;
+const MISSED_TURN_COMPLETION_GRACE_MS = 1_000;
+const THREAD_READ_RECOVERY_TIMEOUT_MS = 5_000;
 const CODEX_CONSUMED_FORK_STATE_KEYS = [
   'forkSource',
   'forkSourceSessionFilePath',
@@ -279,6 +283,7 @@ export class CodexExecutionSession
   private forkIdentityPromise: Promise<CodexPendingForkTarget> | null = null;
   private forkSetupPromise: Promise<CodexEnsuredThread> | null = null;
   private disposePromise: Promise<void> | null = null;
+  private completionRecoveryTimer: number | null = null;
   private disposed = false;
   private lifecycleGeneration = 0;
 
@@ -748,6 +753,16 @@ export class CodexExecutionSession
       this.observeNativeTurn(started.threadId, started.turn.id);
       return;
     }
+    if (method === 'thread/status/changed') {
+      const changed = params as ThreadStatusChangedNotification;
+      if (changed.threadId !== run.nativeThreadId) return;
+      if (changed.status.type === 'idle') {
+        this.scheduleMissedTurnCompletionRecovery(run);
+      } else {
+        this.cancelMissedTurnCompletionRecovery();
+      }
+      return;
+    }
 
     const scope = extractNotificationScope(method, params);
     if (scope) {
@@ -764,6 +779,7 @@ export class CodexExecutionSession
     }
 
     if (method === 'turn/completed') {
+      this.cancelMissedTurnCompletionRecovery();
       const completed = params as TurnCompletedNotification;
       run.completion = {
         status: completed.turn.status === 'inProgress'
@@ -776,6 +792,69 @@ export class CodexExecutionSession
       };
     }
     this.notificationRouter?.handleNotification(method, params);
+  }
+
+  private scheduleMissedTurnCompletionRecovery(run: CodexExecutionRun): void {
+    if (
+      this.completionRecoveryTimer
+      || !run.nativeThreadId
+      || !run.nativeTurnId
+    ) {
+      return;
+    }
+    const generation = this.lifecycleGeneration;
+    this.completionRecoveryTimer = window.setTimeout(() => {
+      this.completionRecoveryTimer = null;
+      void this.recoverMissedTurnCompletion(run, generation);
+    }, MISSED_TURN_COMPLETION_GRACE_MS);
+  }
+
+  private cancelMissedTurnCompletionRecovery(): void {
+    if (this.completionRecoveryTimer === null) return;
+    window.clearTimeout(this.completionRecoveryTimer);
+    this.completionRecoveryTimer = null;
+  }
+
+  private async recoverMissedTurnCompletion(
+    run: CodexExecutionRun,
+    generation: number,
+  ): Promise<void> {
+    const transport = this.transport;
+    const threadId = run.nativeThreadId;
+    const turnId = run.nativeTurnId;
+    if (
+      !transport
+      || !threadId
+      || !turnId
+      || this.activeRun !== run
+      || run.isTerminal
+      || run.isCancellationRequested
+      || generation !== this.lifecycleGeneration
+    ) {
+      return;
+    }
+
+    let result: ThreadReadResult;
+    try {
+      result = await transport.request<ThreadReadResult>(
+        'thread/read',
+        { threadId, includeTurns: true },
+        THREAD_READ_RECOVERY_TIMEOUT_MS,
+      );
+    } catch {
+      return;
+    }
+    if (
+      this.activeRun !== run
+      || run.isTerminal
+      || run.isCancellationRequested
+      || generation !== this.lifecycleGeneration
+    ) {
+      return;
+    }
+    const turn = result.thread.turns.find(candidate => candidate.id === turnId);
+    if (!turn || turn.status === 'inProgress') return;
+    this.handleNotification('turn/completed', { threadId, turn });
   }
 
   private observeNativeTurn(threadId: string, nativeTurnId: string): boolean {
@@ -1201,6 +1280,7 @@ export class CodexExecutionSession
 
   private cancelRun(run: CodexExecutionRun): void {
     if (this.activeRun !== run || run.isTerminal) return;
+    this.cancelMissedTurnCompletionRecovery();
     this.lifecycleGeneration += 1;
     this.serverRequestRouter.abortAll('cancelled');
     const transport = this.transport;
@@ -1288,6 +1368,7 @@ export class CodexExecutionSession
   }
 
   private releaseRun(run: CodexExecutionRun): void {
+    this.cancelMissedTurnCompletionRecovery();
     this.notificationRouter?.endTurn();
     this.notificationRouter = null;
     this.pendingTurnNotifications = [];

--- a/src/providers/codex/runtime/codexAppServerTypes.ts
+++ b/src/providers/codex/runtime/codexAppServerTypes.ts
@@ -429,6 +429,10 @@ export interface ThreadStartResult {
   reasoningEffort: string;
 }
 
+export interface ThreadReadResult {
+  thread: Thread;
+}
+
 export type SandboxPolicy =
   | { type: 'dangerFullAccess' }
   | {

--- a/src/style/features/ask-user-question.css
+++ b/src/style/features/ask-user-question.css
@@ -304,6 +304,15 @@
   margin-bottom: 6px;
 }
 
+.claudian-ask-approval-warning {
+  padding: 6px 10px;
+  margin-bottom: 6px;
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--text-on-accent);
+  background: var(--text-error);
+}
+
 .claudian-ask-approval-desc {
   padding: 8px 10px;
   background: var(--background-primary-alt);

--- a/tests/unit/features/chat/controllers/suspiciousCommandText.test.ts
+++ b/tests/unit/features/chat/controllers/suspiciousCommandText.test.ts
@@ -1,0 +1,25 @@
+import {
+  hasSuspiciousCommandText,
+  isSuspiciousCommandCharacter,
+} from '@/features/chat/controllers/suspiciousCommandText';
+
+const cp = (codePoint: number): string => String.fromCodePoint(codePoint);
+
+describe('suspiciousCommandText', () => {
+  it('flags control, zero-width, and bidirectional characters', () => {
+    for (const codePoint of [0x00, 0x1b, 0x7f, 0x9f, 0x061c, 0x200b, 0x202e, 0x2066, 0xfeff]) {
+      expect(isSuspiciousCommandCharacter(cp(codePoint))).toBe(true);
+    }
+  });
+
+  it('does not flag ordinary command characters or common whitespace', () => {
+    for (const char of 'git commit -m "hello world" | grep foo\t\r\n') {
+      expect(isSuspiciousCommandCharacter(char)).toBe(false);
+    }
+  });
+
+  it('detects hidden characters embedded in a command', () => {
+    expect(hasSuspiciousCommandText(`rm ${cp(0x202e)}harmless.txt`)).toBe(true);
+    expect(hasSuspiciousCommandText('rm -rf ./build && npm run ship')).toBe(false);
+  });
+});

--- a/tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts
+++ b/tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts
@@ -493,6 +493,111 @@ describe('CodexExecutionBackend', () => {
     await session.dispose();
   });
 
+  it('recovers a completed turn when the terminal notification is missed', async () => {
+    jest.useFakeTimers();
+    const threadId = 'thread-missed-completion';
+    const turnId = 'turn-missed-completion';
+    mockTransportRequest.mockImplementation(async (method: string) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'test',
+          codexHome: '/tmp/.codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'thread/start') return createThreadResult(threadId);
+      if (method === 'turn/start') return createTurnResult(turnId);
+      if (method === 'thread/read') {
+        return createThreadResult(threadId, [{ id: turnId }]);
+      }
+      if (method === 'turn/interrupt') return {};
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const session = new CodexExecutionBackend(createPlugin())
+      .createSession(createSessionConfig());
+    const run = session.execute(createRequest());
+    const eventsPromise = collectEvents(run.events);
+
+    try {
+      await waitForCondition(() => mockTransportRequest.mock.calls.some(
+        ([method]) => method === 'turn/start',
+      ));
+      emitNotification('thread/status/changed', {
+        threadId,
+        status: { type: 'idle' },
+      });
+      await jest.advanceTimersByTimeAsync(5_000);
+
+      expect(mockTransportRequest).toHaveBeenCalledWith(
+        'thread/read',
+        { threadId, includeTurns: true },
+        expect.any(Number),
+      );
+      expect((await eventsPromise).at(-1)).toMatchObject({
+        nativeCheckpointId: turnId,
+        type: 'turn_completed',
+      });
+    } finally {
+      run.cancel();
+      await eventsPromise;
+      await session.dispose();
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not recover when the terminal notification arrives during the grace period', async () => {
+    jest.useFakeTimers();
+    const threadId = 'thread-normal-completion';
+    const turnId = 'turn-normal-completion';
+    mockTransportRequest.mockImplementation(async (method: string) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'test',
+          codexHome: '/tmp/.codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'thread/start') return createThreadResult(threadId);
+      if (method === 'turn/start') return createTurnResult(turnId);
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const session = new CodexExecutionBackend(createPlugin())
+      .createSession(createSessionConfig());
+    const run = session.execute(createRequest());
+    const eventsPromise = collectEvents(run.events);
+
+    try {
+      await waitForCondition(() => mockTransportRequest.mock.calls.some(
+        ([method]) => method === 'turn/start',
+      ));
+      emitNotification('thread/status/changed', {
+        threadId,
+        status: { type: 'idle' },
+      });
+      completeTurn(threadId, turnId);
+      await jest.advanceTimersByTimeAsync(5_000);
+
+      expect(mockTransportRequest).not.toHaveBeenCalledWith(
+        'thread/read',
+        expect.anything(),
+        expect.anything(),
+      );
+      expect((await eventsPromise).at(-1)).toMatchObject({
+        nativeCheckpointId: turnId,
+        type: 'turn_completed',
+      });
+    } finally {
+      run.cancel();
+      await eventsPromise;
+      await session.dispose();
+      jest.useRealTimers();
+    }
+  });
+
   it('sends all attached context using canonical escaped XML', async () => {
     mockTransportRequest.mockImplementation(async (method: string) => {
       if (method === 'initialize') {


### PR DESCRIPTION
## Summary

- Recover Codex turns when the app-server reports an idle thread but misses `turn/completed`.
- Reconcile only the active native turn through `thread/read` after a one-second grace period.
- Warn before approval when a command contains invisible, control, or bidirectional characters.

## Validation

- Targeted tests: 53 passed
- `npm run typecheck`
- `npm run lint -- --quiet`
- `git diff --check`

## Upstream context

- Codex recovery: upstream PR #1053, issues #1052/#1051/#1063
- Hidden command warning: upstream PR #923
