### PR TITLE
chore: prepare 2.1.12 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,6 @@ Oh My Claudian is an Obsidian plugin that embeds coding agents in your vault. Ag
 
 > This repository is based on [YishenTu/claudian](https://github.com/YishenTu/claudian) and adds Oh My Pi (OMP) and Cursor support through ACP.
 
-## What's new in 2.1.12
-
-- **Cursor Agent** — ACP-backed Cursor provider with model discovery, Agent/Ask/Plan modes, image attachments, and read-only transcript restoration.
-- **More reliable Codex turns** — recover when the Codex app-server finishes a turn without sending a completion event, including safe cancellation recovery.
-- **Provider readiness** — every provider settings tab now reports enablement, CLI detection, model discovery, and model selection with provider-specific CLI path guidance and refresh actions.
-- **Safer command execution** — warn before approving commands containing hidden, bidirectional, or other suspicious control characters.
-- **Better command and output UX** — provider-native slash commands are filtered by trigger, exact command matches rank first, and long tool-output lines wrap in the expanded view.
-- **Safer image failures** — failed image turns no longer leave unusable image input permanently attached to a conversation.
-- **File and folder context** — drag files or folders from Obsidian or your desktop into the composer, see them as clickable context chips, and send them through the provider request.
-
 ## Added in This Repository
 
 - **Oh My Pi (OMP)** — An ACP-backed OMP provider with model discovery and selection in the chat sidebar.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ Oh My Claudian is an Obsidian plugin that embeds coding agents in your vault. Ag
 
 > This repository is based on [YishenTu/claudian](https://github.com/YishenTu/claudian) and adds Oh My Pi (OMP) and Cursor support through ACP.
 
+## What's new in 2.1.12
+
+- **Cursor Agent** — ACP-backed Cursor provider with model discovery, Agent/Ask/Plan modes, image attachments, and read-only transcript restoration.
+- **More reliable Codex turns** — recover when the Codex app-server finishes a turn without sending a completion event, including safe cancellation recovery.
+- **Provider readiness** — every provider settings tab now reports enablement, CLI detection, model discovery, and model selection with provider-specific CLI path guidance and refresh actions.
+- **Safer command execution** — warn before approving commands containing hidden, bidirectional, or other suspicious control characters.
+- **Better command and output UX** — provider-native slash commands are filtered by trigger, exact command matches rank first, and long tool-output lines wrap in the expanded view.
+- **Safer image failures** — failed image turns no longer leave unusable image input permanently attached to a conversation.
+- **File and folder context** — drag files or folders from Obsidian or your desktop into the composer, see them as clickable context chips, and send them through the provider request.
+
 ## Added in This Repository
 
 - **Oh My Pi (OMP)** — An ACP-backed OMP provider with model discovery and selection in the chat sidebar.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Oh My Claudian is an Obsidian plugin that embeds coding agents in your vault. Ag
 - Readiness state refreshes immediately after provider enablement changes, so the settings page does not show stale status.
 - Model catalog state in provider settings, including freshness, cached/failed refresh state, default model, and all-versus-explicit selection.
 - Provider-neutral execution outcomes for completion, cancellation, invalidation, and recoverable errors, with recovery actions fenced while a turn is active.
+- Drag files and folders from Obsidian or your desktop into the composer to attach them as clickable context chips.
 - MCP support where available from the selected provider.
 - Internationalized interface with 10 locales, including Simplified and Traditional Chinese.
 **Plan Mode** — Toggle via `Shift+Tab`. The agent explores and designs before implementing, then presents a plan for approval.
@@ -69,7 +70,7 @@ Then enable the plugin in Obsidian under **Settings → Community plugins**.
 
 ## Usage
 
-Open the chat sidebar from the ribbon icon or command palette. Select text and use the inline-edit hotkey to edit notes with a diff preview. Use `/` for commands and skills, `@` to reference vault files or provider resources, and the provider selector to choose Claude, Codex, Cursor, Grok, OMP, OpenCode, or Pi.
+Open the chat sidebar from the ribbon icon or command palette. Select text and use the inline-edit hotkey to edit notes with a diff preview. Use `/` for commands and skills, `@` to reference vault files or provider resources, or drag files and folders into the composer to attach them as context chips. Click an attached file chip to open it in Obsidian. Use the provider selector to choose Claude, Codex, Cursor, Grok, OMP, OpenCode, or Pi.
 
 ### First run
 
@@ -118,11 +119,11 @@ Releases are created automatically by [`.github/workflows/release.yml`](.github/
 3. Create a tag that exactly matches the `manifest.json` version, for example:
 
    ```bash
-   git tag 2.1.10
-   git push origin 2.1.10
+   git tag 2.1.12
+   git push origin 2.1.12
    ```
 
-   If your writable remote is named `fork`, use `git push fork 2.1.10` instead.
+   If your writable remote is named `fork`, use `git push fork 2.1.12` instead.
 
 The workflow validates the version, builds the plugin, runs the performance check, generates release notes, and publishes `main.js`, `manifest.json`, and `styles.css` to the GitHub Release. These are the files used for the Obsidian Community Plugins release.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claudian",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claudian",
-      "version": "2.1.11",
+      "version": "2.1.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "description": "Oh My Claudian - provider-backed coding agents embedded in the Obsidian sidebar",
   "main": "main.js",
   "engines": {


### PR DESCRIPTION
## Summary
- document drag-and-drop file and folder attachments
- bump package, manifest, and lockfile versions to 2.1.12
- update release examples to use the new version

## Verification
- `node scripts/check-release-version.mjs 2.1.12`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`

Full local test run is blocked by sandbox restrictions on listening sockets and home-directory temp files; CI covers the full suite.