### PR TITLE
feat: expose provider commands by trigger

### DIFF
--- a/src/providers/codex/commands/CodexSkillCatalog.ts
+++ b/src/providers/codex/commands/CodexSkillCatalog.ts
@@ -65,7 +65,10 @@ export class CodexSkillCatalog implements ProviderCommandCatalog {
       .filter(skill => skill.enabled)
       .sort(compareCodexSkillPriority);
     const entries = skills.map(listedSkillToProviderEntry);
-    return context.includeBuiltIns ? [CODEX_COMPACT_COMMAND, ...entries] : entries;
+    // Return both namespaces in one discovery snapshot. The shared dropdown
+    // filters entries by their display prefix for the active trigger (`/` or `$`).
+    void context;
+    return [CODEX_COMPACT_COMMAND, ...entries];
   }
 
   getDropdownConfig(): ProviderCommandDropdownConfig {

--- a/src/shared/components/SlashCommandDropdown.ts
+++ b/src/shared/components/SlashCommandDropdown.ts
@@ -341,6 +341,9 @@ export class SlashCommandDropdown {
     }
 
     for (const entry of this.cachedProviderEntries) {
+      if (entry.displayPrefix !== this.activeTriggerChar) {
+        continue;
+      }
       const nameLower = entry.name.toLowerCase();
       if (seenNames.has(nameLower) || this.hiddenCommands.has(nameLower)) {
         continue;

--- a/tests/unit/providers/codex/commands/CodexSkillCatalog.test.ts
+++ b/tests/unit/providers/codex/commands/CodexSkillCatalog.test.ts
@@ -44,20 +44,20 @@ describe('CodexSkillCatalog', () => {
 
     expect(listProvider.listSkills).toHaveBeenCalledWith({ signal });
     expect(entries.map(entry => entry.name)).toEqual([
+      'compact',
       'legacy-skill',
       'shared-skill',
       'home-skill',
     ]);
-    expect(entries[0]).toMatchObject({
+    expect(entries[1]).toMatchObject({
       scope: 'vault',
       isEditable: false,
       isDeletable: false,
       displayPrefix: '$',
       insertPrefix: '$',
     });
-    expect(entries[0].persistenceKey).toBeUndefined();
     expect(entries[1].persistenceKey).toBeUndefined();
-    expect(entries[2].scope).toBe('user');
+    expect(entries[3].scope).toBe('user');
   });
 
   it('preserves the exact app-server skill name and filters disabled skills', async () => {
@@ -81,16 +81,18 @@ describe('CodexSkillCatalog', () => {
 
     const entries = await catalog.listDropdownEntries({ includeBuiltIns: false });
 
-    expect(entries.map(entry => entry.name)).toEqual(['scope:qualified-name']);
+    expect(entries.map(entry => entry.name)).toEqual(['compact', 'scope:qualified-name']);
   });
 
-  it('includes the provider built-in only when requested', async () => {
+  it('includes the provider built-in in the shared trigger-aware snapshot', async () => {
     const catalog = new CodexSkillCatalog(createListProvider());
 
     await expect(catalog.listDropdownEntries({ includeBuiltIns: true })).resolves.toEqual([
       expect.objectContaining({ name: 'compact', insertPrefix: '/' }),
     ]);
-    await expect(catalog.listDropdownEntries({ includeBuiltIns: false })).resolves.toEqual([]);
+    await expect(catalog.listDropdownEntries({ includeBuiltIns: false })).resolves.toEqual([
+      expect.objectContaining({ name: 'compact', insertPrefix: '/' }),
+    ]);
   });
 
   it('force-refreshes only through the app-server list provider', async () => {

--- a/tests/unit/shared/components/SlashCommandDropdown.provider.test.ts
+++ b/tests/unit/shared/components/SlashCommandDropdown.provider.test.ts
@@ -136,6 +136,12 @@ const CODEX_ENTRIES: ProviderCommandEntry[] = [
   },
 ];
 
+const CODEX_COMPACT_ENTRY: ProviderCommandEntry = {
+  id: 'codex-builtin-compact', providerId: 'codex', kind: 'command', name: 'compact',
+  description: 'Compact conversation history', content: '', scope: 'system', source: 'builtin',
+  isEditable: false, isDeletable: false, displayPrefix: '/', insertPrefix: '/',
+};
+
 describe('SlashCommandDropdown - provider catalog', () => {
   let containerEl: any;
   let inputEl: any;
@@ -276,7 +282,7 @@ describe('SlashCommandDropdown - provider catalog', () => {
     });
 
     it('shows built-ins + skills on / trigger at position 0', async () => {
-      const getProviderEntries = jest.fn().mockResolvedValue(CODEX_ENTRIES);
+      const getProviderEntries = jest.fn().mockResolvedValue([CODEX_COMPACT_ENTRY, ...CODEX_ENTRIES]);
       const dropdown = new SlashCommandDropdown(
         containerEl,
         inputEl,
@@ -294,7 +300,8 @@ describe('SlashCommandDropdown - provider catalog', () => {
 
       const names = getRenderedCommandNames(containerEl);
       expect(names).toContain('/clear');
-      expect(names).toContain('$analyze');
+      expect(names).toContain('/compact');
+      expect(names).not.toContain('$analyze');
 
       dropdown.destroy();
     });
@@ -484,7 +491,7 @@ describe('SlashCommandDropdown - provider catalog', () => {
           },
         );
 
-        inputEl.value = '/';
+        inputEl.value = displayPrefix;
         inputEl.selectionStart = 1;
         dropdown.handleInputChange();
         await new Promise(resolve => setTimeout(resolve, 0));


### PR DESCRIPTION
## Summary

- Include Codex native slash commands such as `/compact` in provider discovery.
- Filter provider entries by their active trigger prefix so `/` shows commands and `$` shows skills.
- Preserve existing built-in and hidden-command behavior.

## Upstream context

Adapted from upstream PR #854 for the current `ProviderCommandDiscoveryStore` architecture.

## Verification

- `npm test -- --runInBand tests/unit/providers/codex/commands/CodexSkillCatalog.test.ts tests/unit/shared/components/SlashCommandDropdown.provider.test.ts tests/unit/shared/components/SlashCommandDropdown.test.ts`
- `npm run typecheck`
- `npm run lint -- --quiet`