### PR TITLE
refactor: introduce incremental tab runtime architecture

### DIFF
--- a/src/features/chat/AGENTS.md
+++ b/src/features/chat/AGENTS.md
@@ -21,6 +21,7 @@
 | `TabControllerFactory` | Installation of the renderer and selection controllers for a tab; execution controllers remain in the tab orchestration flow until their dependencies are separated |
 | `TabStreamControllerFactory` | Assembly of one tab's stream controller, provider-owned subagent history recovery, and background-work/persistence adapters |
 | `TabConversationControllerFactory` | Assembly of ConversationController and its tab-owned state accessors; provider binding transitions are supplied as one atomic hook |
+| `TabInputControllerFactory` | Assembly of InputController, provider preflight diagnostics, and layout/plan-mode hooks for the tab composer |
 | `TabRuntimeCleanup` | Reverse-order, idempotent teardown of tab-owned resources; cleanup failures are collected so later resources still release |
 | `TabModelSelectionCoordinator` | Per-tab model-selection request ordering, blank-tab provider-transition serialization, and stable-draft rollback |
 | `ChatExecutionCoordinator` | One tab's provider-session binding, active execution, interaction fencing, cancellation, and disposal |

--- a/src/features/chat/AGENTS.md
+++ b/src/features/chat/AGENTS.md
@@ -20,6 +20,7 @@
 | `TabRuntimeFactory` | Allocation of the provider-neutral runtime shell: per-tab DOM, `ChatState`, `TabSession`, placeholder controllers/services/UI slots, and initial draft/provider resolution |
 | `TabControllerFactory` | Installation of the renderer and selection controllers for a tab; execution controllers remain in the tab orchestration flow until their dependencies are separated |
 | `TabStreamControllerFactory` | Assembly of one tab's stream controller, provider-owned subagent history recovery, and background-work/persistence adapters |
+| `TabConversationControllerFactory` | Assembly of ConversationController and its tab-owned state accessors; provider binding transitions are supplied as one atomic hook |
 | `TabRuntimeCleanup` | Reverse-order, idempotent teardown of tab-owned resources; cleanup failures are collected so later resources still release |
 | `TabModelSelectionCoordinator` | Per-tab model-selection request ordering, blank-tab provider-transition serialization, and stable-draft rollback |
 | `ChatExecutionCoordinator` | One tab's provider-session binding, active execution, interaction fencing, cancellation, and disposal |

--- a/src/features/chat/AGENTS.md
+++ b/src/features/chat/AGENTS.md
@@ -22,6 +22,7 @@
 | `TabStreamControllerFactory` | Assembly of one tab's stream controller, provider-owned subagent history recovery, and background-work/persistence adapters |
 | `TabConversationControllerFactory` | Assembly of ConversationController and its tab-owned state accessors; provider binding transitions are supplied as one atomic hook |
 | `TabInputControllerFactory` | Assembly of InputController, provider preflight diagnostics, and layout/plan-mode hooks for the tab composer |
+| `TabNavigationControllerFactory` | Assembly and initialization of keyboard navigation for a tab, including escape-handling suppression for active composer modes |
 | `TabRuntimeCleanup` | Reverse-order, idempotent teardown of tab-owned resources; cleanup failures are collected so later resources still release |
 | `TabModelSelectionCoordinator` | Per-tab model-selection request ordering, blank-tab provider-transition serialization, and stable-draft rollback |
 | `ChatExecutionCoordinator` | One tab's provider-session binding, active execution, interaction fencing, cancellation, and disposal |
@@ -32,6 +33,8 @@
 | `ClaudianView` | View assembly, rendered DOM placement, presentation coordination, layout-mode navigation, and assembly of the persisted current-tab snapshot |
 
 `TabRuntimeFactory` must not create provider execution sessions or feature controllers; those are attached by the owning initialization flow after the shell exists. `TabRuntimeCleanup` must run after conversation save and execution drain, and before the tab DOM is removed. `TabSession` stores lifecycle values, while lifecycle operations in `Tab.ts` and `TabManager` perform the transitions. Controllers, renderers, and UI components must request those operations instead of assigning lifecycle state themselves.
+
+`initializeTabRuntimeControllers` is the current orchestration entry point. `initializeTabControllers` remains only as a deprecated compatibility alias for existing feature tests and integrations.
 
 `TabStatePersistenceCoordinator` owns write sequencing, not semantic tab state. It receives the active tab identity assembled by `ClaudianView`; it must not infer, add, or remove runtime tabs.
 

--- a/src/features/chat/AGENTS.md
+++ b/src/features/chat/AGENTS.md
@@ -18,6 +18,7 @@
 | `TabManager` | Runtime-tab membership, active-tab selection, and create/switch/close operations |
 | `TabSession` | Authoritative per-tab identity, conversation binding, provider binding, lifecycle value, execution-coordinator attachment, active-turn reference, and background-work sequencing |
 | `TabRuntimeFactory` | Allocation of the provider-neutral runtime shell: per-tab DOM, `ChatState`, `TabSession`, placeholder controllers/services/UI slots, and initial draft/provider resolution |
+| `TabControllerFactory` | Installation of the renderer and selection controllers for a tab; execution controllers remain in the tab orchestration flow until their dependencies are separated |
 | `TabRuntimeCleanup` | Reverse-order, idempotent teardown of tab-owned resources; cleanup failures are collected so later resources still release |
 | `TabModelSelectionCoordinator` | Per-tab model-selection request ordering, blank-tab provider-transition serialization, and stable-draft rollback |
 | `ChatExecutionCoordinator` | One tab's provider-session binding, active execution, interaction fencing, cancellation, and disposal |

--- a/src/features/chat/AGENTS.md
+++ b/src/features/chat/AGENTS.md
@@ -19,6 +19,7 @@
 | `TabSession` | Authoritative per-tab identity, conversation binding, provider binding, lifecycle value, execution-coordinator attachment, active-turn reference, and background-work sequencing |
 | `TabRuntimeFactory` | Allocation of the provider-neutral runtime shell: per-tab DOM, `ChatState`, `TabSession`, placeholder controllers/services/UI slots, and initial draft/provider resolution |
 | `TabControllerFactory` | Installation of the renderer and selection controllers for a tab; execution controllers remain in the tab orchestration flow until their dependencies are separated |
+| `TabStreamControllerFactory` | Assembly of one tab's stream controller, provider-owned subagent history recovery, and background-work/persistence adapters |
 | `TabRuntimeCleanup` | Reverse-order, idempotent teardown of tab-owned resources; cleanup failures are collected so later resources still release |
 | `TabModelSelectionCoordinator` | Per-tab model-selection request ordering, blank-tab provider-transition serialization, and stable-draft rollback |
 | `ChatExecutionCoordinator` | One tab's provider-session binding, active execution, interaction fencing, cancellation, and disposal |

--- a/src/features/chat/AGENTS.md
+++ b/src/features/chat/AGENTS.md
@@ -17,6 +17,8 @@
 | --- | --- |
 | `TabManager` | Runtime-tab membership, active-tab selection, and create/switch/close operations |
 | `TabSession` | Authoritative per-tab identity, conversation binding, provider binding, lifecycle value, execution-coordinator attachment, active-turn reference, and background-work sequencing |
+| `TabRuntimeFactory` | Allocation of the provider-neutral runtime shell: per-tab DOM, `ChatState`, `TabSession`, placeholder controllers/services/UI slots, and initial draft/provider resolution |
+| `TabRuntimeCleanup` | Reverse-order, idempotent teardown of tab-owned resources; cleanup failures are collected so later resources still release |
 | `TabModelSelectionCoordinator` | Per-tab model-selection request ordering, blank-tab provider-transition serialization, and stable-draft rollback |
 | `ChatExecutionCoordinator` | One tab's provider-session binding, active execution, interaction fencing, cancellation, and disposal |
 | `WarmExecutionPool` | Application-scoped warm execution ownership, the configured concurrent-running-session limit, and least-recently-used cooling of idle owners |
@@ -25,7 +27,7 @@
 | `TabBar` | Expanded-title presentation state for the current view |
 | `ClaudianView` | View assembly, rendered DOM placement, presentation coordination, layout-mode navigation, and assembly of the persisted current-tab snapshot |
 
-`TabSession` stores lifecycle values, while lifecycle operations in `Tab.ts` and `TabManager` perform the transitions. Controllers, renderers, and UI components must request those operations instead of assigning lifecycle state themselves.
+`TabRuntimeFactory` must not create provider execution sessions or feature controllers; those are attached by the owning initialization flow after the shell exists. `TabRuntimeCleanup` must run after conversation save and execution drain, and before the tab DOM is removed. `TabSession` stores lifecycle values, while lifecycle operations in `Tab.ts` and `TabManager` perform the transitions. Controllers, renderers, and UI components must request those operations instead of assigning lifecycle state themselves.
 
 `TabStatePersistenceCoordinator` owns write sequencing, not semantic tab state. It receives the active tab identity assembled by `ClaudianView`; it must not infer, add, or remove runtime tabs.
 

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -49,7 +49,6 @@ import { getEnhancedPath } from '../../../utils/env';
 import { getVaultPath } from '../../../utils/path';
 import type { FeatureHost } from '../../FeatureHost';
 import { toggleServiceTier } from '../actions/toggleServiceTier';
-import { InputController } from '../controllers/InputController';
 import { NavigationController } from '../controllers/NavigationController';
 import {
   providerOutputEventToStreamChunk,
@@ -75,6 +74,7 @@ import { recalculateUsageForModel } from '../utils/usageInfo';
 import { getTabProviderId } from './providerResolution';
 import { initializeTabPresentationControllers } from './TabControllerFactory';
 import { createTabConversationController } from './TabConversationControllerFactory';
+import { createTabInputController } from './TabInputControllerFactory';
 import { TabModelSelectionCoordinator } from './TabModelSelectionCoordinator';
 import { TabRuntimeCleanup } from './TabRuntimeCleanup';
 import { createTabRuntime } from './TabRuntimeFactory';
@@ -1848,37 +1848,10 @@ export function initializeTabControllers(
     },
   });
 
-  tab.controllers.inputController = new InputController({
-    plugin,
-    state,
-    renderer: tab.renderer!,
-    streamController: tab.controllers.streamController,
-    selectionController: tab.controllers.selectionController!,
-    browserSelectionController: tab.controllers.browserSelectionController ?? undefined,
-    canvasSelectionController: tab.controllers.canvasSelectionController!,
-    conversationController: tab.controllers.conversationController,
-    getInputEl: () => dom.inputEl,
-    getInputContainerEl: () => dom.inputContainerEl,
-    getWelcomeEl: () => dom.welcomeEl,
-    getMessagesEl: () => dom.messagesEl,
-    getFileContextManager: () => ui.fileContextManager,
-    getImageContextManager: () => ui.imageContextManager,
-    getMcpServerSelector: () => ui.mcpServerSelector,
-    getExternalContextSelector: () => ui.externalContextSelector,
-    getInstructionModeManager: () => ui.instructionModeManager,
-    getInstructionRefineService: () => services.instructionRefineService,
-    getTitleGenerationService: () => services.titleGenerationService,
-    getStatusPanel: () => ui.statusPanel,
-    generateId: generateMessageId,
-    resetInputHeight: () => {
-      autoResizeTextarea(dom.inputEl);
-    },
-    getAuxiliaryModel: () => getTabSelectedModel(tab, plugin),
-    getExecutionCoordinator: () => tab.executionCoordinator,
-    getSubagentManager: () => services.subagentManager,
-    getTabProviderId: () => getTabProviderId(tab, plugin),
-    turnOwner: tab.session,
+  tab.controllers.inputController = createTabInputController(tab, plugin, {
     ensureExecutionInitialized,
+    generateId: generateMessageId,
+    getAuxiliaryModel: () => getTabSelectedModel(tab, plugin),
     openConversation,
     handleNewConversationCommand: viewHost.handleNewConversationCommand
       ? () => viewHost.handleNewConversationCommand!()
@@ -1902,28 +1875,7 @@ export function initializeTabControllers(
         }
       }
     },
-    captureReviewableSettlement: tab.captureReviewableSettlement ?? undefined,
     onDiagnosticError: error => showPreHandoffDiagnostic(plugin, tab, error),
-    preflightExecution: async () => {
-      let diagnostics;
-      try {
-        diagnostics = await ProviderRegistry.collectDiagnostics(tab.providerId, {
-          settings: plugin.settings,
-          resolveCliPath: () => plugin.providerHost.getResolvedProviderCliPath(tab.providerId),
-        });
-      } catch {
-        return new Error('Provider CLI not found.');
-      }
-      if (diagnostics?.readiness?.status === 'disabled') {
-        return new Error('Provider is not enabled.');
-      }
-      const blockedCheck = diagnostics?.readiness?.checks.find(check => check.status === 'blocked');
-      if (!blockedCheck) return null;
-      if (blockedCheck.id === 'cli') return new Error('Provider CLI not found.');
-      if (blockedCheck.id === 'selection') return new Error('No chat model is selected.');
-      if (blockedCheck.id === 'enabled') return new Error('Provider is not enabled.');
-      return new Error('Provider model catalog is unavailable.');
-    },
   });
 
   tab.controllers.navigationController = new NavigationController({

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -84,6 +84,7 @@ import { autoResizeTextarea } from '../ui/textareaResize';
 import { recalculateUsageForModel } from '../utils/usageInfo';
 import { getTabProviderId } from './providerResolution';
 import { TabModelSelectionCoordinator } from './TabModelSelectionCoordinator';
+import { TabRuntimeCleanup } from './TabRuntimeCleanup';
 import { TabSession } from './TabSession';
 import type {
   ProviderCatalogInfo,
@@ -2459,45 +2460,73 @@ export async function destroyTab(tab: TabData): Promise<void> {
   tab.services.subagentManager.clear();
   await cleanupTabExecution(tab);
 
-  tab.controllers.selectionController?.stop();
-  tab.controllers.selectionController?.clear();
-  tab.controllers.browserSelectionController?.stop();
-  tab.controllers.browserSelectionController?.clear();
-  tab.controllers.canvasSelectionController?.stop();
-  tab.controllers.canvasSelectionController?.clear();
-  tab.controllers.navigationController?.dispose();
+  const cleanup = new TabRuntimeCleanup();
+  cleanup.register('tab DOM root', () => tab.dom.contentEl.remove());
+  cleanup.register('tab DOM event handlers', () => {
+    for (const eventCleanup of tab.dom.eventCleanups) {
+      eventCleanup();
+    }
+    tab.dom.eventCleanups.length = 0;
+  });
+  cleanup.register('tab stream controller', () => tab.controllers.streamController?.dispose());
+  cleanup.register('tab navigation sidebar', () => {
+    tab.ui.navigationSidebar?.destroy();
+    tab.ui.navigationSidebar = null;
+  });
+  cleanup.register('tab status panel', () => {
+    tab.ui.statusPanel?.destroy();
+    tab.ui.statusPanel = null;
+  });
+  cleanup.register('tab title generation', () => {
+    tab.services.titleGenerationService?.cancel();
+    tab.services.titleGenerationService = null;
+  });
+  cleanup.register('tab instruction refinement', () => {
+    tab.services.instructionRefineService?.cancel();
+    tab.services.instructionRefineService?.resetConversation();
+    tab.services.instructionRefineService = null;
+  });
+  cleanup.register('tab bang-bash mode', () => {
+    tab.ui.bangBashModeManager?.destroy();
+    tab.ui.bangBashModeManager = null;
+  });
+  cleanup.register('tab instruction mode', () => {
+    tab.ui.instructionModeManager?.destroy();
+    tab.ui.instructionModeManager = null;
+  });
+  cleanup.register('tab slash command dropdown', () => {
+    tab.ui.slashCommandDropdown?.destroy();
+    tab.ui.slashCommandDropdown = null;
+  });
+  cleanup.register('tab composer context tray', () => {
+    tab.ui.contextTray?.destroy();
+    tab.ui.contextTray = null;
+  });
+  cleanup.register('tab image context manager', () => tab.ui.imageContextManager?.destroy());
+  cleanup.register('tab file context manager', () => tab.ui.fileContextManager?.destroy());
+  cleanup.register('tab resume dropdown', () => tab.controllers.inputController?.destroyResumeDropdown());
+  cleanup.register('tab thinking state', () => {
+    cleanupThinkingBlock(tab.state.currentThinkingState);
+    tab.state.currentThinkingState = null;
+  });
+  cleanup.register('tab navigation controller', () => tab.controllers.navigationController?.dispose());
+  cleanup.register('tab canvas selection controller', () => {
+    tab.controllers.canvasSelectionController?.stop();
+    tab.controllers.canvasSelectionController?.clear();
+  });
+  cleanup.register('tab browser selection controller', () => {
+    tab.controllers.browserSelectionController?.stop();
+    tab.controllers.browserSelectionController?.clear();
+  });
+  cleanup.register('tab selection controller', () => {
+    tab.controllers.selectionController?.stop();
+    tab.controllers.selectionController?.clear();
+  });
 
-  cleanupThinkingBlock(tab.state.currentThinkingState);
-  tab.state.currentThinkingState = null;
-
-  tab.controllers.inputController?.destroyResumeDropdown();
-  tab.ui.fileContextManager?.destroy();
-  tab.ui.imageContextManager?.destroy();
-  tab.ui.contextTray?.destroy();
-  tab.ui.contextTray = null;
-  tab.ui.slashCommandDropdown?.destroy();
-  tab.ui.slashCommandDropdown = null;
-  tab.ui.instructionModeManager?.destroy();
-  tab.ui.instructionModeManager = null;
-  tab.ui.bangBashModeManager?.destroy();
-  tab.ui.bangBashModeManager = null;
-  tab.services.instructionRefineService?.cancel();
-  tab.services.instructionRefineService?.resetConversation();
-  tab.services.instructionRefineService = null;
-  tab.services.titleGenerationService?.cancel();
-  tab.services.titleGenerationService = null;
-  tab.ui.statusPanel?.destroy();
-  tab.ui.statusPanel = null;
-  tab.ui.navigationSidebar?.destroy();
-  tab.ui.navigationSidebar = null;
-  tab.controllers.streamController?.dispose();
-
-  for (const cleanup of tab.dom.eventCleanups) {
-    cleanup();
+  const failures = await cleanup.dispose();
+  for (const failure of failures) {
+    new Notice(`Tab cleanup failed for ${failure.resource}.`);
   }
-  tab.dom.eventCleanups.length = 0;
-
-  tab.dom.contentEl.remove();
 }
 
 /**

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -49,12 +49,9 @@ import { getEnhancedPath } from '../../../utils/env';
 import { getVaultPath } from '../../../utils/path';
 import type { FeatureHost } from '../../FeatureHost';
 import { toggleServiceTier } from '../actions/toggleServiceTier';
-import { BrowserSelectionController } from '../controllers/BrowserSelectionController';
-import { CanvasSelectionController } from '../controllers/CanvasSelectionController';
 import { ConversationController } from '../controllers/ConversationController';
 import { InputController } from '../controllers/InputController';
 import { NavigationController } from '../controllers/NavigationController';
-import { SelectionController } from '../controllers/SelectionController';
 import {
   providerOutputEventToStreamChunk,
   StreamController,
@@ -63,7 +60,6 @@ import {
   ChatExecutionCoordinator,
   type ChatExecutionEventContext,
 } from '../execution/ChatExecutionCoordinator';
-import { MessageRenderer } from '../rendering/MessageRenderer';
 import { cleanupThinkingBlock } from '../rendering/ThinkingBlockRenderer';
 import { findRewindContext } from '../rewind';
 import { BangBashService } from '../services/BangBashService';
@@ -79,6 +75,7 @@ import { StatusPanel } from '../ui/StatusPanel';
 import { autoResizeTextarea } from '../ui/textareaResize';
 import { recalculateUsageForModel } from '../utils/usageInfo';
 import { getTabProviderId } from './providerResolution';
+import { initializeTabPresentationControllers } from './TabControllerFactory';
 import { TabModelSelectionCoordinator } from './TabModelSelectionCoordinator';
 import { TabRuntimeCleanup } from './TabRuntimeCleanup';
 import { createTabRuntime } from './TabRuntimeFactory';
@@ -111,11 +108,6 @@ const backgroundTurnBuffers = new WeakMap<
   TabData,
   Map<string, Map<string, ProviderBackgroundOutputEvent[]>>
 >();
-
-function getSharedSelectionFocusScopeEls(component: Component): HTMLElement[] {
-  const host = component as Partial<TabManagerViewHost>;
-  return host.getSharedSelectionFocusScopeEls?.() ?? [];
-}
 
 /**
  * Returns model options for a blank tab.
@@ -1768,48 +1760,21 @@ export function initializeTabControllers(
     }
   };
 
-  // Create renderer
-  tab.renderer = new MessageRenderer(
+  initializeTabPresentationControllers(tab, {
     plugin,
     component,
-    dom.messagesEl,
-    (id, mode) => tab.controllers.conversationController!.rewind(id, mode),
-    forkRequestCallback
+    getCapabilities: () => getTabCapabilities(tab, plugin),
+    onRewind: (id, mode) => tab.controllers.conversationController!.rewind(id, mode),
+    onForkRequest: forkRequestCallback
       ? (id) => handleForkRequest(tab, plugin, id, forkRequestCallback)
       : undefined,
-    () => getTabCapabilities(tab, plugin),
-  );
-
-  // Selection controller
-  tab.controllers.selectionController = new SelectionController(
-    plugin.app,
-    ui.contextTray!,
-    dom.inputEl,
-    undefined,
-    [dom.contentEl, dom.inputComposerEl, ...getSharedSelectionFocusScopeEls(component)],
-    () => commitProvisionalTab(tab),
-  );
-
-  tab.controllers.browserSelectionController = new BrowserSelectionController(
-    plugin.app,
-    ui.contextTray!,
-    dom.inputEl,
-    undefined,
-    () => commitProvisionalTab(tab),
-  );
-
-  tab.controllers.canvasSelectionController = new CanvasSelectionController(
-    plugin.app,
-    ui.contextTray!,
-    dom.inputEl,
-    undefined,
-    () => commitProvisionalTab(tab),
-  );
+    onCommitProvisional: () => commitProvisionalTab(tab),
+  });
 
   tab.controllers.streamController = new StreamController({
     plugin,
     state,
-    renderer: tab.renderer,
+    renderer: tab.renderer!,
     subagentManager: services.subagentManager,
     getMessagesEl: () => dom.messagesEl,
     getFileContextManager: () => ui.fileContextManager,
@@ -1879,7 +1844,7 @@ export function initializeTabControllers(
     {
       plugin,
       state,
-      renderer: tab.renderer,
+      renderer: tab.renderer!,
       subagentManager: services.subagentManager,
       getHistoryDropdown: () => null, // Tab doesn't have its own history dropdown
       getWelcomeEl: () => dom.welcomeEl,
@@ -1960,11 +1925,11 @@ export function initializeTabControllers(
   tab.controllers.inputController = new InputController({
     plugin,
     state,
-    renderer: tab.renderer,
+    renderer: tab.renderer!,
     streamController: tab.controllers.streamController,
-    selectionController: tab.controllers.selectionController,
-    browserSelectionController: tab.controllers.browserSelectionController,
-    canvasSelectionController: tab.controllers.canvasSelectionController,
+    selectionController: tab.controllers.selectionController!,
+    browserSelectionController: tab.controllers.browserSelectionController ?? undefined,
+    canvasSelectionController: tab.controllers.canvasSelectionController!,
     conversationController: tab.controllers.conversationController,
     getInputEl: () => dom.inputEl,
     getInputContainerEl: () => dom.inputContainerEl,

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -49,7 +49,6 @@ import { getEnhancedPath } from '../../../utils/env';
 import { getVaultPath } from '../../../utils/path';
 import type { FeatureHost } from '../../FeatureHost';
 import { toggleServiceTier } from '../actions/toggleServiceTier';
-import { NavigationController } from '../controllers/NavigationController';
 import {
   providerOutputEventToStreamChunk,
 } from '../controllers/StreamController';
@@ -76,6 +75,7 @@ import { initializeTabPresentationControllers } from './TabControllerFactory';
 import { createTabConversationController } from './TabConversationControllerFactory';
 import { createTabInputController } from './TabInputControllerFactory';
 import { TabModelSelectionCoordinator } from './TabModelSelectionCoordinator';
+import { initializeTabNavigationController } from './TabNavigationControllerFactory';
 import { TabRuntimeCleanup } from './TabRuntimeCleanup';
 import { createTabRuntime } from './TabRuntimeFactory';
 import { createTabStreamController } from './TabStreamControllerFactory';
@@ -1694,7 +1694,7 @@ async function handleForkAll(
   });
 }
 
-export function initializeTabControllers(
+export function initializeTabRuntimeControllers(
   tab: TabData,
   plugin: FeatureHost,
   component: Component,
@@ -1703,7 +1703,7 @@ export function initializeTabControllers(
   getProviderCatalogConfig?: () => ProviderCatalogInfo,
 ): void;
 /** @deprecated Legacy 7-arg overload — 4th arg was previously an MCP manager. */
-export function initializeTabControllers(
+export function initializeTabRuntimeControllers(
   tab: TabData,
   plugin: FeatureHost,
   component: Component,
@@ -1712,7 +1712,7 @@ export function initializeTabControllers(
   openConversation?: (conversationId: string) => Promise<void>,
   getProviderCatalogConfig?: () => ProviderCatalogInfo,
 ): void;
-export function initializeTabControllers(
+export function initializeTabRuntimeControllers(
   tab: TabData,
   plugin: FeatureHost,
   component: Component,
@@ -1731,7 +1731,7 @@ export function initializeTabControllers(
     (() => ProviderCatalogInfo) | undefined;
   const viewHost = component as Partial<TabManagerViewHost>;
 
-  const { dom, state, services, ui } = tab;
+  const { dom, services } = tab;
   const ensureExecutionInitialized = async (): Promise<boolean> => {
     if (
       tab.lifecycleState === 'warm'
@@ -1878,22 +1878,11 @@ export function initializeTabControllers(
     onDiagnosticError: error => showPreHandoffDiagnostic(plugin, tab, error),
   });
 
-  tab.controllers.navigationController = new NavigationController({
-    getMessagesEl: () => dom.messagesEl,
-    getInputEl: () => dom.inputEl,
-    getSettings: () => plugin.settings.keyboardNavigation,
-    isStreaming: () => state.isStreaming,
-    shouldSkipEscapeHandling: () => {
-      if (ui.instructionModeManager?.isActive()) return true;
-      if (ui.bangBashModeManager?.isActive()) return true;
-      if (tab.controllers.inputController?.isResumeDropdownVisible()) return true;
-      if (ui.slashCommandDropdown?.isVisible()) return true;
-      if (ui.fileContextManager?.isMentionDropdownVisible()) return true;
-      return false;
-    },
-  });
-  tab.controllers.navigationController.initialize();
+  initializeTabNavigationController(tab, plugin);
 }
+
+/** @deprecated Use initializeTabRuntimeControllers. */
+export const initializeTabControllers = initializeTabRuntimeControllers;
 
 /**
  * Wires up input event handlers for a tab.

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -65,12 +65,8 @@ import {
 } from '../execution/ChatExecutionCoordinator';
 import { MessageRenderer } from '../rendering/MessageRenderer';
 import { cleanupThinkingBlock } from '../rendering/ThinkingBlockRenderer';
-import { createWelcomeElement } from '../rendering/WelcomeRenderer';
 import { findRewindContext } from '../rewind';
 import { BangBashService } from '../services/BangBashService';
-import { SubagentManager } from '../services/SubagentManager';
-import { ChatState } from '../state/ChatState';
-import type { TabAttention } from '../state/types';
 import { BangBashModeManager as BangBashModeManagerClass } from '../ui/BangBashModeManager';
 import { ComposerContextTray } from '../ui/ComposerContextTray';
 import { FileContextManager } from '../ui/FileContext';
@@ -85,17 +81,15 @@ import { recalculateUsageForModel } from '../utils/usageInfo';
 import { getTabProviderId } from './providerResolution';
 import { TabModelSelectionCoordinator } from './TabModelSelectionCoordinator';
 import { TabRuntimeCleanup } from './TabRuntimeCleanup';
-import { TabSession } from './TabSession';
+import { createTabRuntime } from './TabRuntimeFactory';
 import type {
   ProviderCatalogInfo,
   ProviderCatalogResolver,
+  TabCreateOptions,
   TabData,
-  TabDOMElements,
-  TabId,
   TabManagerViewHost,
   TabProviderContext,
 } from './types';
-import { generateTabId } from './types';
 
 type TabProviderSettings = Record<string, unknown> & {
   model: string;
@@ -139,23 +133,6 @@ export function getBlankTabModelOptions(
     return uiConfig.getModelOptions(settings)
       .map(model => ({ ...model, group, providerIcon }));
   });
-}
-
-export interface TabCreateOptions {
-  plugin: FeatureHost;
-
-  containerEl: HTMLElement;
-  conversation?: Conversation;
-  tabId?: TabId;
-  /** Initial draft model for an unbound tab. */
-  draftModel?: string | null;
-  lifecycleState?: Extract<TabData['lifecycleState'], 'provisional' | 'cold'>;
-  onStreamingChanged?: (isStreaming: boolean) => void;
-  onRewindingChanged?: (isRewinding: boolean) => void;
-  onTitleChanged?: (title: string) => void;
-  onAttentionChanged?: (attention: TabAttention) => void;
-  captureReviewableSettlement?: () => () => void;
-  onConversationIdChanged?: (conversationId: string | null) => void;
 }
 
 export { getTabProviderId } from './providerResolution';
@@ -593,148 +570,13 @@ export function onProviderAvailabilityChanged(tab: TabData, plugin: FeatureHost)
   return tab.draftModel !== previousDraftModel || tab.providerId !== previousProviderId;
 }
 
-/**
- * Creates a new Tab instance with all required state.
- */
+/** Creates a new Tab instance with all required state. */
 export function createTab(options: TabCreateOptions): TabData {
-  const {
-    plugin,
-    containerEl,
-    conversation,
-    tabId,
-    onStreamingChanged,
-    onRewindingChanged,
-    onAttentionChanged,
-    onConversationIdChanged,
-  } = options;
-
-  const id = tabId ?? generateTabId();
-
-  const contentEl = containerEl.createDiv({ cls: 'claudian-tab-content claudian-hidden' });
-
-  const state = new ChatState({
-    onStreamingStateChanged: onStreamingChanged,
-    onRewindingStateChanged: onRewindingChanged,
-    onAttentionChanged: onAttentionChanged,
-    onConversationChanged: onConversationIdChanged,
+  const tab = createTabRuntime(options, {
+    onStreamingStateChanged: updateSendButton,
   });
-
-  // Create subagent manager with no-op callback.
-  // This placeholder is replaced in initializeTabControllers() with the actual
-  // callback that updates the StreamController. We defer the real callback
-  // because StreamController doesn't exist until controllers are initialized.
-  const subagentManager = new SubagentManager(() => {});
-
-  const dom = buildTabDOM(contentEl);
-  state.queueIndicatorEl = dom.queueIndicatorEl;
-
-  const isBound = !!conversation?.id;
-  const restoredDraftModel = typeof options.draftModel === 'string'
-    ? options.draftModel.trim()
-    : '';
-  const newConversationModel = !isBound && !restoredDraftModel
-    ? resolveNewConversationModel(plugin.settings)
-    : null;
-  const draftModel = isBound
-    ? null
-    : (restoredDraftModel || newConversationModel?.model || null);
-  const initialProviderId = conversation?.providerId
-    ?? newConversationModel?.providerId
-    ?? (draftModel
-      ? getEnabledProviderForModel(draftModel, plugin.settings)
-      : DEFAULT_CHAT_PROVIDER_ID);
-  const session = new TabSession({
-    id,
-    lifecycleState: options.lifecycleState ?? 'cold',
-    draftModel,
-    providerId: initialProviderId,
-    conversationId: conversation?.id ?? null,
-  });
-  const tab: TabData = {
-    session,
-    get id() {
-      return session.id;
-    },
-    get lifecycleState() {
-      return session.lifecycleState;
-    },
-    set lifecycleState(value) {
-      session.lifecycleState = value;
-    },
-    hydrationState: isBound ? 'idle' : 'ready',
-    get draftModel() {
-      return session.draftModel;
-    },
-    set draftModel(value) {
-      session.draftModel = value;
-    },
-    get providerId() {
-      return session.providerId;
-    },
-    set providerId(value) {
-      session.providerId = value;
-    },
-    get conversationId() {
-      return session.conversationId;
-    },
-    set conversationId(value) {
-      session.conversationId = value;
-    },
-    get executionCoordinator() {
-      return session.executionCoordinator;
-    },
-    set executionCoordinator(coordinator) {
-      session.setExecutionCoordinator(coordinator);
-    },
-    providerCatalogResolver: null,
-    captureReviewableSettlement: options.captureReviewableSettlement ?? null,
-    state,
-    controllers: {
-      selectionController: null,
-      browserSelectionController: null,
-      canvasSelectionController: null,
-      conversationController: null,
-      streamController: null,
-      inputController: null,
-      navigationController: null,
-    },
-    services: {
-      subagentManager,
-      instructionRefineService: null,
-      titleGenerationService: null,
-    },
-    ui: {
-      contextTray: null,
-      fileContextManager: null,
-      imageContextManager: null,
-      modelSelector: null,
-      modeSelector: null,
-      thinkingBudgetSelector: null,
-      externalContextSelector: null,
-      mcpServerSelector: null,
-      permissionToggle: null,
-      serviceTierToggle: null,
-      slashCommandDropdown: null,
-      instructionModeManager: null,
-      bangBashModeManager: null,
-      contextUsageMeter: null,
-      statusPanel: null,
-      navigationSidebar: null,
-    },
-    dom,
-    renderer: null,
-  };
-
-  state.callbacks = {
-    ...state.callbacks,
-    onStreamingStateChanged: (isStreaming) => {
-      onStreamingChanged?.(isStreaming);
-      updateSendButton(tab);
-    },
-  };
   updateSendButton(tab);
-
-  tab.executionCoordinator = createTabExecutionCoordinator(tab, plugin);
+  tab.executionCoordinator = createTabExecutionCoordinator(tab, options.plugin);
   return tab;
 }
 
@@ -1134,55 +976,6 @@ function normalizeProviderMode(mode: string): string {
   if (mode === 'bypassPermissions' || mode === 'yolo') return 'yolo';
   if (mode === 'plan') return 'plan';
   return 'normal';
-}
-
-/**
- * Builds the DOM structure for a tab.
- */
-function buildTabDOM(contentEl: HTMLElement): TabDOMElements {
-  const messagesWrapperEl = contentEl.createDiv({ cls: 'claudian-messages-wrapper' });
-  const messagesEl = messagesWrapperEl.createDiv({ cls: 'claudian-messages' });
-  const welcomeEl = createWelcomeElement(messagesEl);
-  const statusPanelContainerEl = contentEl.createDiv({ cls: 'claudian-status-panel-container' });
-  const inputComposerEl = contentEl.createDiv({ cls: 'claudian-input-composer' });
-  const inputContainerEl = inputComposerEl.createDiv({ cls: 'claudian-input-container' });
-  const queueIndicatorEl = inputContainerEl.createDiv({ cls: 'claudian-input-queue-row' });
-  const navRowEl = inputContainerEl.createDiv({ cls: 'claudian-input-nav-row' });
-  const inputWrapper = inputContainerEl.createDiv({ cls: 'claudian-input-wrapper' });
-  const contextRowEl = inputWrapper.createDiv({ cls: 'claudian-context-row' });
-  const inputEl = inputWrapper.createEl('textarea', {
-    cls: 'claudian-input',
-    attr: {
-      placeholder: 'Ask to make changes, @mention files, run /commands',
-      rows: '3',
-      dir: 'auto',
-    },
-  });
-  const sendButtonEl = inputWrapper.createEl('button', {
-    cls: 'claudian-input-send-button',
-    attr: {
-      type: 'button',
-      'aria-label': 'Send message',
-      title: 'Send message (enter)',
-    },
-  });
-  setIcon(sendButtonEl, 'send');
-
-  return {
-    contentEl,
-    messagesEl,
-    welcomeEl,
-    statusPanelContainerEl,
-    inputComposerEl,
-    inputContainerEl,
-    queueIndicatorEl,
-    inputWrapper,
-    inputEl,
-    sendButtonEl,
-    navRowEl,
-    contextRowEl,
-    eventCleanups: [],
-  };
 }
 
 export function updateSendButton(tab: TabData): void {

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -49,7 +49,6 @@ import { getEnhancedPath } from '../../../utils/env';
 import { getVaultPath } from '../../../utils/path';
 import type { FeatureHost } from '../../FeatureHost';
 import { toggleServiceTier } from '../actions/toggleServiceTier';
-import { ConversationController } from '../controllers/ConversationController';
 import { InputController } from '../controllers/InputController';
 import { NavigationController } from '../controllers/NavigationController';
 import {
@@ -75,6 +74,7 @@ import { autoResizeTextarea } from '../ui/textareaResize';
 import { recalculateUsageForModel } from '../utils/usageInfo';
 import { getTabProviderId } from './providerResolution';
 import { initializeTabPresentationControllers } from './TabControllerFactory';
+import { createTabConversationController } from './TabConversationControllerFactory';
 import { TabModelSelectionCoordinator } from './TabModelSelectionCoordinator';
 import { TabRuntimeCleanup } from './TabRuntimeCleanup';
 import { createTabRuntime } from './TabRuntimeFactory';
@@ -1800,87 +1800,53 @@ export function initializeTabControllers(
     }
   );
 
-  tab.controllers.conversationController = new ConversationController(
-    {
-      plugin,
-      state,
-      renderer: tab.renderer!,
-      subagentManager: services.subagentManager,
-      getHistoryDropdown: () => null, // Tab doesn't have its own history dropdown
-      getWelcomeEl: () => dom.welcomeEl,
-      setWelcomeEl: (el) => { dom.welcomeEl = el; },
-      getMessagesEl: () => dom.messagesEl,
-      getInputEl: () => dom.inputEl,
-      restoreMessageToComposer: message => (
-        tab.controllers.inputController!.restoreRewoundMessageToComposer(message)
-      ),
-      getFileContextManager: () => ui.fileContextManager,
-      getImageContextManager: () => ui.imageContextManager,
-      getMcpServerSelector: () => ui.mcpServerSelector,
-      getExternalContextSelector: () => ui.externalContextSelector,
-      clearQueuedMessage: () => tab.controllers.inputController?.clearQueuedMessage(),
-      getTitleGenerationService: () => services.titleGenerationService,
-      getStatusPanel: () => ui.statusPanel,
-      getExecutionCoordinator: () => tab.executionCoordinator,
-      ensureExecutionInitialized,
-      getProviderId: () => getTabProviderId(tab, plugin),
-      getSelectedModel: () => getTabSelectedModel(tab, plugin),
-      getInitialUsage: (providerId, model) => ProviderRegistry
-        .getChatUIConfig(providerId)
-        .getInitialUsage?.(model, plugin.settings) ?? null,
-      dismissPendingInlinePrompts: () => tab.controllers.inputController?.dismissPendingApproval(),
-      awaitBackgroundWork: () => tab.session.awaitBackgroundWork(),
-      isDisposed: () => tab.lifecycleState === 'closing',
-      ensureExecutionForConversation: async (conversation) => {
-        const nextProviderId = getTabProviderId(tab, plugin, conversation);
-        const providerChanged = tab.providerId !== nextProviderId;
-        tab.providerId = nextProviderId;
+  tab.controllers.conversationController = createTabConversationController(tab, plugin, {
+    ensureExecutionInitialized,
+    getProviderId: () => getTabProviderId(tab, plugin),
+    getSelectedModel: () => getTabSelectedModel(tab, plugin),
+    onConversationBindingChanged: async (conversation) => {
+      const nextProviderId = getTabProviderId(tab, plugin, conversation);
+      const providerChanged = tab.providerId !== nextProviderId;
+      tab.providerId = nextProviderId;
 
-        if (providerChanged) {
-          syncTabProviderServices(tab, plugin);
-        }
+      if (providerChanged) {
+        syncTabProviderServices(tab, plugin);
+      }
 
-        tab.conversationId = conversation?.id ?? null;
-        tab.draftModel = null;
-        if (tab.lifecycleState !== 'provisional') {
-          tab.lifecycleState = 'cold';
-        }
-        syncSlashCommandDropdownForProvider(tab, plugin, getProviderCatalogConfig, conversation);
-
-        await tab.executionCoordinator?.bindConversation(conversation
-          ? createConversationExecutionBinding(conversation)
-          : null);
-
-        refreshTabProviderUI(tab, plugin);
-        applyProviderUIGating(tab, plugin);
-      },
-    },
-    {
-      onNewConversation: () => {
-        const previousProviderId = tab.providerId;
-        const nextModel = resolveNewConversationModel(plugin.settings);
-        void tab.executionCoordinator?.bindConversation(null);
+      tab.conversationId = conversation?.id ?? null;
+      tab.draftModel = null;
+      if (tab.lifecycleState !== 'provisional') {
         tab.lifecycleState = 'cold';
-        tab.draftModel = nextModel?.model ?? null;
-        tab.conversationId = null;
-        tab.providerId = nextModel?.providerId ?? DEFAULT_CHAT_PROVIDER_ID;
-        if (tab.providerId !== previousProviderId) {
-          syncTabProviderServices(tab, plugin);
-        }
-        refreshTabProviderUI(tab, plugin);
-        applyProviderUIGating(tab, plugin);
-        syncSlashCommandDropdownForProvider(tab, plugin, getProviderCatalogConfig);
-      },
-      onConversationLoaded: () => {
-        invalidateTabProviderCommands(tab, getProviderCatalogConfig);
-        tab.controllers.inputController?.onConversationActivated();
-      },
-      onConversationSwitched: () => {
-        invalidateTabProviderCommands(tab, getProviderCatalogConfig);
-        tab.controllers.inputController?.onConversationActivated();
-      },
-    }
-  );
+      }
+      syncSlashCommandDropdownForProvider(tab, plugin, getProviderCatalogConfig, conversation);
+
+      await tab.executionCoordinator?.bindConversation(conversation
+        ? createConversationExecutionBinding(conversation)
+        : null);
+
+      refreshTabProviderUI(tab, plugin);
+      applyProviderUIGating(tab, plugin);
+    },
+    onNewConversation: () => {
+      const previousProviderId = tab.providerId;
+      const nextModel = resolveNewConversationModel(plugin.settings);
+      void tab.executionCoordinator?.bindConversation(null);
+      tab.lifecycleState = 'cold';
+      tab.draftModel = nextModel?.model ?? null;
+      tab.conversationId = null;
+      tab.providerId = nextModel?.providerId ?? DEFAULT_CHAT_PROVIDER_ID;
+      if (tab.providerId !== previousProviderId) {
+        syncTabProviderServices(tab, plugin);
+      }
+      refreshTabProviderUI(tab, plugin);
+      applyProviderUIGating(tab, plugin);
+      syncSlashCommandDropdownForProvider(tab, plugin, getProviderCatalogConfig);
+    },
+    onConversationActivated: () => {
+      invalidateTabProviderCommands(tab, getProviderCatalogConfig);
+      tab.controllers.inputController?.onConversationActivated();
+    },
+  });
 
   tab.controllers.inputController = new InputController({
     plugin,

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -54,7 +54,6 @@ import { InputController } from '../controllers/InputController';
 import { NavigationController } from '../controllers/NavigationController';
 import {
   providerOutputEventToStreamChunk,
-  StreamController,
 } from '../controllers/StreamController';
 import {
   ChatExecutionCoordinator,
@@ -79,6 +78,7 @@ import { initializeTabPresentationControllers } from './TabControllerFactory';
 import { TabModelSelectionCoordinator } from './TabModelSelectionCoordinator';
 import { TabRuntimeCleanup } from './TabRuntimeCleanup';
 import { createTabRuntime } from './TabRuntimeFactory';
+import { createTabStreamController } from './TabStreamControllerFactory';
 import type {
   ProviderCatalogInfo,
   ProviderCatalogResolver,
@@ -1771,51 +1771,11 @@ export function initializeTabControllers(
     onCommitProvisional: () => commitProvisionalTab(tab),
   });
 
-  tab.controllers.streamController = new StreamController({
+  tab.controllers.streamController = createTabStreamController(
+    tab,
     plugin,
-    state,
-    renderer: tab.renderer!,
-    subagentManager: services.subagentManager,
-    getMessagesEl: () => dom.messagesEl,
-    getFileContextManager: () => ui.fileContextManager,
-    updateQueueIndicator: () => tab.controllers.inputController?.updateQueueIndicator(),
-    getProviderId: () => getTabProviderId(tab, plugin),
-    getProviderSessionId: () => tab.executionCoordinator?.snapshot?.providerSessionId ?? null,
-    loadSubagentToolCalls: async (request) => {
-      const vaultPath = getVaultPath(plugin.app);
-      if (!vaultPath) return undefined;
-      const service = ProviderRegistry.createSubagentHistoryService(
-        plugin.providerHost,
-        request.providerId,
-      );
-      if (!service) return undefined;
-      return service.loadToolCalls({
-        providerSessionId: request.providerSessionId,
-        subagentId: request.subagentId,
-        vaultPath,
-      });
-    },
-    loadSubagentFinalResult: async (request) => {
-      const vaultPath = getVaultPath(plugin.app);
-      if (!vaultPath) return undefined;
-      const service = ProviderRegistry.createSubagentHistoryService(
-        plugin.providerHost,
-        request.providerId,
-      );
-      if (!service) return undefined;
-      return service.loadFinalResult({
-        providerSessionId: request.providerSessionId,
-        subagentId: request.subagentId,
-        vaultPath,
-      });
-    },
-    enqueueBackgroundWork: (work) => enqueueTabBackgroundWork(tab, work),
-    persistConversation: async () => {
-      if (tab.state.currentConversationId) {
-        await tab.controllers.conversationController?.save(false);
-      }
-    },
-  });
+    (work) => enqueueTabBackgroundWork(tab, work),
+  );
   tab.controllers.streamController.setTabActive(
     !dom.contentEl.hasClass('claudian-hidden')
   );

--- a/src/features/chat/tabs/TabControllerFactory.ts
+++ b/src/features/chat/tabs/TabControllerFactory.ts
@@ -1,0 +1,69 @@
+import type { Component } from 'obsidian';
+
+import type { ChatRewindMode } from '../../../core/execution';
+import type { ProviderCapabilities } from '../../../core/providers/types';
+import type { FeatureHost } from '../../FeatureHost';
+import { BrowserSelectionController } from '../controllers/BrowserSelectionController';
+import { CanvasSelectionController } from '../controllers/CanvasSelectionController';
+import { SelectionController } from '../controllers/SelectionController';
+import { MessageRenderer } from '../rendering/MessageRenderer';
+import type { TabData, TabManagerViewHost } from './types';
+
+export interface TabPresentationControllerOptions {
+  plugin: FeatureHost;
+  component: Component;
+  getCapabilities: () => ProviderCapabilities;
+  onRewind: (messageId: string, mode?: ChatRewindMode) => Promise<void>;
+  onForkRequest?: (messageId: string) => Promise<void>;
+  onCommitProvisional: () => void;
+}
+
+/**
+ * Installs the renderer and selection controllers that form the tab's
+ * presentation layer. Execution controllers are intentionally initialized by
+ * the tab orchestration flow after this layer exists.
+ */
+export function initializeTabPresentationControllers(
+  tab: TabData,
+  options: TabPresentationControllerOptions,
+): void {
+  const { dom, ui } = tab;
+  const viewHost = options.component as Partial<TabManagerViewHost>;
+  const focusScopeEls = viewHost.getSharedSelectionFocusScopeEls?.() ?? [];
+
+  tab.renderer = new MessageRenderer(
+    options.plugin,
+    options.component,
+    dom.messagesEl,
+    options.onRewind,
+    options.onForkRequest
+      ? options.onForkRequest
+      : undefined,
+    options.getCapabilities,
+  );
+
+  tab.controllers.selectionController = new SelectionController(
+    options.plugin.app,
+    ui.contextTray!,
+    dom.inputEl,
+    undefined,
+    [dom.contentEl, dom.inputComposerEl, ...focusScopeEls],
+    options.onCommitProvisional,
+  );
+
+  tab.controllers.browserSelectionController = new BrowserSelectionController(
+    options.plugin.app,
+    ui.contextTray!,
+    dom.inputEl,
+    undefined,
+    options.onCommitProvisional,
+  );
+
+  tab.controllers.canvasSelectionController = new CanvasSelectionController(
+    options.plugin.app,
+    ui.contextTray!,
+    dom.inputEl,
+    undefined,
+    options.onCommitProvisional,
+  );
+}

--- a/src/features/chat/tabs/TabConversationControllerFactory.ts
+++ b/src/features/chat/tabs/TabConversationControllerFactory.ts
@@ -1,0 +1,66 @@
+import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
+import type { Conversation, ProviderId } from '../../../core/types';
+import type { FeatureHost } from '../../FeatureHost';
+import { ConversationController } from '../controllers/ConversationController';
+import type { TabData } from './types';
+
+export interface TabConversationControllerOptions {
+  ensureExecutionInitialized: () => Promise<boolean>;
+  getProviderId: () => ProviderId;
+  getSelectedModel: () => string | null;
+  onConversationBindingChanged: (conversation: Conversation | null) => Promise<void>;
+  onNewConversation: () => void;
+  onConversationActivated: () => void;
+}
+
+/**
+ * Assembles ConversationController against the tab runtime. Conversation
+ * binding remains a hook because provider settings, command catalogs, and
+ * execution sessions must change as one tab-owned transaction.
+ */
+export function createTabConversationController(
+  tab: TabData,
+  plugin: FeatureHost,
+  options: TabConversationControllerOptions,
+): ConversationController {
+  const { dom, state, services, ui } = tab;
+  return new ConversationController(
+    {
+      plugin,
+      state,
+      renderer: tab.renderer!,
+      subagentManager: services.subagentManager,
+      getHistoryDropdown: () => null,
+      getWelcomeEl: () => dom.welcomeEl,
+      setWelcomeEl: (el) => { dom.welcomeEl = el; },
+      getMessagesEl: () => dom.messagesEl,
+      getInputEl: () => dom.inputEl,
+      restoreMessageToComposer: message => (
+        tab.controllers.inputController!.restoreRewoundMessageToComposer(message)
+      ),
+      getFileContextManager: () => ui.fileContextManager,
+      getImageContextManager: () => ui.imageContextManager,
+      getMcpServerSelector: () => ui.mcpServerSelector,
+      getExternalContextSelector: () => ui.externalContextSelector,
+      clearQueuedMessage: () => tab.controllers.inputController?.clearQueuedMessage(),
+      getTitleGenerationService: () => services.titleGenerationService,
+      getStatusPanel: () => ui.statusPanel,
+      getExecutionCoordinator: () => tab.executionCoordinator,
+      ensureExecutionInitialized: options.ensureExecutionInitialized,
+      getProviderId: options.getProviderId,
+      getSelectedModel: options.getSelectedModel,
+      getInitialUsage: (providerId: ProviderId, model: string) => ProviderRegistry
+        .getChatUIConfig(providerId)
+        .getInitialUsage?.(model, plugin.settings) ?? null,
+      dismissPendingInlinePrompts: () => tab.controllers.inputController?.dismissPendingApproval(),
+      awaitBackgroundWork: () => tab.session.awaitBackgroundWork(),
+      isDisposed: () => tab.lifecycleState === 'closing',
+      ensureExecutionForConversation: options.onConversationBindingChanged,
+    },
+    {
+      onNewConversation: options.onNewConversation,
+      onConversationLoaded: options.onConversationActivated,
+      onConversationSwitched: options.onConversationActivated,
+    },
+  );
+}

--- a/src/features/chat/tabs/TabInputControllerFactory.ts
+++ b/src/features/chat/tabs/TabInputControllerFactory.ts
@@ -1,0 +1,90 @@
+import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
+import type { FeatureHost } from '../../FeatureHost';
+import { InputController } from '../controllers/InputController';
+import { autoResizeTextarea } from '../ui/textareaResize';
+import { getTabProviderId } from './providerResolution';
+import type { TabData } from './types';
+
+export interface TabInputControllerOptions {
+  ensureExecutionInitialized: () => Promise<boolean>;
+  generateId: () => string;
+  getAuxiliaryModel: () => string | null;
+  openConversation?: (conversationId: string) => Promise<void>;
+  handleNewConversationCommand?: () => Promise<boolean>;
+  handleNewSessionPlan?: (planContent: string) => Promise<boolean>;
+  onForkAll?: () => Promise<void>;
+  toggleFastMode: () => Promise<boolean>;
+  restorePrePlanPermissionModeIfNeeded: () => void | Promise<void>;
+  onDiagnosticError: (error: unknown) => void;
+}
+
+/**
+ * Assembles InputController from the tab runtime and a small set of layout
+ * and provider-transition hooks. Input behavior itself remains owned by the
+ * controller; this module only owns dependency wiring and preflight policy.
+ */
+export function createTabInputController(
+  tab: TabData,
+  plugin: FeatureHost,
+  options: TabInputControllerOptions,
+): InputController {
+  const { dom, state, services, ui, controllers } = tab;
+  return new InputController({
+    plugin,
+    state,
+    renderer: tab.renderer!,
+    streamController: controllers.streamController!,
+    selectionController: controllers.selectionController!,
+    browserSelectionController: controllers.browserSelectionController ?? undefined,
+    canvasSelectionController: controllers.canvasSelectionController!,
+    conversationController: controllers.conversationController!,
+    getInputEl: () => dom.inputEl,
+    getInputContainerEl: () => dom.inputContainerEl,
+    getWelcomeEl: () => dom.welcomeEl,
+    getMessagesEl: () => dom.messagesEl,
+    getFileContextManager: () => ui.fileContextManager,
+    getImageContextManager: () => ui.imageContextManager,
+    getMcpServerSelector: () => ui.mcpServerSelector,
+    getExternalContextSelector: () => ui.externalContextSelector,
+    getInstructionModeManager: () => ui.instructionModeManager,
+    getInstructionRefineService: () => services.instructionRefineService,
+    getTitleGenerationService: () => services.titleGenerationService,
+    getStatusPanel: () => ui.statusPanel,
+    generateId: options.generateId,
+    resetInputHeight: () => autoResizeTextarea(dom.inputEl),
+    getAuxiliaryModel: options.getAuxiliaryModel,
+    getExecutionCoordinator: () => tab.executionCoordinator,
+    getSubagentManager: () => services.subagentManager,
+    getTabProviderId: () => getTabProviderId(tab, plugin),
+    turnOwner: tab.session,
+    ensureExecutionInitialized: options.ensureExecutionInitialized,
+    openConversation: options.openConversation,
+    handleNewConversationCommand: options.handleNewConversationCommand,
+    handleNewSessionPlan: options.handleNewSessionPlan,
+    onForkAll: options.onForkAll,
+    toggleFastMode: options.toggleFastMode,
+    restorePrePlanPermissionModeIfNeeded: options.restorePrePlanPermissionModeIfNeeded,
+    captureReviewableSettlement: tab.captureReviewableSettlement ?? undefined,
+    onDiagnosticError: options.onDiagnosticError,
+    preflightExecution: async () => {
+      let diagnostics;
+      try {
+        diagnostics = await ProviderRegistry.collectDiagnostics(tab.providerId, {
+          settings: plugin.settings,
+          resolveCliPath: () => plugin.providerHost.getResolvedProviderCliPath(tab.providerId),
+        });
+      } catch {
+        return new Error('Provider CLI not found.');
+      }
+      if (diagnostics?.readiness?.status === 'disabled') {
+        return new Error('Provider is not enabled.');
+      }
+      const blockedCheck = diagnostics?.readiness?.checks.find(check => check.status === 'blocked');
+      if (!blockedCheck) return null;
+      if (blockedCheck.id === 'cli') return new Error('Provider CLI not found.');
+      if (blockedCheck.id === 'selection') return new Error('No chat model is selected.');
+      if (blockedCheck.id === 'enabled') return new Error('Provider is not enabled.');
+      return new Error('Provider model catalog is unavailable.');
+    },
+  });
+}

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -27,7 +27,7 @@ import {
   destroyTab,
   type ForkContext,
   getTabTitle,
-  initializeTabControllers,
+  initializeTabRuntimeControllers,
   initializeTabUI,
   onProviderAvailabilityChanged,
   refreshTabWorkspaceServices,
@@ -248,7 +248,7 @@ export class TabManager implements TabManagerInterface {
       },
     });
 
-    initializeTabControllers(
+    initializeTabRuntimeControllers(
       tab,
       this.plugin,
       this.view,

--- a/src/features/chat/tabs/TabNavigationControllerFactory.ts
+++ b/src/features/chat/tabs/TabNavigationControllerFactory.ts
@@ -1,0 +1,26 @@
+import type { FeatureHost } from '../../FeatureHost';
+import { NavigationController } from '../controllers/NavigationController';
+import type { TabData } from './types';
+
+/** Installs the keyboard-navigation controller for a tab. */
+export function initializeTabNavigationController(
+  tab: TabData,
+  plugin: FeatureHost,
+): void {
+  const { dom, state, ui } = tab;
+  tab.controllers.navigationController = new NavigationController({
+    getMessagesEl: () => dom.messagesEl,
+    getInputEl: () => dom.inputEl,
+    getSettings: () => plugin.settings.keyboardNavigation,
+    isStreaming: () => state.isStreaming,
+    shouldSkipEscapeHandling: () => {
+      if (ui.instructionModeManager?.isActive()) return true;
+      if (ui.bangBashModeManager?.isActive()) return true;
+      if (tab.controllers.inputController?.isResumeDropdownVisible()) return true;
+      if (ui.slashCommandDropdown?.isVisible()) return true;
+      if (ui.fileContextManager?.isMentionDropdownVisible()) return true;
+      return false;
+    },
+  });
+  tab.controllers.navigationController.initialize();
+}

--- a/src/features/chat/tabs/TabRuntimeCleanup.ts
+++ b/src/features/chat/tabs/TabRuntimeCleanup.ts
@@ -1,0 +1,43 @@
+export interface TabRuntimeCleanupFailure {
+  readonly error: unknown;
+  readonly resource: string;
+}
+
+export type TabRuntimeCleanupTask = () => void | Promise<void>;
+
+/** Owns teardown tasks for one tab runtime and releases them in reverse order. */
+export class TabRuntimeCleanup {
+  private readonly tasks: Array<{ resource: string; task: TabRuntimeCleanupTask }> = [];
+  private disposal: Promise<readonly TabRuntimeCleanupFailure[]> | null = null;
+
+  get isDisposed(): boolean {
+    return this.disposal !== null;
+  }
+
+  register(resource: string, task: TabRuntimeCleanupTask): void {
+    if (this.disposal) {
+      throw new Error(`Cannot register ${resource} after tab runtime cleanup`);
+    }
+    this.tasks.push({ resource, task });
+  }
+
+  dispose(): Promise<readonly TabRuntimeCleanupFailure[]> {
+    if (!this.disposal) {
+      this.disposal = this.disposeTasks();
+    }
+    return this.disposal;
+  }
+
+  private async disposeTasks(): Promise<readonly TabRuntimeCleanupFailure[]> {
+    const failures: TabRuntimeCleanupFailure[] = [];
+    const tasks = this.tasks.splice(0).reverse();
+    for (const { resource, task } of tasks) {
+      try {
+        await task();
+      } catch (error) {
+        failures.push({ error, resource });
+      }
+    }
+    return failures;
+  }
+}

--- a/src/features/chat/tabs/TabRuntimeFactory.ts
+++ b/src/features/chat/tabs/TabRuntimeFactory.ts
@@ -1,0 +1,179 @@
+import { setIcon } from 'obsidian';
+
+import {
+  resolveNewConversationModel,
+} from '../../../core/providers/conversationModel';
+import { getEnabledProviderForModel } from '../../../core/providers/modelRouting';
+import { DEFAULT_CHAT_PROVIDER_ID } from '../../../core/providers/types';
+import { createWelcomeElement } from '../rendering/WelcomeRenderer';
+import { SubagentManager } from '../services/SubagentManager';
+import { ChatState } from '../state/ChatState';
+import { TabSession } from './TabSession';
+import type { TabCreateOptions, TabData, TabDOMElements } from './types';
+import { generateTabId } from './types';
+
+export interface TabRuntimeFactoryHooks {
+  onStreamingStateChanged?: (tab: TabData, isStreaming: boolean) => void;
+}
+
+/**
+ * Owns allocation of the provider-neutral runtime shell for one tab.
+ * Provider execution, controllers, and feature UI are initialized separately.
+ */
+export function createTabRuntime(
+  options: TabCreateOptions,
+  hooks: TabRuntimeFactoryHooks = {},
+): TabData {
+  const {
+    plugin,
+    containerEl,
+    conversation,
+    tabId,
+    onStreamingChanged,
+    onRewindingChanged,
+    onAttentionChanged,
+    onConversationIdChanged,
+  } = options;
+
+  const id = tabId ?? generateTabId();
+  const contentEl = containerEl.createDiv({ cls: 'claudian-tab-content claudian-hidden' });
+  const state = new ChatState({
+    onStreamingStateChanged: onStreamingChanged,
+    onRewindingStateChanged: onRewindingChanged,
+    onAttentionChanged,
+    onConversationChanged: onConversationIdChanged,
+  });
+  const subagentManager = new SubagentManager(() => {});
+  const dom = buildTabDOM(contentEl);
+  state.queueIndicatorEl = dom.queueIndicatorEl;
+
+  const isBound = !!conversation?.id;
+  const restoredDraftModel = typeof options.draftModel === 'string'
+    ? options.draftModel.trim()
+    : '';
+  const newConversationModel = !isBound && !restoredDraftModel
+    ? resolveNewConversationModel(plugin.settings)
+    : null;
+  const draftModel = isBound
+    ? null
+    : (restoredDraftModel || newConversationModel?.model || null);
+  const initialProviderId = conversation?.providerId
+    ?? newConversationModel?.providerId
+    ?? (draftModel
+      ? getEnabledProviderForModel(draftModel, plugin.settings)
+      : DEFAULT_CHAT_PROVIDER_ID);
+  const session = new TabSession({
+    id,
+    lifecycleState: options.lifecycleState ?? 'cold',
+    draftModel,
+    providerId: initialProviderId,
+    conversationId: conversation?.id ?? null,
+  });
+  const tab: TabData = {
+    session,
+    get id() { return session.id; },
+    get lifecycleState() { return session.lifecycleState; },
+    set lifecycleState(value) { session.lifecycleState = value; },
+    hydrationState: isBound ? 'idle' : 'ready',
+    get draftModel() { return session.draftModel; },
+    set draftModel(value) { session.draftModel = value; },
+    get providerId() { return session.providerId; },
+    set providerId(value) { session.providerId = value; },
+    get conversationId() { return session.conversationId; },
+    set conversationId(value) { session.conversationId = value; },
+    get executionCoordinator() { return session.executionCoordinator; },
+    set executionCoordinator(coordinator) { session.setExecutionCoordinator(coordinator); },
+    providerCatalogResolver: null,
+    captureReviewableSettlement: options.captureReviewableSettlement ?? null,
+    state,
+    controllers: {
+      selectionController: null,
+      browserSelectionController: null,
+      canvasSelectionController: null,
+      conversationController: null,
+      streamController: null,
+      inputController: null,
+      navigationController: null,
+    },
+    services: {
+      subagentManager,
+      instructionRefineService: null,
+      titleGenerationService: null,
+    },
+    ui: {
+      contextTray: null,
+      fileContextManager: null,
+      imageContextManager: null,
+      modelSelector: null,
+      modeSelector: null,
+      thinkingBudgetSelector: null,
+      externalContextSelector: null,
+      mcpServerSelector: null,
+      permissionToggle: null,
+      serviceTierToggle: null,
+      slashCommandDropdown: null,
+      instructionModeManager: null,
+      bangBashModeManager: null,
+      contextUsageMeter: null,
+      statusPanel: null,
+      navigationSidebar: null,
+    },
+    dom,
+    renderer: null,
+  };
+
+  state.callbacks = {
+    ...state.callbacks,
+    onStreamingStateChanged: (isStreaming) => {
+      onStreamingChanged?.(isStreaming);
+      hooks.onStreamingStateChanged?.(tab, isStreaming);
+    },
+  };
+  return tab;
+}
+
+function buildTabDOM(contentEl: HTMLElement): TabDOMElements {
+  const messagesWrapperEl = contentEl.createDiv({ cls: 'claudian-messages-wrapper' });
+  const messagesEl = messagesWrapperEl.createDiv({ cls: 'claudian-messages' });
+  const welcomeEl = createWelcomeElement(messagesEl);
+  const statusPanelContainerEl = contentEl.createDiv({ cls: 'claudian-status-panel-container' });
+  const inputComposerEl = contentEl.createDiv({ cls: 'claudian-input-composer' });
+  const inputContainerEl = inputComposerEl.createDiv({ cls: 'claudian-input-container' });
+  const queueIndicatorEl = inputContainerEl.createDiv({ cls: 'claudian-input-queue-row' });
+  const navRowEl = inputContainerEl.createDiv({ cls: 'claudian-input-nav-row' });
+  const inputWrapper = inputContainerEl.createDiv({ cls: 'claudian-input-wrapper' });
+  const contextRowEl = inputWrapper.createDiv({ cls: 'claudian-context-row' });
+  const inputEl = inputWrapper.createEl('textarea', {
+    cls: 'claudian-input',
+    attr: {
+      placeholder: 'Ask to make changes, @mention files, run /commands',
+      rows: '3',
+      dir: 'auto',
+    },
+  });
+  const sendButtonEl = inputWrapper.createEl('button', {
+    cls: 'claudian-input-send-button',
+    attr: {
+      type: 'button',
+      'aria-label': 'Send message',
+      title: 'Send message (enter)',
+    },
+  });
+  setIcon(sendButtonEl, 'send');
+
+  return {
+    contentEl,
+    messagesEl,
+    welcomeEl,
+    statusPanelContainerEl,
+    inputComposerEl,
+    inputContainerEl,
+    queueIndicatorEl,
+    inputWrapper,
+    inputEl,
+    sendButtonEl,
+    navRowEl,
+    contextRowEl,
+    eventCleanups: [],
+  };
+}

--- a/src/features/chat/tabs/TabStreamControllerFactory.ts
+++ b/src/features/chat/tabs/TabStreamControllerFactory.ts
@@ -1,0 +1,68 @@
+import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
+import { getVaultPath } from '../../../utils/path';
+import type { FeatureHost } from '../../FeatureHost';
+import { StreamController } from '../controllers/StreamController';
+import { getTabProviderId } from './providerResolution';
+import type { TabData } from './types';
+
+export type TabBackgroundWorkEnqueuer = (
+  work: () => Promise<void>,
+) => Promise<void> | null;
+
+/**
+ * Creates the stream controller for a tab from its already allocated runtime.
+ * Provider history recovery stays behind the provider registry; the caller
+ * supplies only the tab background-work queue adapter.
+ */
+export function createTabStreamController(
+  tab: TabData,
+  plugin: FeatureHost,
+  enqueueBackgroundWork: TabBackgroundWorkEnqueuer,
+): StreamController {
+  const { dom, state, services, ui } = tab;
+  return new StreamController({
+    plugin,
+    state,
+    renderer: tab.renderer!,
+    subagentManager: services.subagentManager,
+    getMessagesEl: () => dom.messagesEl,
+    getFileContextManager: () => ui.fileContextManager,
+    updateQueueIndicator: () => tab.controllers.inputController?.updateQueueIndicator(),
+    getProviderId: () => getTabProviderId(tab, plugin),
+    getProviderSessionId: () => tab.executionCoordinator?.snapshot?.providerSessionId ?? null,
+    loadSubagentToolCalls: async (request) => {
+      const vaultPath = getVaultPath(plugin.app);
+      if (!vaultPath) return undefined;
+      const service = ProviderRegistry.createSubagentHistoryService(
+        plugin.providerHost,
+        request.providerId,
+      );
+      if (!service) return undefined;
+      return service.loadToolCalls({
+        providerSessionId: request.providerSessionId,
+        subagentId: request.subagentId,
+        vaultPath,
+      });
+    },
+    loadSubagentFinalResult: async (request) => {
+      const vaultPath = getVaultPath(plugin.app);
+      if (!vaultPath) return undefined;
+      const service = ProviderRegistry.createSubagentHistoryService(
+        plugin.providerHost,
+        request.providerId,
+      );
+      if (!service) return undefined;
+      return service.loadFinalResult({
+        providerSessionId: request.providerSessionId,
+        subagentId: request.subagentId,
+        vaultPath,
+      });
+    },
+    enqueueBackgroundWork,
+    persistConversation: async () => {
+      if (tab.state.currentConversationId) {
+        await tab.controllers.conversationController?.save(false);
+      }
+    },
+  });
+}

--- a/src/features/chat/tabs/types.ts
+++ b/src/features/chat/tabs/types.ts
@@ -4,7 +4,9 @@ import type { ProviderCommandDropdownConfig } from '../../../core/providers/comm
 import type { ProviderCommandDiscoveryController } from '../../../core/providers/commands/ProviderCommandDiscoveryStore';
 import type { ProviderCommandEntry } from '../../../core/providers/commands/ProviderCommandEntry';
 import type { InstructionRefineService, ProviderId, TitleGenerationService } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
 import type { SlashCommandDropdown } from '../../../shared/components/SlashCommandDropdown';
+import type { FeatureHost } from '../../FeatureHost';
 import type { BrowserSelectionController } from '../controllers/BrowserSelectionController';
 import type { CanvasSelectionController } from '../controllers/CanvasSelectionController';
 import type { ConversationController } from '../controllers/ConversationController';
@@ -79,6 +81,23 @@ export type ProviderCatalogInfo = {
 } | null;
 
 export type ProviderCatalogResolver = () => ProviderCatalogInfo;
+
+export interface TabCreateOptions {
+  plugin: FeatureHost;
+
+  containerEl: HTMLElement;
+  conversation?: Conversation;
+  tabId?: TabId;
+  /** Initial draft model for an unbound tab. */
+  draftModel?: string | null;
+  lifecycleState?: Extract<TabData['lifecycleState'], 'provisional' | 'cold'>;
+  onStreamingChanged?: (isStreaming: boolean) => void;
+  onRewindingChanged?: (isRewinding: boolean) => void;
+  onTitleChanged?: (title: string) => void;
+  onAttentionChanged?: (attention: TabAttention) => void;
+  captureReviewableSettlement?: () => () => void;
+  onConversationIdChanged?: (conversationId: string | null) => void;
+}
 
 /** Generates a unique tab ID. */
 export function generateTabId(): TabId {

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -63,7 +63,7 @@ jest.mock('@/features/chat/tabs/Tab', () => ({
   deactivateTab: jest.fn(),
   destroyTab: (...args: unknown[]) => mockDestroyTab(...args),
   getTabTitle: jest.fn().mockReturnValue('Tab'),
-  initializeTabControllers: (...args: unknown[]) => mockInitializeTabControllers(...args),
+  initializeTabRuntimeControllers: (...args: unknown[]) => mockInitializeTabControllers(...args),
   initializeTabExecution: (...args: unknown[]) => mockInitializeTabExecution(...args),
   initializeTabUI: jest.fn(),
   onProviderAvailabilityChanged: jest.fn().mockReturnValue(false),

--- a/tests/unit/features/chat/tabs/TabRuntimeCleanup.test.ts
+++ b/tests/unit/features/chat/tabs/TabRuntimeCleanup.test.ts
@@ -1,0 +1,49 @@
+import { TabRuntimeCleanup } from '@/features/chat/tabs/TabRuntimeCleanup';
+
+describe('TabRuntimeCleanup', () => {
+  it('disposes registered resources in reverse order', async () => {
+    const order: string[] = [];
+    const cleanup = new TabRuntimeCleanup();
+    cleanup.register('first', () => {
+      order.push('first');
+    });
+    cleanup.register('second', async () => {
+      order.push('second');
+    });
+
+    await expect(cleanup.dispose()).resolves.toEqual([]);
+    expect(order).toEqual(['second', 'first']);
+  });
+
+  it('continues cleanup after a resource fails and reports the failure', async () => {
+    const order: string[] = [];
+    const error = new Error('release failed');
+    const cleanup = new TabRuntimeCleanup();
+    cleanup.register('first', () => {
+      order.push('first');
+    });
+    cleanup.register('broken', () => {
+      order.push('broken');
+      throw error;
+    });
+    cleanup.register('last', () => {
+      order.push('last');
+    });
+
+    await expect(cleanup.dispose()).resolves.toEqual([
+      { error, resource: 'broken' },
+    ]);
+    expect(order).toEqual(['last', 'broken', 'first']);
+  });
+
+  it('makes disposal idempotent and rejects late registration', async () => {
+    const cleanup = new TabRuntimeCleanup();
+    const first = cleanup.dispose();
+
+    expect(cleanup.isDisposed).toBe(true);
+    await expect(cleanup.dispose()).resolves.toBe(await first);
+    expect(() => cleanup.register('late', () => undefined)).toThrow(
+      'Cannot register late after tab runtime cleanup',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Introduce a provider-neutral TabRuntimeFactory for tab DOM, ChatState, TabSession, and base runtime slots.
- Centralize reverse-order, idempotent tab cleanup with failure collection.
- Extract presentation, stream, conversation, input, and navigation controller assembly into focused factories.
- Rename initializeTabControllers to initializeTabRuntimeControllers while retaining the old name as a deprecated compatibility alias.
- Document ownership and lifecycle boundaries in src/features/chat/AGENTS.md.

## Architecture decisions

This is an incremental architecture migration. Provider execution, conversation binding transactions, and controller behavior remain in their existing owners. The new factories own allocation and dependency wiring only; they do not introduce provider parity assumptions or duplicate runtime behavior.

TabRuntimeCleanup runs after conversation persistence and execution draining, before DOM removal, and continues releasing later resources when one cleanup task fails.

## Verification

- npm run typecheck
- npm run lint (8 existing warnings, 0 errors)
- npm test -- --runInBand (387 suites, 6881 tests passed)
- npm run build

Build output was copied successfully to the configured Obsidian plugin directory.