### PR TITLE
chore: prepare 2.1.13 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,11 @@ Releases are created automatically by [`.github/workflows/release.yml`](.github/
 3. Create a tag that exactly matches the `manifest.json` version, for example:
 
    ```bash
-   git tag 2.1.12
-   git push origin 2.1.12
+   git tag 2.1.13
+   git push origin 2.1.13
    ```
 
-   If your writable remote is named `fork`, use `git push fork 2.1.12` instead.
+   If your writable remote is named `fork`, use `git push fork 2.1.13` instead.
 
 The workflow validates the version, builds the plugin, runs the performance check, generates release notes, and publishes `main.js`, `manifest.json`, and `styles.css` to the GitHub Release. These are the files used for the Obsidian Community Plugins release.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claudian",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claudian",
-      "version": "2.1.12",
+      "version": "2.1.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "description": "Oh My Claudian - provider-backed coding agents embedded in the Obsidian sidebar",
   "main": "main.js",
   "engines": {


### PR DESCRIPTION
## Summary
- bump package, manifest, and lockfile versions to 2.1.13
- update the release tag example

This patch release includes the post-2.1.12 lint fix for file-drop overlay visibility.

## Verification
- `node scripts/check-release-version.mjs 2.1.13`
- `npm run typecheck`
- `npm run lint` (existing warnings only)
- `git diff --check`