### PR TITLE
feat: complete file attachment request flow

### DIFF
--- a/src/core/execution/ProviderExecutionRequest.ts
+++ b/src/core/execution/ProviderExecutionRequest.ts
@@ -24,6 +24,7 @@ export interface ProviderExecutionContext {
   readonly browserSelection?: BrowserSelectionContext | null;
   readonly canvasSelection?: CanvasSelectionContext | null;
   readonly externalContextPaths?: readonly string[];
+  readonly contextFiles?: readonly string[];
 }
 
 export type ProviderSystemInstructions =

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -1013,6 +1013,7 @@ export class InputController {
       ? fileContextManager.transformContextMentions(options.content)
       : options.content;
     const enabledMcpServers = mcpServerSelector?.getEnabledServers();
+    const contextFiles = fileContextManager?.getAttachedFiles();
 
     return {
       displayContent: options.content,
@@ -1026,6 +1027,7 @@ export class InputController {
         externalContextPaths: externalContextPaths && externalContextPaths.length > 0
           ? externalContextPaths
           : undefined,
+        contextFiles: contextFiles && contextFiles.size > 0 ? [...contextFiles] : undefined,
         enabledMcpServers: enabledMcpServers && enabledMcpServers.size > 0
           ? enabledMcpServers
           : undefined,
@@ -1095,6 +1097,7 @@ export class InputController {
         ...(request.externalContextPaths
           ? { externalContextPaths: [...request.externalContextPaths] }
           : {}),
+        ...(request.contextFiles ? { contextFiles: [...request.contextFiles] } : {}),
       },
       conversationHistory: user && assistant
         ? this.deps.state.messages.slice(0, -2)
@@ -2265,6 +2268,7 @@ function cloneChatTurnRequest(request: ChatTurnRequest): ChatTurnRequest {
     externalContextPaths: request.externalContextPaths
       ? [...request.externalContextPaths]
       : undefined,
+    contextFiles: request.contextFiles ? [...request.contextFiles] : undefined,
     images: request.images ? [...request.images] : undefined,
   };
 }
@@ -2279,6 +2283,10 @@ function mergeQueuedChatTurns(
   const externalContextPaths = Array.from(new Set([
     ...(existing.request.externalContextPaths ?? []),
     ...(incoming.request.externalContextPaths ?? []),
+  ]));
+  const contextFiles = Array.from(new Set([
+    ...(existing.request.contextFiles ?? []),
+    ...(incoming.request.contextFiles ?? []),
   ]));
   const enabledMcpServers = new Set([
     ...(existing.request.enabledMcpServers ?? []),
@@ -2298,6 +2306,7 @@ function mergeQueuedChatTurns(
         enabledMcpServers.size > 0 ? enabledMcpServers : undefined,
       externalContextPaths:
         externalContextPaths.length > 0 ? externalContextPaths : undefined,
+      contextFiles: contextFiles.length > 0 ? contextFiles : undefined,
       images: images.length > 0 ? images : undefined,
       text: mergeText(existing.request.text, incoming.request.text),
     },

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -1013,7 +1013,7 @@ export class InputController {
       ? fileContextManager.transformContextMentions(options.content)
       : options.content;
     const enabledMcpServers = mcpServerSelector?.getEnabledServers();
-    const contextFiles = fileContextManager?.getAttachedFiles();
+    const contextFiles = fileContextManager?.getAttachedFiles?.();
 
     return {
       displayContent: options.content,

--- a/src/features/chat/state/types.ts
+++ b/src/features/chat/state/types.ts
@@ -22,6 +22,7 @@ export interface ChatTurnRequest {
   browserSelection?: BrowserSelectionContext | null;
   canvasSelection?: CanvasSelectionContext | null;
   externalContextPaths?: string[];
+  contextFiles?: string[];
   enabledMcpServers?: Set<string>;
 }
 

--- a/src/features/chat/ui/ComposerContextTray.ts
+++ b/src/features/chat/ui/ComposerContextTray.ts
@@ -8,12 +8,13 @@ import {
 
 export type ComposerContextSlot =
   | 'current-note'
+  | 'files'
   | 'editor-selection'
   | 'browser-selection'
   | 'canvas-selection'
   | 'images';
 
-export type ComposerContextItemKind = 'note' | 'selection' | 'image';
+export type ComposerContextItemKind = 'note' | 'file' | 'selection' | 'image';
 
 export interface ComposerContextItem {
   id: string;
@@ -32,6 +33,7 @@ export interface ComposerContextTrayOptions {
 
 const SLOT_ORDER: readonly ComposerContextSlot[] = [
   'current-note',
+  'files',
   'editor-selection',
   'browser-selection',
   'canvas-selection',

--- a/src/features/chat/ui/FileContext.ts
+++ b/src/features/chat/ui/FileContext.ts
@@ -42,6 +42,12 @@ export class FileContextManager {
   private ownedContextTray: ComposerContextTray | null = null;
   private deleteEventRef: EventRef | null = null;
   private renameEventRef: EventRef | null = null;
+  private dropTargetEl: HTMLElement | null = null;
+  private dropOverlayEl: HTMLElement | null = null;
+  private dragEnterHandler: ((event: DragEvent) => void) | null = null;
+  private dragOverHandler: ((event: DragEvent) => void) | null = null;
+  private dragLeaveHandler: ((event: DragEvent) => void) | null = null;
+  private dropHandler: ((event: DragEvent) => void) | null = null;
 
   // Current note (shown as chip)
   private currentNotePath: string | null = null;
@@ -111,6 +117,7 @@ export class FileContextManager {
         normalizePathForVault: (rawPath) => this.normalizePathForVault(rawPath),
       }
     );
+    this.setupDragAndDrop();
 
     this.deleteEventRef = this.app.vault.on('delete', (file) => {
       if (file instanceof TFile) this.handleFileDeleted(file.path);
@@ -274,12 +281,84 @@ export class FileContextManager {
     this.chipsView.destroy();
     this.ownedContextTray?.destroy();
     this.ownedContextTray = null;
+    if (this.dropTargetEl) {
+      if (this.dragEnterHandler) this.dropTargetEl.removeEventListener('dragenter', this.dragEnterHandler as EventListener);
+      if (this.dragOverHandler) this.dropTargetEl.removeEventListener('dragover', this.dragOverHandler as EventListener);
+      if (this.dragLeaveHandler) this.dropTargetEl.removeEventListener('dragleave', this.dragLeaveHandler as EventListener);
+      if (this.dropHandler) this.dropTargetEl.removeEventListener('drop', this.dropHandler as EventListener);
+    }
+    this.dropOverlayEl?.remove();
+    this.dropTargetEl = null;
+    this.dropOverlayEl = null;
   }
 
   /** Normalizes a file path to be vault-relative with forward slashes. */
   normalizePathForVault(rawPath: string | undefined | null): string | null {
     const vaultPath = getVaultPath(this.app);
     return normalizePathForVaultUtil(rawPath, vaultPath);
+  }
+
+  private setupDragAndDrop(): void {
+    const target = this.inputEl.closest<HTMLElement>('.claudian-input-wrapper');
+    if (!target) return;
+    const overlay = target.createDiv();
+    overlay.className = 'claudian-file-drop-overlay';
+    overlay.textContent = 'Drop files or folders to attach';
+    overlay.style.display = 'none';
+    target.appendChild(overlay);
+    let dragDepth = 0;
+    this.dragEnterHandler = (event) => {
+      event.preventDefault();
+      dragDepth += 1;
+      overlay.style.display = '';
+    };
+    this.dragOverHandler = (event) => event.preventDefault();
+    this.dragLeaveHandler = (event) => {
+      event.preventDefault();
+      dragDepth = Math.max(0, dragDepth - 1);
+      if (dragDepth === 0) overlay.style.display = 'none';
+    };
+    this.dropHandler = (event) => {
+      event.preventDefault();
+      dragDepth = 0;
+      overlay.style.display = 'none';
+      const paths = this.resolveDroppedPaths(event.dataTransfer);
+      for (const path of paths) this.attachDroppedPath(path);
+    };
+    target.addEventListener('dragenter', this.dragEnterHandler as EventListener);
+    target.addEventListener('dragover', this.dragOverHandler as EventListener);
+    target.addEventListener('dragleave', this.dragLeaveHandler as EventListener);
+    target.addEventListener('drop', this.dropHandler as EventListener);
+    this.dropTargetEl = target;
+    this.dropOverlayEl = overlay;
+  }
+
+  private resolveDroppedPaths(dataTransfer: DataTransfer | null): string[] {
+    if (!dataTransfer) return [];
+    const paths: string[] = [];
+    const text = dataTransfer.getData('text/plain');
+    const uri = text.match(/^obsidian:\/\/open\?file=(.+)$/i)?.[1];
+    if (uri) paths.push(decodeURIComponent(uri));
+    for (const file of Array.from(dataTransfer.files ?? [])) {
+      const rawPath = (file as File & { path?: string }).path;
+      if (rawPath) paths.push(rawPath);
+    }
+    return paths;
+  }
+
+  private attachDroppedPath(rawPath: string): void {
+    const normalized = this.normalizePathForVault(rawPath);
+    if (!normalized) return;
+    const abstract = this.app.vault.getAbstractFileByPath(normalized);
+    const path = abstract instanceof TFolder && !normalized.endsWith('/') ? `${normalized}/` : normalized;
+    this.state.attachFile(path);
+    const mention = `@${path}`;
+    const start = this.inputEl.selectionStart ?? this.inputEl.value.length;
+    const end = this.inputEl.selectionEnd ?? start;
+    this.inputEl.setRangeText(mention, start, end, 'end');
+    this.inputEl.dispatchEvent(new Event('input', { bubbles: true }));
+    this.inputEl.focus();
+    this.callbacks.onUserChipsChanged?.();
   }
 
   private refreshCurrentNoteChip(): void {

--- a/src/features/chat/ui/FileContext.ts
+++ b/src/features/chat/ui/FileContext.ts
@@ -89,15 +89,16 @@ export class FileContextManager {
       },
       onOpenFile: (filePath) => {
         void (async (): Promise<void> => {
-          const file = this.app.vault.getAbstractFileByPath(filePath);
-          if (!(file instanceof TFile)) {
-            new Notice(`Could not open file: ${filePath}`);
-            return;
-          }
           try {
-            await this.app.workspace.getLeaf().openFile(file);
+            const normalizedPath = filePath.replace(/\/$/, '');
+            const file = this.app.vault.getAbstractFileByPath(normalizedPath);
+            if (file instanceof TFile) {
+              await this.app.workspace.getLeaf().openFile(file);
+              return;
+            }
+            await this.app.workspace.openLinkText(normalizedPath, '', false);
           } catch (error) {
-            new Notice(`Failed to open file: ${error instanceof Error ? error.message : String(error)}`);
+            new Notice(`Could not open file: ${filePath}`);
           }
         })();
       },
@@ -371,12 +372,6 @@ export class FileContextManager {
     const path = abstract instanceof TFolder && !normalized.endsWith('/') ? `${normalized}/` : normalized;
     this.state.attachFile(path);
     this.renderAttachedFiles();
-    const mention = `@${path}`;
-    const start = this.inputEl.selectionStart ?? this.inputEl.value.length;
-    const end = this.inputEl.selectionEnd ?? start;
-    this.inputEl.setRangeText(mention, start, end, 'end');
-    this.inputEl.dispatchEvent(new Event('input', { bubbles: true }));
-    this.inputEl.focus();
     this.callbacks.onUserChipsChanged?.();
   }
 

--- a/src/features/chat/ui/FileContext.ts
+++ b/src/features/chat/ui/FileContext.ts
@@ -82,8 +82,10 @@ export class FileContextManager {
           this.currentNotePath = null;
           this.state.detachFile(filePath);
           this.refreshCurrentNoteChip();
-          this.callbacks.onUserChipsChanged?.();
         }
+        this.state.detachFile(filePath);
+        this.renderAttachedFiles();
+        this.callbacks.onUserChipsChanged?.();
       },
       onOpenFile: (filePath) => {
         void (async (): Promise<void> => {
@@ -105,7 +107,10 @@ export class FileContextManager {
       this.dropdownContainerEl,
       this.inputEl,
       {
-        onAttachFile: (filePath) => this.state.attachFile(filePath),
+        onAttachFile: (filePath) => {
+          this.state.attachFile(filePath);
+          this.renderAttachedFiles();
+        },
         onMcpMentionChange: (servers) => this.onMcpMentionChange?.(servers),
         onAgentMentionSelect: (agentId) => this.callbacks.onAgentMentionSelect?.(agentId),
         getMentionedMcpServers: () => this.state.getMentionedMcpServers(),
@@ -339,13 +344,24 @@ export class FileContextManager {
     if (!dataTransfer) return [];
     const paths: string[] = [];
     const text = dataTransfer.getData('text/plain');
-    const uri = text.match(/^obsidian:\/\/open\?file=(.+)$/i)?.[1];
-    if (uri) paths.push(decodeURIComponent(uri));
+    const uriList = dataTransfer.getData('text/uri-list');
+    for (const candidate of [text, uriList]) {
+      if (!candidate) continue;
+      const uri = candidate.trim().split('\n').find(value => /^obsidian:\/\/open\?/i.test(value));
+      if (!uri) continue;
+      try {
+        const filePath = new URL(uri).searchParams.get('file');
+        if (filePath) paths.push(filePath);
+      } catch {
+        const filePath = uri.match(/[?&]file=([^&]+)/i)?.[1];
+        if (filePath) paths.push(decodeURIComponent(filePath));
+      }
+    }
     for (const file of Array.from(dataTransfer.files ?? [])) {
       const rawPath = (file as File & { path?: string }).path;
       if (rawPath) paths.push(rawPath);
     }
-    return paths;
+    return [...new Set(paths)];
   }
 
   private attachDroppedPath(rawPath: string): void {
@@ -354,6 +370,7 @@ export class FileContextManager {
     const abstract = this.app.vault.getAbstractFileByPath(normalized);
     const path = abstract instanceof TFolder && !normalized.endsWith('/') ? `${normalized}/` : normalized;
     this.state.attachFile(path);
+    this.renderAttachedFiles();
     const mention = `@${path}`;
     const start = this.inputEl.selectionStart ?? this.inputEl.value.length;
     const end = this.inputEl.selectionEnd ?? start;
@@ -365,7 +382,12 @@ export class FileContextManager {
 
   private refreshCurrentNoteChip(): void {
     this.chipsView.renderCurrentNote(this.currentNotePath);
+    this.renderAttachedFiles();
     this.callbacks.onChipsChanged?.();
+  }
+
+  private renderAttachedFiles(): void {
+    this.chipsView.renderAttachedFiles(this.state.getAttachedFiles(), this.currentNotePath);
   }
 
   private handleFileRenamed(

--- a/src/features/chat/ui/FileContext.ts
+++ b/src/features/chat/ui/FileContext.ts
@@ -299,8 +299,10 @@ export class FileContextManager {
   }
 
   private setupDragAndDrop(): void {
+    if (typeof this.inputEl.closest !== 'function') return;
     const target = this.inputEl.closest<HTMLElement>('.claudian-input-wrapper');
     if (!target) return;
+    if (typeof (target as HTMLElement & { createDiv?: unknown }).createDiv !== 'function') return;
     const overlay = target.createDiv();
     overlay.className = 'claudian-file-drop-overlay';
     overlay.textContent = 'Drop files or folders to attach';

--- a/src/features/chat/ui/FileContext.ts
+++ b/src/features/chat/ui/FileContext.ts
@@ -97,7 +97,7 @@ export class FileContextManager {
               return;
             }
             await this.app.workspace.openLinkText(normalizedPath, '', false);
-          } catch (error) {
+          } catch {
             new Notice(`Could not open file: ${filePath}`);
           }
         })();

--- a/src/features/chat/ui/file-context/view/FileChipsView.ts
+++ b/src/features/chat/ui/file-context/view/FileChipsView.ts
@@ -16,6 +16,27 @@ export class FileChipsView {
 
   destroy(): void {
     this.contextTray.clearItems('current-note');
+    this.contextTray.clearItems('files');
+  }
+
+  renderAttachedFiles(filePaths: Iterable<string>, currentNotePath?: string | null): void {
+    const items = [...filePaths]
+      .filter(filePath => filePath !== currentNotePath)
+      .map(filePath => {
+        const normalizedPath = filePath.replace(/\\/g, '/');
+        const label = normalizedPath.replace(/\/$/, '').split('/').pop() || filePath;
+        return {
+          id: filePath,
+          kind: 'file' as const,
+          label,
+          icon: normalizedPath.endsWith('/') ? 'folder' : 'file-text',
+          title: filePath,
+          ariaLabel: `Attached file: ${filePath}`,
+          onRemove: () => this.callbacks.onRemoveAttachment(filePath),
+          onActivate: () => this.callbacks.onOpenFile(filePath),
+        };
+      });
+    this.contextTray.setItems('files', items);
   }
 
   renderCurrentNote(filePath: string | null): void {

--- a/src/providers/claude/execution/ClaudeExecutionRequestEncoder.ts
+++ b/src/providers/claude/execution/ClaudeExecutionRequestEncoder.ts
@@ -25,6 +25,7 @@ import type {
 import { appendBrowserContext } from '../../../utils/browser';
 import { appendCanvasContext } from '../../../utils/canvas';
 import {
+  appendContextFiles,
   appendCurrentNote,
   appendCurrentNoteContent,
 } from '../../../utils/context';
@@ -297,6 +298,9 @@ export class ClaudeExecutionRequestEncoder {
     }
     if (context?.canvasSelection) {
       prompt = appendCanvasContext(prompt, context.canvasSelection);
+    }
+    if (context?.contextFiles?.length) {
+      prompt = appendContextFiles(prompt, [...context.contextFiles]);
     }
 
     const history = replayConversationHistory

--- a/src/providers/codex/execution/CodexExecutionSession.ts
+++ b/src/providers/codex/execution/CodexExecutionSession.ts
@@ -27,6 +27,7 @@ import type { ChatMessage, ImageAttachment, StreamChunk } from '../../../core/ty
 import { appendBrowserContext } from '../../../utils/browser';
 import { appendCanvasContext } from '../../../utils/canvas';
 import {
+  appendContextFiles,
   appendCurrentNote,
   appendCurrentNoteContent,
 } from '../../../utils/context';
@@ -1805,6 +1806,9 @@ export class CodexExecutionSession
     }
     if (context?.canvasSelection) {
       prompt = appendCanvasContext(prompt, context.canvasSelection);
+    }
+    if (context?.contextFiles?.length) {
+      prompt = appendContextFiles(prompt, [...context.contextFiles]);
     }
 
     const history = request.conversationHistory;

--- a/src/providers/cursor/execution/CursorExecutionSession.ts
+++ b/src/providers/cursor/execution/CursorExecutionSession.ts
@@ -21,7 +21,7 @@ import {
   type AcpUsageUpdate,
   buildAcpUsageInfo,
 } from '@/providers/acp';
-import { appendCurrentNote } from '@/utils/context';
+import { appendContextFiles, appendCurrentNote } from '@/utils/context';
 import { appendEditorContext } from '@/utils/editor';
 
 import { decodeCursorModelId } from '../models';
@@ -311,6 +311,9 @@ export function buildCursorPrompt(request: ProviderExecutionRequest): AcpContent
   }
   if (request.context?.editorSelection) {
     text = appendEditorContext(text, request.context.editorSelection);
+  }
+  if (request.context?.contextFiles?.length) {
+    text = appendContextFiles(text, [...request.context.contextFiles]);
   }
   const blocks: AcpContentBlock[] = [{ type: 'text', text }];
   for (const block of request.input) {

--- a/src/providers/grok/execution/GrokExecutionSession.ts
+++ b/src/providers/grok/execution/GrokExecutionSession.ts
@@ -21,7 +21,7 @@ import type { ProviderHost } from '../../../core/providers/ProviderHost';
 import type { ChatMessage } from '../../../core/types';
 import { appendBrowserContext } from '../../../utils/browser';
 import { appendCanvasContext } from '../../../utils/canvas';
-import { appendCurrentNote } from '../../../utils/context';
+import { appendContextFiles, appendCurrentNote } from '../../../utils/context';
 import { appendEditorContext } from '../../../utils/editor';
 import {
   buildContextFromHistory,
@@ -1234,6 +1234,7 @@ function buildPromptBlocks(
   }
   if (context?.browserSelection) text = appendBrowserContext(text, context.browserSelection);
   if (context?.canvasSelection) text = appendCanvasContext(text, context.canvasSelection);
+  if (context?.contextFiles?.length) text = appendContextFiles(text, [...context.contextFiles]);
   if (replayConversationHistory && request.conversationHistory?.length) {
     const history = [...request.conversationHistory] as ChatMessage[];
     text = buildPromptWithHistoryContext(

--- a/src/providers/omp/execution/OmpExecutionSession.ts
+++ b/src/providers/omp/execution/OmpExecutionSession.ts
@@ -21,7 +21,7 @@ import {
   buildAcpUsageInfo,
   extractAcpSessionThoughtLevelState,
 } from '@/providers/acp';
-import { appendCurrentNote } from '@/utils/context';
+import { appendContextFiles, appendCurrentNote } from '@/utils/context';
 import { appendEditorContext } from '@/utils/editor';
 
 import { decodeOmpModelId } from '../models';
@@ -306,6 +306,9 @@ export function buildOmpPrompt(request: ProviderExecutionRequest): AcpContentBlo
   }
   if (request.context?.editorSelection) {
     text = appendEditorContext(text, request.context.editorSelection);
+  }
+  if (request.context?.contextFiles?.length) {
+    text = appendContextFiles(text, [...request.context.contextFiles]);
   }
   const blocks: AcpContentBlock[] = [{ type: 'text', text }];
   for (const block of request.input) {

--- a/src/providers/opencode/execution/OpencodeExecutionSession.ts
+++ b/src/providers/opencode/execution/OpencodeExecutionSession.ts
@@ -864,6 +864,7 @@ function buildPromptBlocks(
     currentNoteContent: currentNote?.content,
     currentNotePath: currentNote?.path,
     editorSelection: request.context?.editorSelection,
+    contextFiles: request.context?.contextFiles ? [...request.context.contextFiles] : undefined,
     images,
     text,
   }, bootstrapHistory

--- a/src/providers/opencode/runtime/buildOpencodePrompt.ts
+++ b/src/providers/opencode/runtime/buildOpencodePrompt.ts
@@ -7,6 +7,7 @@ import {
   appendCanvasContext,
   type CanvasSelectionContext,
 } from '../../../utils/canvas';
+import { appendContextFiles } from '../../../utils/context';
 import {
   appendCurrentNote,
   appendCurrentNoteContent,
@@ -27,6 +28,7 @@ export interface OpencodePromptRequest {
   browserSelection?: BrowserSelectionContext | null;
   canvasSelection?: CanvasSelectionContext | null;
   externalContextPaths?: string[];
+  contextFiles?: string[];
 }
 
 export function buildOpencodePromptText(
@@ -55,6 +57,9 @@ export function buildOpencodePromptText(
 
   if (request.canvasSelection) {
     prompt = appendCanvasContext(prompt, request.canvasSelection);
+  }
+  if (request.contextFiles?.length) {
+    prompt = appendContextFiles(prompt, request.contextFiles);
   }
 
   if (conversationHistory.length > 0) {

--- a/src/providers/pi/execution/PiExecutionSession.ts
+++ b/src/providers/pi/execution/PiExecutionSession.ts
@@ -1477,6 +1477,9 @@ function encodePrompt(
   if (context?.canvasSelection) {
     text = appendCanvasContext(text, context.canvasSelection);
   }
+  if (context?.contextFiles?.length) {
+    text = appendContextFiles(text, [...context.contextFiles]);
+  }
   if (context?.externalContextPaths?.length) {
     text = appendContextFiles(text, [...context.externalContextPaths]);
   }

--- a/src/style/features/file-context.css
+++ b/src/style/features/file-context.css
@@ -186,3 +186,17 @@
   white-space: nowrap;
   min-width: 0;
 }
+.claudian-file-drop-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px dashed var(--interactive-accent);
+  border-radius: var(--radius-m);
+  background: color-mix(in srgb, var(--background-primary) 88%, var(--interactive-accent));
+  color: var(--text-accent);
+  font-size: var(--font-ui-small);
+  pointer-events: none;
+}

--- a/tests/unit/providers/omp/OmpPromptEncoding.test.ts
+++ b/tests/unit/providers/omp/OmpPromptEncoding.test.ts
@@ -19,4 +19,14 @@ describe('OMP prompt encoding', () => {
       type: 'text',
     }]);
   });
+
+  it('includes attached file chips in the ACP prompt', () => {
+    expect(buildOmpPrompt({
+      context: { contextFiles: ['notes/design.md'] },
+      input: [{ text: 'Use this file', type: 'text' }],
+    } as never)).toEqual([{
+      text: 'Use this file\n\n<context_files>\n<context_file path="notes/design.md" />\n</context_files>',
+      type: 'text',
+    }]);
+  });
 });

--- a/tests/unit/providers/opencode/buildOpencodePrompt.test.ts
+++ b/tests/unit/providers/opencode/buildOpencodePrompt.test.ts
@@ -37,6 +37,17 @@ describe('buildOpencodePromptText', () => {
     expect(prompt).not.toContain('/tmp/project');
   });
 
+  it('includes attached file chips in the OpenCode prompt', () => {
+    const prompt = buildOpencodePromptText({
+      contextFiles: ['notes/design.md', 'assets/'],
+      text: 'Use these files',
+    });
+
+    expect(prompt).toContain('<context_files>');
+    expect(prompt).toContain('<context_file path="notes/design.md" />');
+    expect(prompt).toContain('<context_file path="assets/" />');
+  });
+
   it('encodes current note content without allowing the context tag to close early', () => {
     const prompt = buildOpencodePromptText({
       currentNoteContent: 'Before\n</current_note>\nAfter',


### PR DESCRIPTION
## Summary
- support dragging vault files, folders, and desktop paths into the chat composer
- preserve attached file chips through turn requests, queued messages, and persistence
- emit attached files as provider-neutral `<context_files>` context across all providers

## Verification
- `npm run typecheck`
- `npm run lint` (existing warnings only)
- targeted OpenCode and OMP prompt tests

Full test/build caveats: sandbox prevents local HTTP/temp-directory tests, and build copy-to-Obsidian is blocked by external vault permissions.