### PR TITLE
fix: make vault file pane navigation discoverable

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -410,6 +410,10 @@ export class ClaudianView extends ItemView {
     this.sidebarSurfaceSwitcherEl = this.sessionSidebarEl.createDiv({
       cls: 'claudian-sidebar-surface-switcher',
     });
+    this.sessionSidebarEl.insertBefore(
+      this.sidebarSurfaceSwitcherEl,
+      this.sessionSidebarEl.firstChild,
+    );
     this.sidebarSurfaceSwitcherEl.setAttribute('role', 'group');
     this.sidebarSurfaceSwitcherEl.setAttribute('aria-label', 'Sidebar view');
     this.sessionsSurfaceButtonEl = this.sidebarSurfaceSwitcherEl.createEl('button', {

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -416,11 +416,15 @@ export class ClaudianView extends ItemView {
       cls: 'claudian-sidebar-surface-button claudian-sidebar-surface-button--sessions',
       attr: { 'aria-label': 'Sessions', type: 'button' },
     });
+    setIcon(this.sessionsSurfaceButtonEl, 'messages-square');
+    this.sessionsSurfaceButtonEl.createSpan({ text: 'Sessions' });
     this.sessionsSurfaceButtonEl.addEventListener('click', () => this.showSessions());
     this.filesSurfaceButtonEl = this.sidebarSurfaceSwitcherEl.createEl('button', {
       cls: 'claudian-sidebar-surface-button claudian-sidebar-surface-button--files',
       attr: { 'aria-label': 'Files', type: 'button' },
     });
+    setIcon(this.filesSurfaceButtonEl, 'folder-tree');
+    this.filesSurfaceButtonEl.createSpan({ text: 'Files' });
     this.filesSurfaceButtonEl.addEventListener('click', () => this.showVaultFiles());
     if (this.activeSidebarSurface !== 'files') {
       this.activeSidebarSurface = 'sessions';

--- a/src/style/components/history.css
+++ b/src/style/components/history.css
@@ -58,36 +58,15 @@
 }
 
 .claudian-sidebar-surface-switcher {
-  position: absolute;
-  inset-inline: 0;
-  bottom: 0;
-  z-index: 5;
+  position: relative;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   box-sizing: border-box;
-  height: var(--claudian-sidebar-surface-footer-height);
+  flex: 0 0 auto;
   gap: 6px;
-  padding: 6px 8px 8px;
+  padding: 8px 12px;
   background: var(--background-primary);
-  opacity: 1;
-  transition: opacity 0.12s ease;
-}
-
-.claudian-sidebar-surface-switcher:hover,
-.claudian-sidebar-surface-switcher:focus-within {
-  opacity: 1;
-}
-
-.claudian-session-sidebar:has(> .claudian-sidebar-surface-switcher:hover)
-  > .claudian-session-surface,
-.claudian-session-sidebar:has(> .claudian-sidebar-surface-switcher:hover)
-  > .claudian-files-surface,
-.claudian-session-sidebar:has(> .claudian-sidebar-surface-switcher:focus-within)
-  > .claudian-session-surface,
-.claudian-session-sidebar:has(> .claudian-sidebar-surface-switcher:focus-within)
-  > .claudian-files-surface {
-  clip-path: inset(0 0 var(--claudian-sidebar-surface-footer-height) 0);
 }
 
 .claudian-session-sidebar .claudian-sidebar-surface-button {
@@ -125,13 +104,8 @@
 }
 
 .claudian-session-sidebar .claudian-sidebar-surface-button:focus-visible {
-  background: transparent;
+  background: var(--background-modifier-hover);
   box-shadow: none;
-  outline: none;
-}
-
-.claudian-session-sidebar .claudian-sidebar-surface-button:focus-visible::before {
-  opacity: 0.72;
   outline: 2px solid var(--interactive-accent);
   outline-offset: 2px;
 }

--- a/src/style/components/history.css
+++ b/src/style/components/history.css
@@ -67,10 +67,10 @@
   justify-content: center;
   box-sizing: border-box;
   height: var(--claudian-sidebar-surface-footer-height);
-  gap: 14px;
-  padding: 8px 12px 12px;
-  background: transparent;
-  opacity: 0;
+  gap: 6px;
+  padding: 6px 8px 8px;
+  background: var(--background-primary);
+  opacity: 1;
   transition: opacity 0.12s ease;
 }
 
@@ -94,40 +94,34 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
-  min-width: 20px;
-  height: 20px;
-  padding: 0;
+  width: auto;
+  min-width: 0;
+  height: 28px;
+  gap: 6px;
+  padding: 4px 8px;
   color: var(--text-normal);
+  font-size: 12px;
   cursor: pointer;
-  border: 0;
-  border-radius: 0;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
   background: transparent;
   box-shadow: none;
 }
 
 .claudian-session-sidebar .claudian-sidebar-surface-button:hover,
 .claudian-session-sidebar .claudian-sidebar-surface-button:active {
-  background: transparent;
+  background: var(--background-modifier-hover);
   box-shadow: none;
 }
 
 .claudian-session-sidebar .claudian-sidebar-surface-button::before {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: currentColor;
-  content: "";
-  opacity: 0.22;
-  transition: opacity 0.12s ease;
+  display: none;
 }
 
-.claudian-session-sidebar .claudian-sidebar-surface-button:hover::before {
-  opacity: 0.45;
-}
-
-.claudian-session-sidebar .claudian-sidebar-surface-button.is-active::before {
-  opacity: 0.72;
+.claudian-session-sidebar .claudian-sidebar-surface-button.is-active {
+  color: var(--text-accent);
+  border-color: var(--interactive-accent);
+  background: var(--background-modifier-hover);
 }
 
 .claudian-session-sidebar .claudian-sidebar-surface-button:focus-visible {

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -1090,17 +1090,21 @@ describe('ClaudianView tab controls', () => {
     expect(viewContainerEl.children[0].hasClass('claudian-chat-panel')).toBe(true);
     expect(viewContainerEl.children[1].hasClass('claudian-session-resizer')).toBe(true);
     expect(viewContainerEl.children[2].hasClass('claudian-session-sidebar')).toBe(true);
-    expect(viewContainerEl.children[2].children[0].hasClass('claudian-session-surface')).toBe(true);
-    expect(viewContainerEl.children[2].children[1].hasClass('claudian-files-surface')).toBe(true);
-    expect(viewContainerEl.children[2].children[1].hasClass('claudian-hidden')).toBe(true);
-    expect(viewContainerEl.children[2].children[2]
+    expect(viewContainerEl.children[2].children[0]
       .hasClass('claudian-sidebar-surface-switcher')).toBe(true);
+    expect(viewContainerEl.children[2].children[1].hasClass('claudian-session-surface')).toBe(true);
+    expect(viewContainerEl.children[2].children[2].hasClass('claudian-files-surface')).toBe(true);
+    expect(viewContainerEl.children[2].children[2].hasClass('claudian-hidden')).toBe(true);
     expect(view.sidebarSurfaceSwitcherEl.getAttribute('role')).toBe('group');
     expect(view.sidebarSurfaceSwitcherEl.getAttribute('aria-label')).toBe('Sidebar view');
-    expect(view.sessionsSurfaceButtonEl.textContent).toBe('');
+    expect(view.sessionsSurfaceButtonEl.children.some((child: any) => (
+      child.textContent === 'Sessions'
+    ))).toBe(true);
     expect(view.sessionsSurfaceButtonEl.getAttribute('aria-label')).toBe('Sessions');
     expect(view.sessionsSurfaceButtonEl.getAttribute('aria-pressed')).toBe('true');
-    expect(view.filesSurfaceButtonEl.textContent).toBe('');
+    expect(view.filesSurfaceButtonEl.children.some((child: any) => (
+      child.textContent === 'Files'
+    ))).toBe(true);
     expect(view.filesSurfaceButtonEl.getAttribute('aria-label')).toBe('Files');
     expect(view.filesSurfaceButtonEl.getAttribute('aria-pressed')).toBe('false');
     expect(viewContainerEl.children[2].getAttribute('aria-label')).toBeNull();

--- a/tests/unit/style/components/history.test.ts
+++ b/tests/unit/style/components/history.test.ts
@@ -2,17 +2,14 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
 describe('Persistent sidebar surface pager styles', () => {
-  it('reveals the native sidebar background by clipping content under the footer', () => {
+  it('keeps the sidebar surface switcher visible at the top', () => {
     const css = readFileSync(path.resolve('src/style/components/history.css'), 'utf8');
 
     expect(css).toMatch(
       /\.claudian-session-sidebar\s*{[^}]*--claudian-sidebar-surface-footer-height:\s*40px;/,
     );
     expect(css).toMatch(
-      /\.claudian-sidebar-surface-switcher\s*{[^}]*height:\s*var\(--claudian-sidebar-surface-footer-height\);[^}]*background:\s*transparent;/,
-    );
-    expect(css).toMatch(
-      /\.claudian-session-sidebar:has\(> \.claudian-sidebar-surface-switcher:(?:hover|focus-within)\)[^{]*> \.claudian-(?:session|files)-surface[^{]*{[^}]*clip-path:\s*inset\(0 0 var\(--claudian-sidebar-surface-footer-height\) 0\);/,
+      /\.claudian-sidebar-surface-switcher\s*{[^}]*position:\s*relative;[^}]*flex:\s*0 0 auto;[^}]*background:\s*var\(--background-primary\);/,
     );
   });
 });


### PR DESCRIPTION
## Summary

- Move the Sessions/Files surface switcher from the bottom of the session sidebar to the top.
- Keep the switcher permanently visible instead of revealing it only on hover.
- Replace the nearly invisible dot controls with labeled, icon-backed buttons.
- Preserve active-state styling and keyboard focus visibility.

## Problem

The Vault file tree and native file actions were already implemented, but the entry point was a pair of transparent bottom dots. Users could not discover the Files surface from the visible Sessions sidebar.

## Verification

- 109 focused tests passed across ClaudianView and Vault file tree/menu/modal suites.
- typecheck passed.
- lint passed with one existing sentence-case warning.
- production build passed and copied main.js, manifest.json, and styles.css to the configured Obsidian plugin directory.