### PR TITLE
fix: harden OMP and Cursor provider settings

### DIFF
--- a/src/providers/cursor/registration.ts
+++ b/src/providers/cursor/registration.ts
@@ -1,4 +1,6 @@
 import { NOOP_TASK_RESULT_INTERPRETER } from '../../core/providers/NoopTaskResultInterpreter';
+import { getProviderConfig } from '../../core/providers/providerConfig';
+import { hasStoredConfigNormalization } from '../../core/providers/settings/storedSettings';
 import type { ProviderModule } from '../../core/providers/types';
 import { cursorWorkspaceRegistration } from './app/CursorWorkspaceServices';
 import { CURSOR_PROVIDER_CAPABILITIES } from './capabilities';
@@ -23,8 +25,12 @@ export const cursorProviderRegistration: ProviderModule = {
   settingsStorage: {
     hostScopedFields: ['cliPathsByHost'],
     normalizeStored(target, stored) {
+      const storedConfig = getProviderConfig(stored, 'cursor');
       updateCursorProviderSettings(target, getCursorProviderSettings(stored));
-      return false;
+      return hasStoredConfigNormalization(
+        storedConfig,
+        getProviderConfig(target, 'cursor'),
+      );
     },
   },
   taskResultInterpreter: NOOP_TASK_RESULT_INTERPRETER,

--- a/src/providers/cursor/settings.ts
+++ b/src/providers/cursor/settings.ts
@@ -1,6 +1,10 @@
 import { getProviderConfig, setProviderConfig } from '../../core/providers/providerConfig';
 import { getProviderEnvironmentVariables } from '../../core/providers/providerEnvironment';
 import { normalizeHostnameStringMap } from '../../core/providers/settings/HostnameStringMap';
+import {
+  readStoredBoolean,
+  readStoredString,
+} from '../../core/providers/settings/storedSettings';
 import type { HostnameCliPaths } from '../../core/types/settings';
 import {
   type CursorDiscoveredModel,
@@ -34,15 +38,24 @@ export function getCursorProviderSettings(settings: Record<string, unknown>): Cu
   const config = getProviderConfig(settings, 'cursor');
   const discoveredModels = normalizeCursorDiscoveredModels(config.discoveredModels);
   return {
-    cliPath: typeof config.cliPath === 'string' ? config.cliPath : DEFAULT_CURSOR_PROVIDER_SETTINGS.cliPath,
+    cliPath: readStoredString(config.cliPath, DEFAULT_CURSOR_PROVIDER_SETTINGS.cliPath),
     cliPathsByHost: normalizeHostnameStringMap(config.cliPathsByHost),
-    enabled: config.enabled === true,
-    environmentHash: typeof config.environmentHash === 'string' ? config.environmentHash : '',
-    environmentVariables: typeof config.environmentVariables === 'string'
-      ? config.environmentVariables
-      : getProviderEnvironmentVariables(settings, 'cursor') ?? '',
+    enabled: readStoredBoolean(config.enabled, DEFAULT_CURSOR_PROVIDER_SETTINGS.enabled),
+    environmentHash: readStoredString(
+      config.environmentHash,
+      DEFAULT_CURSOR_PROVIDER_SETTINGS.environmentHash,
+    ),
+    environmentVariables: readStoredString(
+      config.environmentVariables,
+      getProviderEnvironmentVariables(settings, 'cursor')
+        ?? DEFAULT_CURSOR_PROVIDER_SETTINGS.environmentVariables,
+    ),
     discoveredModels,
-    catalogTimestamp: typeof config.catalogTimestamp === 'number' ? config.catalogTimestamp : 0,
+    catalogTimestamp: typeof config.catalogTimestamp === 'number'
+      && Number.isFinite(config.catalogTimestamp)
+      && config.catalogTimestamp >= 0
+      ? Math.floor(config.catalogTimestamp)
+      : DEFAULT_CURSOR_PROVIDER_SETTINGS.catalogTimestamp,
     visibleModels: normalizeCursorVisibleModels(config.visibleModels, discoveredModels),
   };
 }

--- a/src/providers/omp/registration.ts
+++ b/src/providers/omp/registration.ts
@@ -1,4 +1,6 @@
 import { NOOP_TASK_RESULT_INTERPRETER } from '../../core/providers/NoopTaskResultInterpreter';
+import { getProviderConfig } from '../../core/providers/providerConfig';
+import { hasStoredConfigNormalization } from '../../core/providers/settings/storedSettings';
 import type { ProviderModule } from '../../core/providers/types';
 import { ompWorkspaceRegistration } from './app/OmpWorkspaceServices';
 import { OMP_PROVIDER_CAPABILITIES } from './capabilities';
@@ -23,8 +25,12 @@ export const ompProviderRegistration: ProviderModule = {
   settingsStorage: {
     hostScopedFields: ['cliPathsByHost'],
     normalizeStored(target, stored) {
+      const storedConfig = getProviderConfig(stored, 'omp');
       updateOmpProviderSettings(target, getOmpProviderSettings(stored));
-      return false;
+      return hasStoredConfigNormalization(
+        storedConfig,
+        getProviderConfig(target, 'omp'),
+      );
     },
   },
   taskResultInterpreter: NOOP_TASK_RESULT_INTERPRETER,

--- a/src/providers/omp/settings.ts
+++ b/src/providers/omp/settings.ts
@@ -1,6 +1,10 @@
 import { getProviderConfig, setProviderConfig } from '../../core/providers/providerConfig';
 import { getProviderEnvironmentVariables } from '../../core/providers/providerEnvironment';
 import { normalizeHostnameStringMap } from '../../core/providers/settings/HostnameStringMap';
+import {
+  readStoredBoolean,
+  readStoredString,
+} from '../../core/providers/settings/storedSettings';
 import type { HostnameCliPaths } from '../../core/types/settings';
 import {
   normalizeOmpDiscoveredModels,
@@ -38,16 +42,25 @@ export function getOmpProviderSettings(settings: Record<string, unknown>): OmpPr
   const config = getProviderConfig(settings, 'omp');
   const discoveredModels = normalizeOmpDiscoveredModels(config.discoveredModels);
   return {
-    cliPath: typeof config.cliPath === 'string' ? config.cliPath : DEFAULT_OMP_PROVIDER_SETTINGS.cliPath,
+    cliPath: readStoredString(config.cliPath, DEFAULT_OMP_PROVIDER_SETTINGS.cliPath),
     cliPathsByHost: normalizeHostnameStringMap(config.cliPathsByHost),
-    enabled: config.enabled === true,
-    environmentHash: typeof config.environmentHash === 'string' ? config.environmentHash : '',
-    environmentVariables: typeof config.environmentVariables === 'string'
-      ? config.environmentVariables
-      : getProviderEnvironmentVariables(settings, 'omp') ?? '',
+    enabled: readStoredBoolean(config.enabled, DEFAULT_OMP_PROVIDER_SETTINGS.enabled),
+    environmentHash: readStoredString(
+      config.environmentHash,
+      DEFAULT_OMP_PROVIDER_SETTINGS.environmentHash,
+    ),
+    environmentVariables: readStoredString(
+      config.environmentVariables,
+      getProviderEnvironmentVariables(settings, 'omp')
+        ?? DEFAULT_OMP_PROVIDER_SETTINGS.environmentVariables,
+    ),
     thinking: normalizeOmpThinkingConfig(config.thinking),
     discoveredModels,
-    catalogTimestamp: typeof config.catalogTimestamp === 'number' ? config.catalogTimestamp : 0,
+    catalogTimestamp: typeof config.catalogTimestamp === 'number'
+      && Number.isFinite(config.catalogTimestamp)
+      && config.catalogTimestamp >= 0
+      ? Math.floor(config.catalogTimestamp)
+      : DEFAULT_OMP_PROVIDER_SETTINGS.catalogTimestamp,
     visibleModels: normalizeOmpVisibleModels(config.visibleModels, discoveredModels),
   };
 }

--- a/tests/unit/providers/ProviderModuleCatalog.test.ts
+++ b/tests/unit/providers/ProviderModuleCatalog.test.ts
@@ -83,7 +83,7 @@ describe('built-in ProviderModule catalog', () => {
         normalizedSettings,
         malformedSettings,
       );
-      expect(normalized).toBe(!['cursor', 'omp'].includes(module.id));
+      expect(normalized).toBe(true);
       const config = getProviderConfig(normalizedSettings, module.id);
       expect(config.enabled).toBe(defaultEnabled[module.id]);
       expect(config.cliPath).toEqual(expect.any(String));


### PR DESCRIPTION
## Summary
- normalize persisted OMP and Cursor scalar settings through provider-owned defaults
- reject invalid catalog timestamps instead of retaining unsafe values
- report settings normalization changes so malformed stored config is rewritten

## Context
This ports the useful provider-settings hardening from upstream #1069 and extends it to the fork-specific OMP and Cursor providers.

## Verification
- typecheck passed
- lint passed with existing warnings only
- targeted tests: 4 suites, 43 tests passed