### PR TITLE
fix: wrap expanded tool output lines

### DIFF
--- a/src/features/chat/rendering/ToolCallRenderer.ts
+++ b/src/features/chat/rendering/ToolCallRenderer.ts
@@ -473,7 +473,7 @@ function renderLinesExpanded(
   const linesEl = container.createDiv({ cls: 'claudian-tool-lines' });
   for (const line of displayLines) {
     const stripped = line.replace(/^\s*\d+→/, '');
-    const lineEl = linesEl.createDiv({ cls: 'claudian-tool-line' });
+    const lineEl = linesEl.createDiv({ cls: 'claudian-tool-line claudian-tool-line-wrap' });
     if (hoverable) lineEl.addClass('hoverable');
     lineEl.setText(stripped || ' ');
   }

--- a/tests/unit/features/chat/rendering/ToolCallRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/ToolCallRenderer.test.ts
@@ -167,6 +167,23 @@ describe('ToolCallRenderer', () => {
       expect(setIcon).toHaveBeenCalledWith(expect.anything(), 'check');
     });
 
+    it('wraps long lines in expanded tool results', () => {
+      const parentEl = createMockEl();
+      const toolCall = createToolCall({
+        name: 'Read',
+        status: 'completed',
+        result: `short line\n${'x'.repeat(200)}\nanother line`,
+      });
+
+      const toolEl = renderStoredToolCall(parentEl, toolCall);
+      const lines = toolEl.querySelectorAll('.claudian-tool-line');
+
+      expect(lines).toHaveLength(3);
+      for (const line of lines) {
+        expect(line.hasClass('claudian-tool-line-wrap')).toBe(true);
+      }
+    });
+
     it('should show error status icon', () => {
       const parentEl = createMockEl();
       const toolCall = createToolCall({ status: 'error' });


### PR DESCRIPTION
## Summary

- Apply the existing `claudian-tool-line-wrap` class to expanded tool-call result lines.
- Prevent long JSON, logs, and source lines from forcing horizontal scrolling.

## Verification

- `npm test -- --runInBand tests/unit/features/chat/rendering/ToolCallRenderer.test.ts`
- `npm run typecheck`
- `npm run lint -- --quiet`