### PR TITLE
fix: discard incomplete image inputs after provider errors

### DIFF
--- a/src/app/conversations/ConversationRepository.ts
+++ b/src/app/conversations/ConversationRepository.ts
@@ -943,6 +943,19 @@ export class ConversationRepository {
     await this.persistLedgerOnly(conversationId, ledger);
   }
 
+  async discardIncompleteConversationInput(
+    conversationId: string,
+    recordId: string,
+  ): Promise<void> {
+    const ledger = await this.requireInputLedger(conversationId);
+    const index = ledger.records.findIndex(({ id }) => id === recordId);
+    if (index === -1) return;
+    const record = ledger.records[index];
+    if (record.state !== 'accepted' || record.providerAssistantMessageId) return;
+    ledger.records.splice(index, 1);
+    await this.persistLedgerOnly(conversationId, ledger);
+  }
+
   async getConversationInputLedger(
     conversationId: string,
   ): Promise<ConversationInputLedger | null> {

--- a/src/features/chat/execution/ChatExecutionCoordinator.ts
+++ b/src/features/chat/execution/ChatExecutionCoordinator.ts
@@ -102,6 +102,10 @@ export interface ChatExecutionPersistence {
     conversationId: string,
     recordId: string,
   ): Promise<void>;
+  discardIncompleteConversationInput(
+    conversationId: string,
+    recordId: string,
+  ): Promise<void>;
   copyConversationInputsForFork(
     sourceConversationId: string,
     targetConversationId: string,
@@ -188,6 +192,7 @@ interface ActiveExecution {
   readonly run: ProviderExecutionRun;
   readonly requestController: AbortController;
   readonly inputRecordId: string;
+  readonly hasImages: boolean;
   readonly messages?: ChatTurnMessageBinding;
   terminationOverride: 'cancelled' | 'invalidated' | null;
 }
@@ -422,6 +427,7 @@ export class ChatExecutionCoordinator {
       run,
       requestController,
       inputRecordId: record.id,
+      hasImages: submission.images.length > 0,
       messages: submission.messages,
       terminationOverride: null,
     };
@@ -808,6 +814,17 @@ export class ChatExecutionCoordinator {
       );
       throw new ChatExecutionPreHandoffError(
         terminalSinkFailure?.error ?? terminal,
+      );
+    }
+    if (
+      active.hasImages
+      && accepted
+      && terminal?.type === 'execution_error'
+      && !nativeAssistantMessageId
+    ) {
+      await this.deps.persistence.discardIncompleteConversationInput(
+        active.binding.conversation.conversationId,
+        active.inputRecordId,
       );
     }
     const unacceptedMissingSession = isUnacceptedMissingSession(terminal, accepted);

--- a/tests/unit/features/chat/execution/ChatExecutionCoordinator.test.ts
+++ b/tests/unit/features/chat/execution/ChatExecutionCoordinator.test.ts
@@ -252,6 +252,7 @@ function createHarness(options: {
     stageConversationInput: jest.fn(async () => undefined),
     acceptConversationInput: jest.fn(async () => undefined),
     discardStagedConversationInput: jest.fn(async () => undefined),
+    discardIncompleteConversationInput: jest.fn(async () => undefined),
     copyConversationInputsForFork: jest.fn(async () => undefined),
     truncateConversationInputsFrom: jest.fn(async () => undefined),
   } as unknown as jest.Mocked<ChatExecutionPersistence>;
@@ -1071,6 +1072,39 @@ describe('ChatExecutionCoordinator', () => {
       { providerUserMessageId: undefined },
     );
     expect(harness.repository.discardStagedConversationInput).not.toHaveBeenCalled();
+  });
+
+  it('removes an accepted image input when execution fails before an assistant response', async () => {
+    const harness = createHarness();
+    const { session, run, resultPromise } = await beginExecution(
+      harness,
+      createSubmission({
+        images: [{
+          id: 'image-1', name: 'image.png', mediaType: 'image/png', data: 'encoded',
+          size: 7, source: 'paste',
+        }],
+      }),
+    );
+
+    run.events.push({
+      type: 'turn_started',
+      scope: requestedScope(session, run, 1),
+      accepted: true,
+    });
+    run.events.push({
+      type: 'execution_error',
+      scope: requestedScope(session, run, 2),
+      category: 'provider',
+      message: 'Model cannot process image input.',
+      recoverable: true,
+    });
+    run.events.end();
+
+    await expect(resultPromise).resolves.toMatchObject({ status: 'error', accepted: true });
+    expect(harness.repository.discardIncompleteConversationInput).toHaveBeenCalledWith(
+      'conversation-1',
+      'input-1',
+    );
   });
 
   it('routes only current monotonically correlated requested events and persists snapshots', async () => {
@@ -2078,6 +2112,9 @@ describe('ChatExecutionCoordinator', () => {
       acceptConversationInput: (...args) => repository.acceptConversationInput(...args),
       discardStagedConversationInput: (...args) => (
         repository.discardStagedConversationInput(...args)
+      ),
+      discardIncompleteConversationInput: (...args) => (
+        repository.discardIncompleteConversationInput(...args)
       ),
       copyConversationInputsForFork: (...args) => (
         repository.copyConversationInputsForFork(...args)

--- a/tests/unit/features/chat/execution/ProviderRecoveryTestHarness.ts
+++ b/tests/unit/features/chat/execution/ProviderRecoveryTestHarness.ts
@@ -52,6 +52,7 @@ export function createProviderRecoveryTestHarness(
     stageConversationInput: jest.fn(async () => undefined),
     acceptConversationInput: jest.fn(async () => undefined),
     discardStagedConversationInput: jest.fn(async () => undefined),
+    discardIncompleteConversationInput: jest.fn(async () => undefined),
     copyConversationInputsForFork: jest.fn(async () => undefined),
     truncateConversationInputsFrom: jest.fn(async () => undefined),
   };


### PR DESCRIPTION
## Summary

- Remove accepted image input records that fail before any assistant response is produced.
- Prevent a rejected image turn from being replayed forever after the provider session is reset.
- Keep ordinary accepted text errors unchanged.

## Upstream context

Addresses the state-safety concern raised in upstream Issue #1055. The upstream report could not be reproduced on the current Claude history path, so this narrows the fix to the confirmed invariant: an accepted image input without an assistant completion must not remain replayable.

## Verification

- `npm test -- --runInBand tests/unit/features/chat/execution/ChatExecutionCoordinator.test.ts`
- `npm run typecheck`
- `npm run lint -- --quiet`