### PR TITLE
feat: refine chat composer and message styling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.1.16",
+  "version": "2.1.17",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claudian",
-  "version": "2.1.16",
+  "version": "2.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claudian",
-      "version": "2.1.16",
+      "version": "2.1.17",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "2.1.16",
+  "version": "2.1.17",
   "description": "Oh My Claudian - provider-backed coding agents embedded in the Obsidian sidebar",
   "main": "main.js",
   "engines": {

--- a/src/features/chat/tabs/TabRuntimeFactory.ts
+++ b/src/features/chat/tabs/TabRuntimeFactory.ts
@@ -159,7 +159,7 @@ function buildTabDOM(contentEl: HTMLElement): TabDOMElements {
       title: 'Send message (enter)',
     },
   });
-  setIcon(sendButtonEl, 'send');
+  setIcon(sendButtonEl, 'arrow-up');
 
   return {
     contentEl,

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -1,7 +1,7 @@
 /* Input area */
 .claudian-input-container {
   position: relative;
-  padding: 12px 0 0 0;
+  padding: 12px 0 0;
 }
 
 .claudian-input-footer {
@@ -16,16 +16,22 @@
 
 /* Input wrapper (border container) - flex column so textarea expands when no chips */
 .claudian-input-wrapper {
-  --claudian-input-wrapper-border-color: var(--background-modifier-border);
+  --claudian-input-wrapper-border-color: color-mix(in srgb, var(--background-modifier-border) 85%, var(--text-normal));
   --claudian-input-wrapper-box-shadow: none;
   position: relative;
   display: flex;
   flex-direction: column;
-  min-height: 140px;
+  min-height: 144px;
   border: 1px solid var(--claudian-input-wrapper-border-color);
-  border-radius: 6px;
+  border-radius: 16px;
   background: var(--background-primary);
   box-shadow: var(--claudian-input-wrapper-box-shadow);
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.claudian-input-wrapper:focus-within {
+  --claudian-input-wrapper-border-color: var(--text-muted);
+  --claudian-input-wrapper-box-shadow: 0 0 0 1px var(--background-modifier-border);
 }
 
 /* Nav row (tab badges start, action icons end) - above input wrapper */
@@ -33,7 +39,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 0 6px 0;
+  padding: 0 2px 6px;
   min-height: 0;
 }
 
@@ -52,7 +58,7 @@
 .claudian-input-nav-actions {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 4px;
   flex-shrink: 0;
   margin-inline-start: auto;
 }
@@ -61,11 +67,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: 28px;
+  height: 28px;
   padding: 0;
   border: 0;
-  border-radius: 4px;
+  border-radius: 8px;
   background: transparent;
   cursor: pointer;
   color: var(--text-faint);
@@ -90,12 +96,12 @@
 .claudian-input-wrapper textarea.claudian-input {
   width: 100%;
   flex: 1 1 0;
-  min-height: var(--claudian-textarea-min-height, 60px);
+  min-height: var(--claudian-textarea-min-height, 64px);
   max-height: var(--claudian-textarea-max-height, none);
   resize: none;
-  padding: 8px 10px 10px 10px;
+  padding: 13px 15px 48px;
   border: none;
-  border-radius: 6px;
+  border-radius: 15px;
   background: transparent;
   color: var(--text-normal);
   font-family: inherit;
@@ -119,18 +125,21 @@
 }
 
 .claudian-input-send-button {
+  position: absolute;
+  right: 10px;
+  bottom: 8px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  flex: 0 0 32px;
-  width: 32px;
-  height: 32px;
-  margin-inline-start: 8px;
+  flex: 0 0 36px;
+  width: 36px;
+  height: 36px;
+  margin: 0;
   padding: 0;
-  border: 1px solid var(--background-modifier-border);
-  border-radius: 6px;
-  background: transparent;
-  color: var(--text-muted);
+  border: 1px solid var(--claudian-brand);
+  border-radius: 50%;
+  background: var(--claudian-brand);
+  color: var(--background-primary);
   cursor: pointer;
   transition: background 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
 }
@@ -141,18 +150,17 @@
 }
 
 .claudian-input-send-button:hover:not(:disabled) {
-  background: var(--claudian-brand);
-  border-color: var(--claudian-brand);
+  background: color-mix(in srgb, var(--claudian-brand) 82%, var(--text-normal));
+  border-color: color-mix(in srgb, var(--claudian-brand) 82%, var(--text-normal));
   color: var(--background-primary);
-  filter: brightness(1.08);
 }
 
 .claudian-input-send-button:disabled {
-  background: transparent;
-  border-color: color-mix(in srgb, var(--claudian-brand) 35%, transparent);
-  color: color-mix(in srgb, var(--claudian-brand) 55%, var(--text-faint));
+  background: rgba(var(--claudian-brand-rgb), 0.48);
+  border-color: rgba(var(--claudian-brand-rgb), 0.48);
+  color: var(--background-primary);
   cursor: default;
-  opacity: 0.7;
+  opacity: 0.48;
 }
 
 .claudian-input-send-button.is-streaming {
@@ -173,8 +181,8 @@
   justify-content: flex-start;
   flex-wrap: wrap;
   flex-shrink: 0;
-  row-gap: 12px;
-  padding: 4px 6px 6px 6px;
+  row-gap: 8px;
+  padding: 4px 56px 8px 10px;
 }
 
 /* Hide secondary text when the full toolbar would wrap. */

--- a/src/style/components/messages.css
+++ b/src/style/components/messages.css
@@ -11,10 +11,10 @@
 .claudian-messages {
   flex: 1;
   overflow-y: auto;
-  padding: 12px 0 0;
+  padding: 16px 12px 0;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
 }
 
 /* Focusable messages panel for vim-style navigation */
@@ -46,17 +46,19 @@
 .claudian-message {
   position: relative;
   padding: 10px 14px;
-  border-radius: 8px;
+  border-radius: 14px;
   max-width: 95%;
   word-wrap: break-word;
 }
 
 .claudian-message-user {
   position: relative;
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(var(--claudian-brand-rgb), 0.16);
+  border: 1px solid rgba(var(--claudian-brand-rgb), 0.22);
   align-self: flex-end;
   margin-block-end: 16px;
-  border-end-end-radius: 4px;
+  max-width: min(80%, 48ch);
+  border-end-end-radius: 6px;
 }
 
 /* Text selection in user messages - visible highlight */
@@ -68,8 +70,9 @@
 .claudian-message-assistant {
   background: transparent;
   align-self: stretch;
-  width: 100%;
-  max-width: 100%;
+  width: min(100%, 72ch);
+  max-width: 72ch;
+  padding-inline: 0;
   border-end-start-radius: 4px;
   text-align: start;
 }
@@ -100,7 +103,7 @@
 .claudian-message-assistant .claudian-message-timestamp {
   position: static;
   display: block;
-  margin-top: 6px;
+  margin-top: 10px;
   text-align: start;
 }
 

--- a/src/style/components/thinking.css
+++ b/src/style/components/thinking.css
@@ -17,7 +17,7 @@
 }
 
 .claudian-thinking-block {
-  margin: 8px 0;
+  margin: 4px 0;
 }
 
 .claudian-text-block+.claudian-thinking-block {
@@ -47,9 +47,10 @@
 
 .claudian-thinking-label {
   flex: 1;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 500;
   color: var(--claudian-brand);
+  opacity: 0.86;
 }
 
 /* Thinking block content - tree-branch style */

--- a/src/style/components/toolcalls.css
+++ b/src/style/components/toolcalls.css
@@ -1,5 +1,5 @@
 .claudian-tool-call {
-  margin: 8px 0;
+  margin: 4px 0;
 }
 
 .claudian-tool-header {

--- a/src/style/toolbar/model-selector.css
+++ b/src/style/toolbar/model-selector.css
@@ -6,16 +6,21 @@
 .claudian-model-btn {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 4px 8px;
-  border-radius: 4px;
+  gap: 6px;
+  padding: 4px 6px;
+  border-radius: 7px;
   cursor: pointer;
   color: var(--claudian-brand);
   font-size: 12px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.claudian-model-btn:hover {
+  background: var(--background-modifier-hover);
 }
 
 .claudian-model-label {
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .claudian-model-chevron {

--- a/src/style/toolbar/thinking-selector.css
+++ b/src/style/toolbar/thinking-selector.css
@@ -27,7 +27,7 @@
 
 /* Current selection (visible when collapsed) */
 .claudian-thinking-current {
-  padding: 3px 8px;
+  padding: 4px 6px;
   font-size: 11px;
   color: var(--claudian-brand);
   font-weight: 500;


### PR DESCRIPTION
## Summary

- Refine the chat composer layout and controls for a softer, more compact interaction surface.
- Keep provider-specific theme colors driven by the existing provider theme variables.
- Improve message spacing, user bubble styling, assistant reading width, thinking labels, and tool row density.
- Bump the plugin version to 2.1.17.
- Keep the change presentation-only; no provider adapters or provider-specific runtime behavior were added.

## Validation

- `npm run typecheck`
- `npm run lint` (8 existing warnings, 0 errors)
- `npm run build`
- GitHub CI: lockfile, lint, typecheck, test, and build all passed.
