### PR TITLE
feat: rank exact slash command matches first

### DIFF
--- a/src/features/chat/rendering/ToolCallRenderer.ts
+++ b/src/features/chat/rendering/ToolCallRenderer.ts
@@ -473,7 +473,7 @@ function renderLinesExpanded(
   const linesEl = container.createDiv({ cls: 'claudian-tool-lines' });
   for (const line of displayLines) {
     const stripped = line.replace(/^\s*\d+→/, '');
-    const lineEl = linesEl.createDiv({ cls: 'claudian-tool-line' });
+    const lineEl = linesEl.createDiv({ cls: 'claudian-tool-line claudian-tool-line-wrap' });
     if (hoverable) lineEl.addClass('hoverable');
     lineEl.setText(stripped || ' ');
   }

--- a/src/shared/components/SlashCommandDropdown.ts
+++ b/src/shared/components/SlashCommandDropdown.ts
@@ -286,7 +286,22 @@ export class SlashCommandDropdown {
         item.name.toLowerCase().includes(searchLower)
         || item.description?.toLowerCase().includes(searchLower)
       )
-      .sort((a, b) => a.name.localeCompare(b.name));
+      .sort((a, b) => this.compareSearchResults(a, b, searchLower));
+  }
+
+  private compareSearchResults(a: DropdownItem, b: DropdownItem, searchLower: string): number {
+    const rankDiff = this.getSearchRank(a, searchLower) - this.getSearchRank(b, searchLower);
+    return rankDiff !== 0 ? rankDiff : a.name.localeCompare(b.name);
+  }
+
+  private getSearchRank(item: DropdownItem, searchLower: string): number {
+    if (!searchLower) return 0;
+    const nameLower = item.name.toLowerCase();
+    if (nameLower === searchLower) return 0;
+    if (nameLower.startsWith(searchLower)) return 1;
+    if (nameLower.includes(searchLower)) return 2;
+    if (item.description?.toLowerCase().includes(searchLower)) return 3;
+    return 4;
   }
 
   private finishRender(searchText: string): void {

--- a/tests/unit/features/chat/rendering/ToolCallRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/ToolCallRenderer.test.ts
@@ -167,6 +167,23 @@ describe('ToolCallRenderer', () => {
       expect(setIcon).toHaveBeenCalledWith(expect.anything(), 'check');
     });
 
+    it('wraps long lines in expanded tool results', () => {
+      const parentEl = createMockEl();
+      const toolCall = createToolCall({
+        name: 'Read',
+        status: 'completed',
+        result: `short line\n${'x'.repeat(200)}\nanother line`,
+      });
+
+      const toolEl = renderStoredToolCall(parentEl, toolCall);
+      const lines = toolEl.querySelectorAll('.claudian-tool-line');
+
+      expect(lines).toHaveLength(3);
+      for (const line of lines) {
+        expect(line.hasClass('claudian-tool-line-wrap')).toBe(true);
+      }
+    });
+
     it('should show error status icon', () => {
       const parentEl = createMockEl();
       const toolCall = createToolCall({ status: 'error' });

--- a/tests/unit/shared/components/SlashCommandDropdown.test.ts
+++ b/tests/unit/shared/components/SlashCommandDropdown.test.ts
@@ -152,6 +152,56 @@ describe('SlashCommandDropdown', () => {
     dropdownWithoutBuiltIns.destroy();
   });
 
+  describe('search result ranking', () => {
+    it('ranks exact, prefix, substring, then description matches', async () => {
+      const entries = [
+        makeEntry('my-paper-writer', 'Substring match'),
+        makeEntry('paper-writer-long', 'Prefix match'),
+        makeEntry('alpha-helper', 'Description mentions paper-writer'),
+        makeEntry('paper-writer', 'Exact match'),
+      ];
+      const dropdownWithEntries = new SlashCommandDropdown(
+        containerEl,
+        inputEl,
+        callbacks,
+        { providerConfig: CLAUDE_CONFIG, providerDiscovery: createEntryDiscovery(async () => entries) },
+      );
+
+      inputEl.value = '/paper-writer';
+      inputEl.selectionStart = 13;
+      dropdownWithEntries.handleInputChange();
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(getRenderedCommandNames(containerEl)).toEqual([
+        'paper-writer',
+        'paper-writer-long',
+        'my-paper-writer',
+        'alpha-helper',
+      ]);
+      dropdownWithEntries.destroy();
+    });
+
+    it('keeps empty searches alphabetically sorted', async () => {
+      const dropdownWithEntries = new SlashCommandDropdown(
+        containerEl,
+        inputEl,
+        callbacks,
+        { providerConfig: CLAUDE_CONFIG, providerDiscovery: createEntryDiscovery(async () => [
+          makeEntry('zebra'),
+          makeEntry('alpha'),
+        ]) },
+      );
+
+      inputEl.value = '/';
+      inputEl.selectionStart = 1;
+      dropdownWithEntries.handleInputChange();
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(getRenderedCommandNames(containerEl)).toEqual(['add-dir', 'alpha', 'clear', 'zebra']);
+      dropdownWithEntries.destroy();
+    });
+  });
+
   describe('setEnabled', () => {
     it('should not show dropdown when disabled', async () => {
       dropdown.setEnabled(false);


### PR DESCRIPTION
## Summary

- Rank exact slash-command name matches before prefix, substring, and description matches.
- Preserve alphabetical ordering when the search text is empty.
- Keep built-in, provider, and hidden-command behavior unchanged.

## Upstream context

Adapted from upstream PR #757 for the current ProviderCommandDiscoveryStore architecture.

## Verification

- `npm test -- --runInBand tests/unit/shared/components/SlashCommandDropdown.test.ts tests/unit/shared/components/SlashCommandDropdown.provider.test.ts`
- `npm run typecheck`
- `npm run lint -- --quiet`