### PR TITLE
sync: derive blocked tool status from provider outcomes

### DIFF
--- a/src/core/execution/ProviderExecutionEvent.ts
+++ b/src/core/execution/ProviderExecutionEvent.ts
@@ -150,6 +150,8 @@ export type ProviderToolCompletedEvent = ProviderEventBase<
   ProviderToolIdentity & {
     readonly content?: string;
     readonly isError?: boolean;
+    /** Authoritative provider outcome; never infer this from result content. */
+    readonly isBlocked?: boolean;
     readonly toolUseResult?: SDKToolUseResult;
     readonly providerPayload?: ToolProviderPayload;
   };

--- a/src/core/tools/toolNames.ts
+++ b/src/core/tools/toolNames.ts
@@ -61,18 +61,6 @@ export function isSubagentHiddenTool(name: string): boolean {
   return (SUBAGENT_HIDDEN_TOOLS as readonly string[]).includes(name);
 }
 
-// These tools resolve via dedicated callbacks (not content-based), so their
-// tool_result should never be marked "blocked" based on result text.
-export const TOOLS_SKIP_BLOCKED_DETECTION = [
-  TOOL_ENTER_PLAN_MODE,
-  TOOL_EXIT_PLAN_MODE,
-  TOOL_ASK_USER_QUESTION,
-] as const;
-
-export function skipsBlockedDetection(name: string): boolean {
-  return (TOOLS_SKIP_BLOCKED_DETECTION as readonly string[]).includes(name);
-}
-
 export const EDIT_TOOLS = [TOOL_WRITE, TOOL_EDIT, TOOL_NOTEBOOK_EDIT] as const;
 export type EditToolName = (typeof EDIT_TOOLS)[number];
 

--- a/src/core/types/chat.ts
+++ b/src/core/types/chat.ts
@@ -260,7 +260,14 @@ export type StreamChunk =
       input: Record<string, unknown>;
       providerPayload?: ToolProviderPayload;
     }
-  | { type: 'tool_result'; id: string; content: string; isError?: boolean; toolUseResult?: SDKToolUseResult }
+  | {
+      type: 'tool_result';
+      id: string;
+      content: string;
+      isError?: boolean;
+      isBlocked?: boolean;
+      toolUseResult?: SDKToolUseResult;
+    }
   | { type: 'tool_output'; id: string; content: string }
   | {
       type: 'error';
@@ -273,7 +280,15 @@ export type StreamChunk =
   | { type: 'usage'; usage: UsageInfo; sessionId?: string | null }
   | { type: 'context_compacted' }
   | { type: 'subagent_tool_use'; subagentId: string; id: string; name: string; input: Record<string, unknown> }
-  | { type: 'subagent_tool_result'; subagentId: string; id: string; content: string; isError?: boolean; toolUseResult?: SDKToolUseResult };
+  | {
+      type: 'subagent_tool_result';
+      subagentId: string;
+      id: string;
+      content: string;
+      isError?: boolean;
+      isBlocked?: boolean;
+      toolUseResult?: SDKToolUseResult;
+    };
 
 /**
  * Context window usage information.

--- a/src/features/chat/controllers/StreamController.ts
+++ b/src/features/chat/controllers/StreamController.ts
@@ -18,7 +18,6 @@ import { extractResolvedAnswers, extractResolvedAnswersFromResultText } from '..
 import {
   isEditTool,
   isWriteEditTool,
-  skipsBlockedDetection,
   TOOL_APPLY_PATCH,
   TOOL_ASK_USER_QUESTION,
   TOOL_SUBAGENT,
@@ -69,7 +68,6 @@ import {
 import {
   getToolName,
   getToolSummary,
-  isBlockedToolResult,
   renderToolCall,
   updateToolCallResult,
 } from '../rendering/ToolCallRenderer';
@@ -949,7 +947,14 @@ export class StreamController {
   }
 
   private async handleToolResult(
-    chunk: { type: 'tool_result'; id: string; content: string; isError?: boolean; toolUseResult?: SDKToolUseResult },
+    chunk: {
+      type: 'tool_result';
+      id: string;
+      content: string;
+      isError?: boolean;
+      isBlocked?: boolean;
+      toolUseResult?: SDKToolUseResult;
+    },
     msg: ChatMessage
   ): Promise<void> {
     const { state, subagentManager } = this.deps;
@@ -999,8 +1004,9 @@ export class StreamController {
 
     const existingToolCall = msg.toolCalls?.find(tc => tc.id === chunk.id);
 
-    // Regular tool result
-    const isBlocked = isBlockedToolResult(normalizedContent, chunk.isError);
+    // Completion outcomes come from the provider boundary. Result content is
+    // arbitrary user/tool data and must never be interpreted as status metadata.
+    const isBlocked = chunk.isBlocked === true;
 
     if (existingToolCall) {
       const providerPayload = extractToolProviderPayload(chunk.toolUseResult);
@@ -1010,16 +1016,10 @@ export class StreamController {
           ...providerPayload,
         };
       }
-      // Tools that resolve via dedicated callbacks (not content-based) skip
-      // blocked detection — their status is determined solely by isError
-      if (chunk.isError) {
-        existingToolCall.status = 'error';
-      } else if (
-        lifecycleAdapter?.protocol !== 'lifecycle'
-        && !skipsBlockedDetection(existingToolCall.name)
-        && isBlocked
-      ) {
+      if (isBlocked) {
         existingToolCall.status = 'blocked';
+      } else if (chunk.isError) {
+        existingToolCall.status = 'error';
       } else {
         existingToolCall.status = 'completed';
       }
@@ -1337,8 +1337,9 @@ export class StreamController {
         const toolCall = subagentState.info.toolCalls.find((tc: ToolCallInfo) => tc.id === chunk.id);
         if (toolCall) {
           const normalizedContent = this.normalizeToolResultContent(chunk.content);
-          const isBlocked = isBlockedToolResult(normalizedContent, chunk.isError);
-          toolCall.status = isBlocked ? 'blocked' : (chunk.isError ? 'error' : 'completed');
+          toolCall.status = chunk.isBlocked
+            ? 'blocked'
+            : (chunk.isError ? 'error' : 'completed');
           toolCall.result = normalizedContent;
           subagentManager.updateSyncToolResult(parentToolUseId, chunk.id, toolCall);
         }
@@ -2018,6 +2019,7 @@ export function providerOutputEventToStreamChunk(
           content: event.content ?? '',
           id: event.toolCallId,
           ...(event.isError !== undefined ? { isError: event.isError } : {}),
+          ...(event.isBlocked !== undefined ? { isBlocked: event.isBlocked } : {}),
           subagentId: event.toolScope.subagentId,
           ...(event.toolUseResult ? { toolUseResult: event.toolUseResult } : {}),
           type: 'subagent_tool_result',
@@ -2026,6 +2028,7 @@ export function providerOutputEventToStreamChunk(
           content: event.content ?? '',
           id: event.toolCallId,
           ...(event.isError !== undefined ? { isError: event.isError } : {}),
+          ...(event.isBlocked !== undefined ? { isBlocked: event.isBlocked } : {}),
           ...(event.toolUseResult ? { toolUseResult: event.toolUseResult } : {}),
           type: 'tool_result',
         };

--- a/src/features/chat/rendering/ToolCallRenderer.ts
+++ b/src/features/chat/rendering/ToolCallRenderer.ts
@@ -23,7 +23,6 @@ import {
   TOOL_WRITE,
   TOOL_WRITE_STDIN,
 } from '../../../core/tools/toolNames';
-import { extractToolResultContent } from '../../../core/tools/toolResultContent';
 import type { AskUserQuestionItem, AskUserQuestionOption, ToolCallInfo } from '../../../core/types';
 import type { DiffStats } from '../../../core/types/diff';
 import { appendMcpIcon } from '../../../shared/icons';
@@ -806,16 +805,6 @@ export function renderTodoWriteResult(
   }
 
   renderTodoItems(container, todos);
-}
-
-export function isBlockedToolResult(content: unknown, isError?: boolean): boolean {
-  const lower = extractToolResultContent(content, { fallbackIndent: 2 }).toLowerCase();
-  if (lower.includes('outside the vault')) return true;
-  if (lower.includes('access denied')) return true;
-  if (lower.includes('user denied')) return true;
-  if (lower.includes('approval')) return true;
-  if (isError && lower.includes('deny')) return true;
-  return false;
 }
 
 interface ToolElementStructure {

--- a/src/providers/acp/AcpExecutionEventNormalizer.ts
+++ b/src/providers/acp/AcpExecutionEventNormalizer.ts
@@ -200,6 +200,7 @@ export class AcpExecutionEventNormalizer {
               return [{
                 content: chunk.content,
                 isError: chunk.isError,
+                isBlocked: chunk.isBlocked,
                 scope: this.nextScope(),
                 toolCallId: chunk.id,
                 toolScope,

--- a/src/providers/acp/AcpExecutionEventNormalizer.ts
+++ b/src/providers/acp/AcpExecutionEventNormalizer.ts
@@ -43,6 +43,7 @@ export interface AcpExecutionEventNormalizerOptions {
     context: AcpToolScopeContext,
   ) => ToolExecutionScope;
   readonly mapUsage?: (usage: AcpUsageUpdate) => UsageInfo | null;
+  readonly isToolBlocked?: (toolCallId: string) => boolean;
   readonly toolStreamAdapter?: AcpToolStreamAdapter;
 }
 
@@ -200,7 +201,12 @@ export class AcpExecutionEventNormalizer {
               return [{
                 content: chunk.content,
                 isError: chunk.isError,
-                isBlocked: chunk.isBlocked,
+                ...(
+                  chunk.isBlocked === true
+                  || this.options.isToolBlocked?.(chunk.id) === true
+                    ? { isBlocked: true }
+                    : {}
+                ),
                 scope: this.nextScope(),
                 toolCallId: chunk.id,
                 toolScope,

--- a/src/providers/acp/AcpInteractionController.ts
+++ b/src/providers/acp/AcpInteractionController.ts
@@ -30,6 +30,7 @@ export interface AcpPermissionPresentation {
 export interface AcpInteractionControllerOptions {
   readonly getTurnId: () => string | null;
   readonly interactionPort: ProviderInteractionPort;
+  readonly onPermissionDenied?: (toolCallId: string) => void;
   readonly presentPermission?: (
     request: AcpRequestPermissionRequest,
     input: Readonly<Record<string, unknown>>,
@@ -108,7 +109,17 @@ export class AcpInteractionController {
       }
 
       this.dismiss(interactionId, 'resolved');
-      return mapAcpApprovalDecision(response.decision, request.options);
+      const mappedResponse = mapAcpApprovalDecision(response.decision, request.options);
+      const mappedOutcome = mappedResponse.outcome;
+      const rejectedOption = mappedOutcome.outcome === 'selected'
+        && request.options.find(option => option.optionId === mappedOutcome.optionId)?.kind.startsWith('reject');
+      if (
+        response.decision === 'deny'
+        || rejectedOption
+      ) {
+        this.options.onPermissionDenied?.(request.toolCall.toolCallId);
+      }
+      return mappedResponse;
     } catch {
       this.dismiss(interactionId, 'cancelled');
       return CANCELLED_RESPONSE;

--- a/src/providers/claude/execution/ClaudeExecutionEventNormalizer.ts
+++ b/src/providers/claude/execution/ClaudeExecutionEventNormalizer.ts
@@ -94,6 +94,7 @@ interface NormalizationState {
   readonly taskToolNormalizer: ClaudeTaskToolNormalizer;
   readonly usageState: ReturnType<typeof createTransformUsageState>;
   readonly toolScopes: Map<string, ToolIdentity>;
+  readonly blockedToolIds: Set<string>;
   assistantStarted: boolean;
   sawStreamText: boolean;
   sawStreamThinking: boolean;
@@ -159,12 +160,20 @@ export class ClaudeExecutionEventNormalizer {
     return normalized;
   }
 
+  markToolBlocked(
+    toolUseId: string,
+    channel: ClaudeExecutionEventChannel,
+  ): void {
+    this.states[channel].blockedToolIds.add(toolUseId);
+  }
+
   reset(channel: ClaudeExecutionEventChannel): void {
     const state = this.states[channel];
     state.streamState.clearAll();
     state.taskToolNormalizer.reset();
     state.usageState.clear();
     state.toolScopes.clear();
+    state.blockedToolIds.clear();
     state.assistantStarted = false;
     state.sawStreamText = false;
     state.sawStreamThinking = false;
@@ -248,6 +257,7 @@ function createNormalizationState(): NormalizationState {
     taskToolNormalizer: new ClaudeTaskToolNormalizer(),
     usageState: createTransformUsageState(),
     toolScopes: new Map(),
+    blockedToolIds: new Set(),
     assistantStarted: false,
     sawStreamText: false,
     sawStreamThinking: false,
@@ -396,6 +406,9 @@ function normalizeToolCompleted(
     | Extract<StreamChunk, { type: 'subagent_tool_result' }>,
   state: NormalizationState,
 ): ClaudeNormalizedOutputEvent {
+  if (chunk.isBlocked) {
+    state.blockedToolIds.add(chunk.id);
+  }
   const identity = state.toolScopes.get(chunk.id) ?? (
     chunk.type === 'subagent_tool_result'
       ? {
@@ -413,6 +426,7 @@ function normalizeToolCompleted(
     ...identity,
     content: chunk.content,
     isError: chunk.isError,
+    isBlocked: state.blockedToolIds.has(chunk.id),
     toolUseResult: chunk.toolUseResult,
   };
 }

--- a/src/providers/claude/execution/ClaudeExecutionSession.ts
+++ b/src/providers/claude/execution/ClaudeExecutionSession.ts
@@ -161,6 +161,12 @@ ClaudeExecutionStrategySink {
       getPermissionMode: () => this.currentPermissionMode,
       resolveSdkPermissionMode: (mode) =>
         this.encoder.resolveSdkPermissionMode(mode),
+      onToolBlocked: (toolUseId) => {
+        this.eventNormalizer.markToolBlocked(
+          toolUseId,
+          this.activeRun ? 'requested' : 'background',
+        );
+      },
     });
     this.strategy = config.lifecycle === 'persistent'
       ? new ClaudePersistentExecutionStrategy(this)

--- a/src/providers/claude/execution/ClaudeInteractionHandler.ts
+++ b/src/providers/claude/execution/ClaudeInteractionHandler.ts
@@ -25,6 +25,7 @@ export interface ClaudeExecutionInteractionDeps {
   readonly resolveSdkPermissionMode: (
     mode: PermissionMode,
   ) => SDKPermissionMode;
+  readonly onToolBlocked: (toolUseId: string) => void;
 }
 
 export class ClaudeInteractionHandler {
@@ -177,6 +178,7 @@ export class ClaudeInteractionHandler {
           ),
         };
       }
+      this.deps.onToolBlocked(options.toolUseID);
       return {
         behavior: 'deny',
         message: 'User denied this action.',

--- a/src/providers/claude/stream/transformClaudeMessage.ts
+++ b/src/providers/claude/stream/transformClaudeMessage.ts
@@ -14,7 +14,13 @@ import { isDefaultClaudeModel, resolveContextWindowSize } from '../types/models'
 import { createTransformStreamState, type TransformStreamState } from './toolInputStreamState';
 
 type ToolUseFields = { id: string; name: string; input: Record<string, unknown> };
-type ToolResultFields = { id: string; content: string; isError?: boolean; toolUseResult?: SDKToolUseResult };
+type ToolResultFields = {
+  id: string;
+  content: string;
+  isError?: boolean;
+  isBlocked?: boolean;
+  toolUseResult?: SDKToolUseResult;
+};
 type AsyncSubagentCompletionStatus = ClaudeAsyncSubagentCompletionEvent['status'];
 
 export { createTransformStreamState };
@@ -413,6 +419,13 @@ export function* transformSDKMessage(
         if (notification) {
           yield notification;
         }
+      } else if (message.subtype === 'permission_denied') {
+        yield emitToolResult(message.agent_id ?? null, {
+          id: message.tool_use_id,
+          content: message.message,
+          isError: true,
+          isBlocked: true,
+        });
       }
       break;
 

--- a/src/providers/codex/execution/CodexExecutionEventAdapter.ts
+++ b/src/providers/codex/execution/CodexExecutionEventAdapter.ts
@@ -54,6 +54,7 @@ export function adaptCodexStreamChunk(
         toolScope: { kind: 'main' },
         content: chunk.content,
         ...(chunk.isError !== undefined ? { isError: chunk.isError } : {}),
+        ...(chunk.isBlocked !== undefined ? { isBlocked: chunk.isBlocked } : {}),
         ...(chunk.toolUseResult ? { toolUseResult: chunk.toolUseResult } : {}),
       };
     case 'usage':
@@ -88,6 +89,7 @@ export function adaptCodexStreamChunk(
         toolScope: { kind: 'subagent', subagentId: chunk.subagentId },
         content: chunk.content,
         ...(chunk.isError !== undefined ? { isError: chunk.isError } : {}),
+        ...(chunk.isBlocked !== undefined ? { isBlocked: chunk.isBlocked } : {}),
         ...(chunk.toolUseResult ? { toolUseResult: chunk.toolUseResult } : {}),
       };
     case 'error':

--- a/src/providers/codex/runtime/CodexNotificationRouter.ts
+++ b/src/providers/codex/runtime/CodexNotificationRouter.ts
@@ -1418,16 +1418,17 @@ export class CodexNotificationRouter {
     const normalizedName = normalizeCodexToolName('command_execution');
     const output = item.aggregatedOutput ?? '';
     const content = rawResult?.content ?? normalizeCodexToolResult(normalizedName, output);
-    const isError = item.exitCode !== null
+    const isDeclined = item.status === 'declined';
+    const isError = isDeclined || (item.exitCode !== null
       ? item.exitCode !== 0
-      : rawResult?.isError ?? isCodexToolOutputError(output);
+      : rawResult?.isError ?? isCodexToolOutputError(output));
 
     this.emit({
       type: 'tool_result',
       id: resultId,
       content,
       isError,
-      ...(item.status === 'declined' ? { isBlocked: true } : {}),
+      ...(isDeclined ? { isBlocked: true } : {}),
     });
   }
 

--- a/src/providers/codex/runtime/CodexNotificationRouter.ts
+++ b/src/providers/codex/runtime/CodexNotificationRouter.ts
@@ -1422,7 +1422,13 @@ export class CodexNotificationRouter {
       ? item.exitCode !== 0
       : rawResult?.isError ?? isCodexToolOutputError(output);
 
-    this.emit({ type: 'tool_result', id: resultId, content, isError });
+    this.emit({
+      type: 'tool_result',
+      id: resultId,
+      content,
+      isError,
+      ...(item.status === 'declined' ? { isBlocked: true } : {}),
+    });
   }
 
   // -- fileChange -------------------------------------------------------------
@@ -1457,6 +1463,7 @@ export class CodexNotificationRouter {
       id: item.id,
       content: paths || 'File change completed',
       isError: item.status === 'failed' || item.status === 'declined',
+      ...(item.status === 'declined' ? { isBlocked: true } : {}),
     });
   }
 

--- a/src/providers/grok/execution/GrokExecutionSession.ts
+++ b/src/providers/grok/execution/GrokExecutionSession.ts
@@ -202,6 +202,7 @@ RewindableExecutionSession {
   private nativeStartupFlight: Promise<GrokExecutionNativeConnection> | null = null;
   private quarantineGeneration = 0;
   private readonly interactionController: AcpInteractionController;
+  private readonly blockedToolCallIds = new Set<string>();
   private readonly interactionRouter: GrokExecutionInteractionRouter;
   private readonly listeners = new Set<(event: ProviderSessionEvent) => void>();
   private readonly mirrorDeduplicator = new GrokSessionNotificationMirrorDeduplicator();
@@ -230,6 +231,7 @@ RewindableExecutionSession {
     this.interactionController = new AcpInteractionController({
       getTurnId: () => this.active?.run.turnId ?? null,
       interactionPort: config.interactionPort,
+      onPermissionDenied: toolCallId => this.blockedToolCallIds.add(toolCallId),
       sessionInstanceId: this.sessionInstanceId,
     });
     this.interactionRouter = new GrokExecutionInteractionRouter(
@@ -243,6 +245,7 @@ RewindableExecutionSession {
   execute(request: ProviderExecutionRequest): ProviderExecutionRun {
     if (this.disposed) throw new Error('Grok execution session is disposed.');
     if (this.active) throw new Error('Grok execution session is already executing.');
+    this.blockedToolCallIds.clear();
     const run = new GrokExecutionRunState(
       randomUUID(),
       randomUUID(),
@@ -255,6 +258,7 @@ RewindableExecutionSession {
       cancellationGeneration: this.cancellationGeneration,
       normalizer: new AcpExecutionEventNormalizer({
         mapUsage: usage => buildAcpUsageInfo({ contextWindow: usage }),
+        isToolBlocked: toolCallId => this.blockedToolCallIds.has(toolCallId),
         scope: {
           executionId: run.executionId,
           kind: 'requested',

--- a/src/providers/omp/execution/OmpAcpSessionKernel.ts
+++ b/src/providers/omp/execution/OmpAcpSessionKernel.ts
@@ -30,6 +30,7 @@ export interface OmpAcpSessionKernelOptions {
   readonly getActiveTurnId: () => string | null;
   readonly onClosed: (error: Error) => void;
   readonly onNotification: (notification: AcpSessionNotification) => void;
+  readonly onPermissionDenied?: (toolCallId: string) => void;
   readonly plugin: ProviderHost;
 }
 
@@ -93,6 +94,7 @@ export class DefaultOmpAcpSessionKernel implements OmpAcpSessionKernel {
     this.interaction = new AcpInteractionController({
       getTurnId: this.options.getActiveTurnId,
       interactionPort: this.options.config.interactionPort,
+      onPermissionDenied: this.options.onPermissionDenied,
       presentPermission: presentOmpPermission,
       sessionInstanceId: 'omp',
     });

--- a/src/providers/omp/execution/OmpExecutionSession.ts
+++ b/src/providers/omp/execution/OmpExecutionSession.ts
@@ -114,6 +114,7 @@ export class OmpExecutionSession implements ProviderExecutionSession {
   readonly sessionInstanceId = randomUUID();
   private readonly createKernel: (options: OmpAcpSessionKernelOptions) => OmpAcpSessionKernel;
   private readonly listeners = new Set<(event: ProviderSessionEvent) => void>();
+  private readonly blockedToolCallIds = new Set<string>();
   private kernel: OmpAcpSessionKernel | null = null;
   private nativeSessionId: string | null;
   private activeRun: OmpExecutionRun | null = null;
@@ -163,6 +164,7 @@ export class OmpExecutionSession implements ProviderExecutionSession {
   }
 
   private async startRun(run: OmpExecutionRun, request: ProviderExecutionRequest): Promise<void> {
+    this.blockedToolCallIds.clear();
     try {
       if (!this.kernel) {
         this.kernel = this.createKernel({
@@ -176,6 +178,7 @@ export class OmpExecutionSession implements ProviderExecutionSession {
             const activeRun = this.activeRun;
             if (activeRun) this.handleNotification(activeRun, notification);
           },
+          onPermissionDenied: toolCallId => this.blockedToolCallIds.add(toolCallId),
           plugin: this.plugin,
         });
         await this.kernel.connect();
@@ -190,6 +193,7 @@ export class OmpExecutionSession implements ProviderExecutionSession {
           usage,
           decodeOmpModelId(request.configuration.model ?? '') ?? undefined,
         ),
+        isToolBlocked: toolCallId => this.blockedToolCallIds.has(toolCallId),
         scope: {
           executionId: run.executionId,
           kind: 'requested',

--- a/src/providers/opencode/execution/OpencodeAcpSessionKernel.ts
+++ b/src/providers/opencode/execution/OpencodeAcpSessionKernel.ts
@@ -61,6 +61,7 @@ export interface OpencodeAcpSessionKernelOptions {
   readonly getActiveTurnId: () => string | null;
   readonly onClosed: (error: Error) => void;
   readonly onNotification: (notification: AcpSessionNotification) => void;
+  readonly onPermissionDenied?: (toolCallId: string) => void;
   readonly plugin: ProviderHost;
   readonly sessionInstanceId: string;
 }
@@ -243,9 +244,10 @@ export class DefaultOpencodeAcpSessionKernel
         }
       });
 
-      this.interactionController = new AcpInteractionController({
-        getTurnId: this.options.getActiveTurnId,
-        interactionPort: this.options.config.interactionPort,
+    this.interactionController = new AcpInteractionController({
+      getTurnId: this.options.getActiveTurnId,
+      interactionPort: this.options.config.interactionPort,
+      onPermissionDenied: this.options.onPermissionDenied,
         presentPermission: presentOpencodePermission,
         sessionInstanceId: this.options.sessionInstanceId,
       });

--- a/src/providers/opencode/execution/OpencodeExecutionSession.ts
+++ b/src/providers/opencode/execution/OpencodeExecutionSession.ts
@@ -160,6 +160,7 @@ export class OpencodeExecutionSession implements ProviderExecutionSession {
 
   private readonly createKernel: OpencodeAcpSessionKernelFactory;
   private readonly listeners = new Set<(event: ProviderSessionEvent) => void>();
+  private readonly blockedToolCallIds = new Set<string>();
   private activeRun: OpencodeExecutionRun | null = null;
   private kernel: OpencodeAcpSessionKernel | null = null;
   private kernelGeneration = 0;
@@ -204,6 +205,7 @@ export class OpencodeExecutionSession implements ProviderExecutionSession {
       (active) => this.cancelRun(active),
     );
     this.activeRun = run;
+    this.blockedToolCallIds.clear();
     const onAbort = () => run.cancel();
     request.signal.addEventListener('abort', onAbort, { once: true });
     run.abortCleanup = () => request.signal.removeEventListener('abort', onAbort);
@@ -300,6 +302,7 @@ export class OpencodeExecutionSession implements ProviderExecutionSession {
               );
             }
           },
+          onPermissionDenied: toolCallId => this.blockedToolCallIds.add(toolCallId),
           plugin: this.plugin,
           sessionInstanceId: this.sessionInstanceId,
         });
@@ -460,6 +463,7 @@ export class OpencodeExecutionSession implements ProviderExecutionSession {
           model: this.resolveSelectedRawModelId(undefined) ?? undefined,
           promptUsage: null,
         }),
+        isToolBlocked: toolCallId => this.blockedToolCallIds.has(toolCallId),
         scope: {
           executionId: run.executionId,
           kind: 'requested',

--- a/src/providers/pi/execution/PiExecutionSession.ts
+++ b/src/providers/pi/execution/PiExecutionSession.ts
@@ -788,6 +788,7 @@ implements ProviderExecutionSession, SteerableExecutionSession {
         this.emitRequested(active, {
           content: chunk.content,
           isError: chunk.isError,
+          isBlocked: chunk.isBlocked,
           toolCallId: chunk.id,
           toolScope: { kind: 'main' },
           toolUseResult: chunk.toolUseResult,

--- a/tests/unit/core/tools/toolNames.test.ts
+++ b/tests/unit/core/tools/toolNames.test.ts
@@ -14,16 +14,12 @@ import {
   isWriteEditTool,
   MCP_TOOLS,
   READ_ONLY_TOOLS,
-  skipsBlockedDetection,
   // Constants
   TOOL_AGENT_OUTPUT,
-  TOOL_ASK_USER_QUESTION,
   TOOL_BASH,
   TOOL_BASH_OUTPUT,
   TOOL_CLOSE_AGENT,
   TOOL_EDIT,
-  TOOL_ENTER_PLAN_MODE,
-  TOOL_EXIT_PLAN_MODE,
   TOOL_GLOB,
   TOOL_GREP,
   TOOL_KILL_SHELL,
@@ -45,7 +41,6 @@ import {
   TOOL_WEB_FETCH,
   TOOL_WEB_SEARCH,
   TOOL_WRITE,
-  TOOLS_SKIP_BLOCKED_DETECTION,
   WRITE_EDIT_TOOLS,
 } from '@/core/tools/toolNames';
 
@@ -397,43 +392,5 @@ describe('isReadOnlyTool', () => {
 
   it('should return false for unknown tool', () => {
     expect(isReadOnlyTool('UnknownTool')).toBe(false);
-  });
-});
-
-describe('TOOLS_SKIP_BLOCKED_DETECTION', () => {
-  it('should contain EnterPlanMode, ExitPlanMode, and AskUserQuestion', () => {
-    expect(TOOLS_SKIP_BLOCKED_DETECTION).toContain(TOOL_ENTER_PLAN_MODE);
-    expect(TOOLS_SKIP_BLOCKED_DETECTION).toContain(TOOL_EXIT_PLAN_MODE);
-    expect(TOOLS_SKIP_BLOCKED_DETECTION).toContain(TOOL_ASK_USER_QUESTION);
-    expect(TOOLS_SKIP_BLOCKED_DETECTION).toHaveLength(3);
-  });
-});
-
-describe('skipsBlockedDetection', () => {
-  it('should return true for EnterPlanMode', () => {
-    expect(skipsBlockedDetection('EnterPlanMode')).toBe(true);
-  });
-
-  it('should return true for ExitPlanMode', () => {
-    expect(skipsBlockedDetection('ExitPlanMode')).toBe(true);
-  });
-
-  it('should return true for AskUserQuestion', () => {
-    expect(skipsBlockedDetection('AskUserQuestion')).toBe(true);
-  });
-
-  it('should return false for regular tools', () => {
-    expect(skipsBlockedDetection('Read')).toBe(false);
-    expect(skipsBlockedDetection('Bash')).toBe(false);
-    expect(skipsBlockedDetection('Write')).toBe(false);
-  });
-
-  it('should return false for empty string', () => {
-    expect(skipsBlockedDetection('')).toBe(false);
-  });
-
-  it('should be case-sensitive', () => {
-    expect(skipsBlockedDetection('enterplanmode')).toBe(false);
-    expect(skipsBlockedDetection('EXITPLANMODE')).toBe(false);
   });
 });

--- a/tests/unit/features/chat/controllers/StreamController.test.ts
+++ b/tests/unit/features/chat/controllers/StreamController.test.ts
@@ -60,7 +60,6 @@ jest.mock('@/features/chat/rendering/ThinkingBlockRenderer', () => ({
 jest.mock('@/features/chat/rendering/ToolCallRenderer', () => ({
   getToolName: jest.fn().mockReturnValue('Read'),
   getToolSummary: jest.fn().mockReturnValue('file.md'),
-  isBlockedToolResult: jest.fn().mockReturnValue(false),
   renderToolCall: jest.fn(),
   updateToolCallResult: jest.fn(),
 }));
@@ -591,6 +590,32 @@ describe('StreamController - Text Content', () => {
           }],
         },
       );
+    });
+  });
+
+  describe('tool completion outcome mapping', () => {
+    it('preserves an authoritative blocked outcome from provider events', () => {
+      expect(providerOutputEventToStreamChunk({
+        type: 'tool_completed',
+        scope: {
+          kind: 'requested',
+          sessionInstanceId: 'session-1',
+          executionId: 'execution-1',
+          turnId: 'turn-1',
+          sequence: 1,
+        },
+        toolCallId: 'tool-1',
+        toolScope: { kind: 'main' },
+        content: 'The tool was not run.',
+        isError: true,
+        isBlocked: true,
+      })).toEqual({
+        type: 'tool_result',
+        id: 'tool-1',
+        content: 'The tool was not run.',
+        isError: true,
+        isBlocked: true,
+      });
     });
   });
 
@@ -3147,8 +3172,6 @@ describe('StreamController - Text Content', () => {
     });
 
     it('does not infer list_agents status from nested agent result prose', async () => {
-      const { isBlockedToolResult } = jest.requireMock('@/features/chat/rendering/ToolCallRenderer');
-      (isBlockedToolResult as jest.Mock).mockReturnValueOnce(true);
       const msg = createTestMessage();
       deps.getProviderId = () => 'codex';
       msg.toolCalls = [{
@@ -4286,7 +4309,7 @@ describe('StreamController - Plan Mode', () => {
     });
   });
 
-  describe('blocked detection bypass', () => {
+  describe('tool completion outcomes', () => {
     it('persists provider payload from an incomplete tool stream without changing presentation', async () => {
       const rawInput = ['opaque', { nested: true }];
       const rawOutput = { partial: { bytes: [1, 2, 3] } };
@@ -4377,10 +4400,7 @@ describe('StreamController - Plan Mode', () => {
       expect(msg.toolCalls![0].resolvedAnswers).toEqual({ 'Color?': 'Blue' });
     });
 
-    it('should not mark AskUserQuestion as blocked even when result looks blocked', async () => {
-      const { isBlockedToolResult } = jest.requireMock('@/features/chat/rendering/ToolCallRenderer');
-      (isBlockedToolResult as jest.Mock).mockReturnValueOnce(true);
-
+    it('should not infer AskUserQuestion status from result text', async () => {
       const msg = createTestMessage();
       msg.toolCalls = [{
         id: 'ask-1',
@@ -4397,10 +4417,7 @@ describe('StreamController - Plan Mode', () => {
       expect(msg.toolCalls![0].status).toBe('completed');
     });
 
-    it('should not mark ExitPlanMode as blocked even when result looks blocked', async () => {
-      const { isBlockedToolResult } = jest.requireMock('@/features/chat/rendering/ToolCallRenderer');
-      (isBlockedToolResult as jest.Mock).mockReturnValueOnce(true);
-
+    it('should not infer ExitPlanMode status from result text', async () => {
       const msg = createTestMessage();
       msg.toolCalls = [{
         id: 'exit-1',
@@ -4417,10 +4434,24 @@ describe('StreamController - Plan Mode', () => {
       expect(msg.toolCalls![0].status).toBe('completed');
     });
 
-    it('should mark regular tool as blocked when result is blocked', async () => {
-      const { isBlockedToolResult } = jest.requireMock('@/features/chat/rendering/ToolCallRenderer');
-      (isBlockedToolResult as jest.Mock).mockReturnValueOnce(true);
+    it('should complete a successful Read whose file content discusses approval', async () => {
+      const msg = createTestMessage();
+      msg.toolCalls = [{
+        id: 'read-1',
+        name: 'Read',
+        input: { file_path: 'repro-a.md' },
+        status: 'running',
+      }];
 
+      await controller.handleStreamChunk(
+        { type: 'tool_result', id: 'read-1', content: 'wait for explicit approval' },
+        msg
+      );
+
+      expect(msg.toolCalls![0].status).toBe('completed');
+    });
+
+    it('should mark a tool as blocked only when the provider reports that outcome', async () => {
       const msg = createTestMessage();
       msg.toolCalls = [{
         id: 'bash-1',
@@ -4430,7 +4461,12 @@ describe('StreamController - Plan Mode', () => {
       }];
 
       await controller.handleStreamChunk(
-        { type: 'tool_result', id: 'bash-1', content: 'Access denied by user approval' },
+        {
+          type: 'tool_result',
+          id: 'bash-1',
+          content: 'The tool was not run.',
+          isBlocked: true,
+        },
         msg
       );
 

--- a/tests/unit/features/chat/rendering/ToolCallRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/ToolCallRenderer.test.ts
@@ -6,7 +6,6 @@ import {
   getToolLabel,
   getToolName,
   getToolSummary,
-  isBlockedToolResult,
   renderStoredToolCall,
   renderTodoWriteResult,
   renderToolCall,
@@ -906,33 +905,6 @@ describe('ToolCallRenderer', () => {
 
       expect(lines).toContain('src/main.ts');
       expect(lines).not.toContain('update: src/main.ts');
-    });
-  });
-
-  describe('isBlockedToolResult', () => {
-    it.each([
-      'Path is outside the vault',
-      'Access Denied for this file',
-      'User denied the action',
-      'Requires approval from user',
-    ])('should detect blocked result: %s', (result) => {
-      expect(isBlockedToolResult(result)).toBe(true);
-    });
-
-    it('should detect "deny" only when isError is true', () => {
-      expect(isBlockedToolResult('deny permission', true)).toBe(true);
-      expect(isBlockedToolResult('deny permission', false)).toBe(false);
-      expect(isBlockedToolResult('deny permission')).toBe(false);
-    });
-
-    it('should return false for normal results', () => {
-      expect(isBlockedToolResult('File content here')).toBe(false);
-    });
-
-    it('extracts text from structured content blocks before blocked detection', () => {
-      expect(isBlockedToolResult([
-        { type: 'text', text: 'Requires approval from user' },
-      ])).toBe(true);
     });
   });
 

--- a/tests/unit/providers/acp/AcpExecutionEventNormalizer.test.ts
+++ b/tests/unit/providers/acp/AcpExecutionEventNormalizer.test.ts
@@ -177,6 +177,33 @@ describe('AcpExecutionEventNormalizer', () => {
     }));
   });
 
+  it('marks a denied ACP tool result as blocked through the provider boundary', () => {
+    const normalizer = new AcpExecutionEventNormalizer({
+      isToolBlocked: toolCallId => toolCallId === 'tool-1',
+      scope: {
+        executionId: 'execution-1',
+        kind: 'requested',
+        sessionInstanceId: 'session-instance-1',
+        turnId: 'turn-1',
+      },
+    });
+
+    const result = normalizer.normalize({
+      rawInput: { path: 'README.md' },
+      sessionUpdate: 'tool_call',
+      status: 'failed',
+      title: 'Read',
+      toolCallId: 'tool-1',
+    });
+
+    expect(result.events).toContainEqual(expect.objectContaining({
+      isBlocked: true,
+      isError: true,
+      toolCallId: 'tool-1',
+      type: 'tool_completed',
+    }));
+  });
+
   it('preserves unknown forward-compatible updates in an opaque notice payload', () => {
     const normalizer = new AcpExecutionEventNormalizer({
       scope: {

--- a/tests/unit/providers/acp/AcpInteractionController.test.ts
+++ b/tests/unit/providers/acp/AcpInteractionController.test.ts
@@ -100,6 +100,45 @@ describe('AcpInteractionController', () => {
     );
   });
 
+  it('reports a denied permission so the matching tool result can become blocked', async () => {
+    const port = createPort();
+    port.requestApproval.mockImplementation(async (request) => ({
+      decision: 'deny',
+      interactionId: request.interactionId,
+    }));
+    const onPermissionDenied = jest.fn();
+    const controller = new AcpInteractionController({
+      getTurnId: () => 'turn-1',
+      interactionPort: port,
+      onPermissionDenied,
+      sessionInstanceId: 'session-instance-1',
+    });
+
+    await expect(controller.requestPermission(PERMISSION_REQUEST)).resolves.toEqual({
+      outcome: { optionId: 'reject', outcome: 'selected' },
+    });
+    expect(onPermissionDenied).toHaveBeenCalledWith('tool-1');
+  });
+
+  it('does not classify an explicitly cancelled approval as blocked', async () => {
+    const port = createPort();
+    port.requestApproval.mockImplementation(async (request) => ({
+      decision: 'cancel',
+      interactionId: request.interactionId,
+    }));
+    const onPermissionDenied = jest.fn();
+    const controller = new AcpInteractionController({
+      getTurnId: () => 'turn-1',
+      interactionPort: port,
+      onPermissionDenied,
+      sessionInstanceId: 'session-instance-1',
+    });
+
+    await controller.requestPermission(PERMISSION_REQUEST);
+
+    expect(onPermissionDenied).not.toHaveBeenCalled();
+  });
+
   it('cancels stale or cross-turn resolutions instead of applying them', async () => {
     let turnId = 'turn-1';
     let resolveApproval!: (value: {

--- a/tests/unit/providers/claude/execution/ClaudeExecutionEventNormalizer.test.ts
+++ b/tests/unit/providers/claude/execution/ClaudeExecutionEventNormalizer.test.ts
@@ -6,6 +6,33 @@ import { ClaudeExecutionEventNormalizer } from '@/providers/claude/execution/Cla
 const msg = buildSDKMessage;
 
 describe('ClaudeExecutionEventNormalizer task tools', () => {
+  it('preserves a blocked decision for the matching native tool result', () => {
+    const normalizer = new ClaudeExecutionEventNormalizer();
+    normalizer.markToolBlocked('tool-1', 'requested');
+
+    const events = normalizer.normalize(msg({
+      type: 'user',
+      message: {
+        content: [{
+          type: 'tool_result',
+          tool_use_id: 'tool-1',
+          content: 'The tool was not run.',
+          is_error: true,
+        }],
+      },
+    }), 'requested');
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'output',
+      event: expect.objectContaining({
+        type: 'tool_completed',
+        toolCallId: 'tool-1',
+        isError: true,
+        isBlocked: true,
+      }),
+    }));
+  });
+
   it('adapts main-thread task mutations and preserves native payloads', () => {
     const normalizer = new ClaudeExecutionEventNormalizer();
 

--- a/tests/unit/providers/claude/execution/ClaudeInteractionHandler.test.ts
+++ b/tests/unit/providers/claude/execution/ClaudeInteractionHandler.test.ts
@@ -23,6 +23,7 @@ function createPort(): jest.Mocked<ProviderInteractionPort> {
 
 function createHandler(
   port: jest.Mocked<ProviderInteractionPort>,
+  onToolBlocked: jest.Mock = jest.fn(),
 ): CanUseTool {
   return createClaudeExecutionCanUseTool({
     interactionPort: port,
@@ -31,6 +32,7 @@ function createHandler(
     isToolAllowed: () => true,
     getPermissionMode: () => 'normal',
     resolveSdkPermissionMode: () => 'default',
+    onToolBlocked,
   });
 }
 
@@ -68,6 +70,25 @@ describe('createClaudeExecutionCanUseTool', () => {
       'claude:session-local:native-tool-1',
       'resolved',
     );
+  });
+
+  it('reports a denied approval against its native tool identity', async () => {
+    const port = createPort();
+    port.requestApproval.mockImplementation(async (request) => ({
+      interactionId: request.interactionId,
+      decision: 'deny',
+    }));
+    const onToolBlocked = jest.fn();
+    const handler = createHandler(port, onToolBlocked);
+
+    const result = await handler('Bash', { command: 'rm -rf /' }, nativeOptions);
+
+    expect(result).toEqual({
+      behavior: 'deny',
+      message: 'User denied this action.',
+      interrupt: false,
+    });
+    expect(onToolBlocked).toHaveBeenCalledWith('native-tool-1');
   });
 
   it('routes questions and injects Claude Code compatible custom-answer support', async () => {
@@ -128,8 +149,9 @@ describe('createClaudeExecutionCanUseTool', () => {
       sessionInstanceId: 'session-local',
       getTurnId: () => 'turn-local',
       isToolAllowed: (toolName) => toolName === 'Read',
-    getPermissionMode: () => 'normal',
+      getPermissionMode: () => 'normal',
       resolveSdkPermissionMode: () => 'default',
+      onToolBlocked: jest.fn(),
     });
 
     const result = await handler('Edit', {}, nativeOptions);

--- a/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
+++ b/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
@@ -41,6 +41,29 @@ describe('transformSDKMessage', () => {
       expect(results).toEqual([]);
     });
 
+    it('emits an authoritative blocked tool result for permission denials', () => {
+      const message = {
+        type: 'system',
+        subtype: 'permission_denied',
+        tool_name: 'Bash',
+        tool_use_id: 'tool-123',
+        decision_reason: 'Denied by policy',
+        message: 'The tool was not run.',
+        uuid: 'message-123',
+        session_id: 'test-session',
+      } as any;
+
+      const results = [...transformSDKMessage(message)];
+
+      expect(results).toEqual([{
+        type: 'tool_result',
+        id: 'tool-123',
+        content: 'The tool was not run.',
+        isError: true,
+        isBlocked: true,
+      }]);
+    });
+
     it('yields context_compacted event for compact_boundary subtype', () => {
       const message = msg({
         type: 'system',

--- a/tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts
@@ -3280,6 +3280,26 @@ describe('CodexNotificationRouter', () => {
       ]);
     });
 
+    it('marks a declined file change result as blocked', () => {
+      router.handleNotification('item/completed', {
+        item: {
+          type: 'fileChange',
+          id: 'call_fc_declined',
+          status: 'declined',
+          changes: [{ path: '/workspace/foo.ts', type: 'modify' }],
+        },
+        threadId: 't1',
+        turnId: 'turn1',
+      });
+
+      expect(chunks).toContainEqual(expect.objectContaining({
+        id: 'call_fc_declined',
+        isBlocked: true,
+        isError: true,
+        type: 'tool_result',
+      }));
+    });
+
     it('maps fileChange patchUpdated diffs into apply_patch tool input', () => {
       router.handleNotification('item/fileChange/patchUpdated', {
         threadId: 't1',

--- a/tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts
@@ -3300,6 +3300,33 @@ describe('CodexNotificationRouter', () => {
       }));
     });
 
+    it('marks a declined command result as both blocked and error', () => {
+      router.handleNotification('item/completed', {
+        item: {
+          type: 'commandExecution',
+          id: 'call_command_declined',
+          command: 'rm -rf workspace',
+          cwd: '/workspace',
+          processId: 'process-1',
+          source: 'shell',
+          status: 'declined',
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+        threadId: 't1',
+        turnId: 'turn1',
+      });
+
+      expect(chunks).toContainEqual(expect.objectContaining({
+        id: 'call_command_declined',
+        isBlocked: true,
+        isError: true,
+        type: 'tool_result',
+      }));
+    });
+
     it('maps fileChange patchUpdated diffs into apply_patch tool input', () => {
       router.handleNotification('item/fileChange/patchUpdated', {
         threadId: 't1',


### PR DESCRIPTION
## Summary

Sync upstream commit 5ffbd10c (#1075) and complete the provider outcome wiring.

- derive blocked tool status from provider execution outcomes
- keep Claude permission-denied tracking
- propagate ACP permission denials for Grok, OpenCode, and OMP
- mark declined Codex command/file-change results as blocked
- keep cancellation/session abort distinct from user denial

Pi currently has no independent permission-denial event source; its adapter continues to preserve provider-supplied blocked outcomes without guessing from event names or text.

## Verification

- npm run typecheck
- 296 provider/ACP/runtime tests passed
- npm run lint (0 errors; existing warnings only)