### PR TITLE
refactor: coordinate session lifecycle

### DIFF
--- a/src/app/conversations/SessionInvalidationCoordinator.ts
+++ b/src/app/conversations/SessionInvalidationCoordinator.ts
@@ -1,0 +1,174 @@
+import { ProviderRegistry } from '../../core/providers/ProviderRegistry';
+import type { ProviderId } from '../../core/providers/types';
+import type { ClaudianSettings } from '../../core/types';
+import type { ConditionalSettingsMutation } from '../settings/SettingsCoordinator';
+
+export interface SessionInvalidationCoordinatorOptions {
+  getSettings: () => ClaudianSettings;
+  mutateSettingsConditionally: (
+    mutation: ConditionalSettingsMutation<ClaudianSettings>,
+  ) => Promise<void>;
+}
+
+export interface ProviderSessionInvalidationStatus {
+  pendingGeneration: number | undefined;
+  blockedGeneration: number | undefined;
+}
+
+export class SessionInvalidationCoordinator {
+  private readonly getSettings: () => ClaudianSettings;
+  private readonly mutateSettingsConditionally: (
+    mutation: ConditionalSettingsMutation<ClaudianSettings>,
+  ) => Promise<void>;
+  private pendingGenerations = new Map<ProviderId, number>();
+  private blockedGenerations = new Map<ProviderId, number>();
+
+  constructor(options: SessionInvalidationCoordinatorOptions) {
+    this.getSettings = options.getSettings;
+    this.mutateSettingsConditionally = options.mutateSettingsConditionally;
+  }
+
+  sync(settings: ClaudianSettings): boolean {
+    const pending = readPendingProviderSessionInvalidations(settings);
+    const changed = !hasSamePendingProviderSessionInvalidations(
+      settings.pendingProviderSessionInvalidations,
+      pending,
+    );
+    settings.pendingProviderSessionInvalidations = serializePendingProviderSessionInvalidations(pending);
+    this.pendingGenerations = pending;
+    return changed;
+  }
+
+  getPendingProviderIds(): ProviderId[] {
+    return [...this.pendingGenerations.keys()];
+  }
+
+  getPendingGenerations(): Map<ProviderId, number> {
+    return new Map(this.pendingGenerations);
+  }
+
+  getStatus(providerId: ProviderId): ProviderSessionInvalidationStatus {
+    return {
+      pendingGeneration: this.pendingGenerations.get(providerId),
+      blockedGeneration: this.blockedGenerations.get(providerId),
+    };
+  }
+
+  stage(settings: ClaudianSettings, providerIds: ProviderId[]): Map<ProviderId, number> {
+    const pending = readPendingProviderSessionInvalidations(settings);
+    const marked = new Map<ProviderId, number>();
+    for (const providerId of new Set(providerIds)) {
+      const previousGeneration = Math.max(
+        pending.get(providerId) ?? 0,
+        this.pendingGenerations.get(providerId) ?? 0,
+      );
+      const generation = Math.max(Date.now(), previousGeneration + 1);
+      pending.set(providerId, generation);
+      marked.set(providerId, generation);
+    }
+    settings.pendingProviderSessionInvalidations = serializePendingProviderSessionInvalidations(pending);
+    return marked;
+  }
+
+  commit(generations: ReadonlyMap<ProviderId, number>): void {
+    for (const [providerId, generation] of generations) {
+      this.pendingGenerations.set(providerId, generation);
+    }
+  }
+
+  block(generations: ReadonlyMap<ProviderId, number>): void {
+    for (const [providerId, generation] of generations) {
+      this.blockedGenerations.set(providerId, generation);
+    }
+  }
+
+  release(generations: ReadonlyMap<ProviderId, number>): void {
+    for (const [providerId, generation] of generations) {
+      if (this.blockedGenerations.get(providerId) === generation) {
+        this.blockedGenerations.delete(providerId);
+      }
+    }
+  }
+
+  getCompletable(): Map<ProviderId, number> {
+    return new Map(Array.from(
+      this.pendingGenerations,
+      ([providerId, generation]) => [providerId, generation] as const,
+    ).filter(([providerId, generation]) => (
+      this.blockedGenerations.get(providerId) !== generation
+    )));
+  }
+
+  async complete(generations: ReadonlyMap<ProviderId, number>): Promise<void> {
+    if (generations.size === 0) return;
+
+    const removed = new Map<ProviderId, number>();
+    try {
+      await this.mutateSettingsConditionally((settings) => {
+        const pending = readPendingProviderSessionInvalidations(settings);
+        for (const [providerId, generation] of generations) {
+          if (pending.get(providerId) === generation) {
+            pending.delete(providerId);
+            removed.set(providerId, generation);
+          }
+        }
+        if (removed.size === 0) return false;
+        settings.pendingProviderSessionInvalidations = serializePendingProviderSessionInvalidations(pending);
+        return true;
+      });
+    } catch (error) {
+      const pending = readPendingProviderSessionInvalidations(this.getSettings());
+      for (const [providerId, generation] of removed) {
+        if (this.pendingGenerations.get(providerId) === generation) {
+          pending.set(providerId, generation);
+        }
+      }
+      this.getSettings().pendingProviderSessionInvalidations = serializePendingProviderSessionInvalidations(pending);
+      throw error;
+    }
+
+    for (const [providerId, generation] of removed) {
+      if (this.pendingGenerations.get(providerId) === generation) {
+        this.pendingGenerations.delete(providerId);
+      }
+    }
+  }
+}
+
+function readPendingProviderSessionInvalidations(
+  settings: Record<string, unknown>,
+): Map<ProviderId, number> {
+  const registeredProviderIds = new Set(ProviderRegistry.getRegisteredProviderIds());
+  const value = settings.pendingProviderSessionInvalidations;
+  const pending = new Map<ProviderId, number>();
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return pending;
+  for (const [providerId, generation] of Object.entries(value)) {
+    if (
+      registeredProviderIds.has(providerId)
+      && typeof generation === 'number'
+      && Number.isSafeInteger(generation)
+      && generation > 0
+    ) {
+      pending.set(providerId, generation);
+    }
+  }
+  return pending;
+}
+
+function serializePendingProviderSessionInvalidations(
+  pending: ReadonlyMap<ProviderId, number>,
+): Partial<Record<string, number>> {
+  return Object.fromEntries(
+    Array.from(pending.entries()).sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function hasSamePendingProviderSessionInvalidations(
+  value: unknown,
+  pending: ReadonlyMap<ProviderId, number>,
+): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const entries = Object.entries(value);
+  return entries.length === pending.size
+    && entries.every(([providerId, generation]) => pending.get(providerId) === generation);
+}

--- a/src/app/conversations/SessionMetadataCoordinator.ts
+++ b/src/app/conversations/SessionMetadataCoordinator.ts
@@ -1,0 +1,221 @@
+import type {
+  SessionMetadataReader,
+  SessionMetadataReadResult,
+} from '../../core/bootstrap/SessionStorage';
+import { StartupProfiler } from '../../core/performance/StartupProfiler';
+import { ProviderSettingsCoordinator } from '../../core/providers/ProviderSettingsCoordinator';
+import type { ProviderId } from '../../core/providers/types';
+import { DEFAULT_CHAT_PROVIDER_ID } from '../../core/providers/types';
+import type {
+  Conversation,
+  SessionMetadata,
+} from '../../core/types';
+import type { ConversationRepository } from './ConversationRepository';
+
+export interface SessionMetadataCoordinatorOptions {
+  sessions: SessionMetadataReader;
+  repository: ConversationRepository;
+  getPendingInvalidationProviderIds: () => readonly ProviderId[];
+  isUnloading: () => boolean;
+  recoverMissingConversationModels: () => Promise<Conversation[]>;
+  completePendingSessionInvalidations: () => Promise<void>;
+  notifyConversationViewsChanged: () => void;
+}
+
+export class SessionMetadataCoordinator {
+  private readonly sessions: SessionMetadataReader;
+  private readonly repository: ConversationRepository;
+  private readonly getPendingInvalidationProviderIds: () => readonly ProviderId[];
+  private readonly isUnloading: () => boolean;
+  private readonly recoverMissingConversationModels: () => Promise<Conversation[]>;
+  private readonly completePendingSessionInvalidations: () => Promise<void>;
+  private readonly notifyConversationViewsChanged: () => void;
+
+  constructor(options: SessionMetadataCoordinatorOptions) {
+    this.sessions = options.sessions;
+    this.repository = options.repository;
+    this.getPendingInvalidationProviderIds = options.getPendingInvalidationProviderIds;
+    this.isUnloading = options.isUnloading;
+    this.recoverMissingConversationModels = options.recoverMissingConversationModels;
+    this.completePendingSessionInvalidations = options.completePendingSessionInvalidations;
+    this.notifyConversationViewsChanged = options.notifyConversationViewsChanged;
+  }
+
+  async loadSessionMetadataWithSources(): Promise<{
+    records: SessionMetadataReadResult[];
+    complete: boolean;
+    invalidMetadataCount: number;
+  }> {
+    const scan = await this.sessions.scanMetadata();
+    return {
+      records: await this.resolveMetadataSources(scan.metadata),
+      complete: scan.complete,
+      invalidMetadataCount: scan.invalidMetadataCount,
+    };
+  }
+
+  async loadRemainingSessionMetadata(): Promise<boolean> {
+    const addedConversations: Conversation[] = [];
+    const invalidatedConversations: Conversation[] = [];
+    let didChangeConversationList = false;
+    const publishBatch = (metadata: SessionMetadata[]): void => {
+      if (this.isUnloading() || metadata.length === 0) return;
+
+      const recoverySources = metadata.map((item) => (
+        createConversationMetadataShell(item)
+      ));
+      const shells = metadata
+        .map((item) => createConversationMetadataShell(item))
+        .filter((conversation) => (
+          this.repository.isSelectedModelPublicationSafe(conversation)
+        ));
+      const publishedIds = new Set(shells.map(({ id }) => id));
+      const invalidatedShells = ProviderSettingsCoordinator
+        .invalidateConversationSessions(
+          shells,
+          [...this.getPendingInvalidationProviderIds()],
+        );
+      const invalidatedIds = new Set(
+        invalidatedShells.map(({ id }) => id),
+      );
+      const added = this.repository.mergeMetadataConversations(shells);
+      this.repository.registerHistoricalModelRecoverySources(
+        recoverySources.filter(({ id }) => publishedIds.has(id)),
+      );
+      if (added.length === 0) return;
+
+      addedConversations.push(...added);
+      invalidatedConversations.push(
+        ...added.filter(({ id }) => invalidatedIds.has(id)),
+      );
+      didChangeConversationList = true;
+    };
+    const scan = await this.sessions.scanMetadata({
+      onBatch: publishBatch,
+    });
+    if (this.isUnloading()) {
+      return scan.complete;
+    }
+
+    StartupProfiler.recordCount('session-metadata-count', scan.metadata.length);
+    StartupProfiler.recordCount(
+      'invalid-session-metadata-count',
+      scan.invalidMetadataCount,
+    );
+    const scannedShells = scan.metadata
+      .map(({ id }) => this.repository.getCachedConversation(id))
+      .filter((shell): shell is Conversation => shell !== null);
+    const records = await this.resolveMetadataSources(scan.metadata);
+    const resolvedIds = new Set(records.map(({ metadata }) => metadata.id));
+    const unresolvedShells = scannedShells.filter(
+      ({ id }) => !resolvedIds.has(id),
+    );
+    this.repository.discardUnresolvedMetadataShells(unresolvedShells);
+    if (unresolvedShells.length > 0) {
+      didChangeConversationList = true;
+    }
+    publishBatch(records.map(({ metadata }) => metadata));
+    const entries = records.map(({ metadata, needsMigration, source }) => ({
+      conversation: createConversationMetadataShell(metadata),
+      needsMigration,
+      source,
+    }));
+    const shells = entries.map(({ conversation }) => conversation);
+    const invalidatedEntries = ProviderSettingsCoordinator
+      .invalidateConversationSessions(
+        shells,
+        [...this.getPendingInvalidationProviderIds()],
+      );
+    const invalidatedIds = new Set(
+      invalidatedEntries.map(({ id }) => id),
+    );
+    const existingIds = new Set(
+      this.repository.getAll().map(({ id }) => id),
+    );
+    await this.repository.adoptMetadataConversations(entries);
+    this.repository.registerHistoricalModelRecoverySources(shells);
+    const adoptedConversations = shells.filter((conversation) => (
+      !existingIds.has(conversation.id)
+      && this.repository.getCachedConversation(conversation.id)
+        === conversation
+    ));
+    if (adoptedConversations.length > 0) {
+      addedConversations.push(...adoptedConversations);
+      invalidatedConversations.push(
+        ...adoptedConversations.filter(({ id }) => invalidatedIds.has(id)),
+      );
+      didChangeConversationList = true;
+    }
+    const currentAddedConversations = addedConversations.filter((conversation) => (
+      this.repository.getCachedConversation(conversation.id) === conversation
+    ));
+    const currentInvalidatedConversations = invalidatedConversations.filter(
+      (conversation) => (
+        this.repository.getCachedConversation(conversation.id) === conversation
+      ),
+    );
+    const uniqueCurrentInvalidatedConversations = currentInvalidatedConversations.filter(
+      ({ id }, index, conversations) => (
+        conversations.findIndex(conversation => conversation.id === id) === index
+      ),
+    );
+    StartupProfiler.recordCount(
+      'background-session-metadata-count',
+      currentAddedConversations.length,
+    );
+    let recoveredModels: Conversation[] = [];
+    if (!this.isUnloading()) {
+      recoveredModels = await this.recoverMissingConversationModels();
+      StartupProfiler.recordCount(
+        'recovered-session-model-count',
+        recoveredModels.length,
+      );
+    }
+    await this.repository.persistConversations(uniqueCurrentInvalidatedConversations);
+    if (
+      !this.isUnloading()
+      && (didChangeConversationList || recoveredModels.length > 0)
+    ) {
+      this.notifyConversationViewsChanged();
+    }
+    if (scan.complete && !this.isUnloading()) {
+      await this.completePendingSessionInvalidations();
+    }
+    return scan.complete;
+  }
+
+  private async resolveMetadataSources(
+    metadata: SessionMetadata[],
+  ): Promise<SessionMetadataReadResult[]> {
+    const records = await Promise.all(
+      metadata.map(({ id }) => this.sessions.load(id)),
+    );
+    return records.filter(
+      (record): record is SessionMetadataReadResult => record !== null,
+    );
+  }
+}
+
+export function createConversationMetadataShell(meta: SessionMetadata): Conversation {
+  return {
+    id: meta.id,
+    providerId: meta.providerId ?? DEFAULT_CHAT_PROVIDER_ID,
+    title: meta.title,
+    createdAt: meta.createdAt,
+    lastActivityAt: meta.lastActivityAt,
+    sessionId: meta.sessionId !== undefined ? meta.sessionId : meta.id,
+    selectedModel: meta.selectedModel,
+    providerState: meta.providerState,
+    task: meta.task,
+    modelRecoverySource: meta.modelRecoverySource,
+    messages: [],
+    currentNote: meta.currentNote,
+    isPinned: meta.isPinned,
+    isArchived: meta.isArchived,
+    externalContextPaths: meta.externalContextPaths,
+    enabledMcpServers: meta.enabledMcpServers,
+    usage: meta.usage,
+    titleGenerationStatus: meta.titleGenerationStatus,
+    resumeAtMessageId: meta.resumeAtMessageId,
+  };
+}

--- a/src/app/settings/ProviderRuntimeSettingsCoordinator.ts
+++ b/src/app/settings/ProviderRuntimeSettingsCoordinator.ts
@@ -1,0 +1,150 @@
+import type { SettingsReconciliationResult } from '../../core/providers/ProviderSettingsCoordinator';
+import { ProviderSettingsCoordinator } from '../../core/providers/ProviderSettingsCoordinator';
+import type { ProviderId } from '../../core/providers/types';
+import type { ClaudianSettings } from '../../core/types';
+import type { ConversationRepository } from '../conversations/ConversationRepository';
+import type { SessionInvalidationCoordinator } from '../conversations/SessionInvalidationCoordinator';
+import {
+  type SettingsCommit,
+  type SettingsMutation,
+  SettingsPostCommitError,
+} from './SettingsCoordinator';
+
+export interface ProviderRuntimeSettingsCoordinatorOptions {
+  repository: ConversationRepository;
+  sessionInvalidation: SessionInvalidationCoordinator;
+  mutateSettings: (
+    mutation: SettingsMutation<ClaudianSettings>,
+    onCommitted?: SettingsCommit<ClaudianSettings>,
+  ) => Promise<void>;
+  reconcileModelWithEnvironment: (
+    providerIds: ProviderId[],
+    invalidateConversations: boolean,
+  ) => SettingsReconciliationResult;
+  isSessionMetadataLoaded: () => boolean;
+  isUnloading: () => boolean;
+}
+
+export interface ProviderRuntimeSettingsCommitOptions {
+  failureMessage: string;
+  onInvalidationsPersisted?: (
+    reconciliation: SettingsReconciliationResult,
+  ) => void | Promise<void>;
+  onSettingsCommitted?: (
+    reconciliation: SettingsReconciliationResult,
+  ) => void | Promise<void>;
+}
+
+export class ProviderRuntimeSettingsCoordinator {
+  private readonly repository: ConversationRepository;
+  private readonly sessionInvalidation: SessionInvalidationCoordinator;
+  private readonly mutateSettings: ProviderRuntimeSettingsCoordinatorOptions['mutateSettings'];
+  private readonly reconcileModelWithEnvironment: ProviderRuntimeSettingsCoordinatorOptions[
+    'reconcileModelWithEnvironment'
+  ];
+  private readonly isSessionMetadataLoaded: () => boolean;
+  private readonly isUnloading: () => boolean;
+
+  constructor(options: ProviderRuntimeSettingsCoordinatorOptions) {
+    this.repository = options.repository;
+    this.sessionInvalidation = options.sessionInvalidation;
+    this.mutateSettings = options.mutateSettings;
+    this.reconcileModelWithEnvironment = options.reconcileModelWithEnvironment;
+    this.isSessionMetadataLoaded = options.isSessionMetadataLoaded;
+    this.isUnloading = options.isUnloading;
+  }
+
+  async commit(
+    providerIds: ProviderId[],
+    mutation: SettingsMutation<ClaudianSettings>,
+    options: ProviderRuntimeSettingsCommitOptions,
+  ): Promise<SettingsReconciliationResult> {
+    let reconciliation: SettingsReconciliationResult = {
+      changed: false,
+      environmentChangedProviderIds: [],
+      invalidatedConversations: [],
+      sessionInvalidationProviderIds: [],
+    };
+    let invalidationGenerations = new Map<ProviderId, number>();
+    let invalidationPublished = false;
+    let settingsCommitted = false;
+    const errors: unknown[] = [];
+
+    try {
+      await this.mutateSettings(async (settings) => {
+        await mutation(settings);
+        reconciliation = this.reconcileModelWithEnvironment(providerIds, false);
+        invalidationGenerations = this.sessionInvalidation.stage(
+          settings,
+          reconciliation.sessionInvalidationProviderIds,
+        );
+      }, () => {
+        this.sessionInvalidation.commit(invalidationGenerations);
+        this.sessionInvalidation.block(invalidationGenerations);
+        ProviderSettingsCoordinator.invalidateConversationSessions(
+          this.repository.getAll(),
+          reconciliation.sessionInvalidationProviderIds,
+        );
+        invalidationPublished = true;
+      });
+      settingsCommitted = true;
+    } catch (error) {
+      if (error instanceof SettingsPostCommitError) {
+        settingsCommitted = true;
+        errors.push(error.cause);
+      } else {
+        errors.push(error);
+      }
+    }
+
+    if (settingsCommitted) {
+      try {
+        await options.onSettingsCommitted?.(reconciliation);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+
+    if (invalidationPublished && invalidationGenerations.size > 0) {
+      let invalidationMetadataPersisted = false;
+      try {
+        const invalidatedProviderIds = new Set(invalidationGenerations.keys());
+        const conversationsToPersist = this.repository.getAll().filter(
+          conversation => invalidatedProviderIds.has(conversation.providerId),
+        );
+        await this.repository.persistConversations(
+          conversationsToPersist.filter(
+            conversation => this.repository.getCachedConversation(conversation.id) === conversation,
+          ),
+        );
+        invalidationMetadataPersisted = true;
+      } catch (error) {
+        errors.push(error);
+      }
+      if (invalidationMetadataPersisted) {
+        this.sessionInvalidation.release(invalidationGenerations);
+        if (this.isSessionMetadataLoaded() && !this.isUnloading()) {
+          try {
+            await this.sessionInvalidation.complete(invalidationGenerations);
+          } catch (error) {
+            errors.push(error);
+          }
+        }
+      }
+    }
+
+    if (settingsCommitted) {
+      try {
+        await options.onInvalidationsPersisted?.(reconciliation);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+
+    if (errors.length === 1) throw errors[0];
+    if (errors.length > 1) {
+      throw new AggregateError(errors, options.failureMessage);
+    }
+    return reconciliation;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,10 +11,19 @@ import type { Editor, TAbstractFile, WorkspaceLeaf } from 'obsidian';
 import { MarkdownView, Notice, Plugin, TFolder } from 'obsidian';
 
 import { ConversationRepository } from './app/conversations/ConversationRepository';
+import {
+  type ProviderSessionInvalidationStatus,
+  SessionInvalidationCoordinator,
+} from './app/conversations/SessionInvalidationCoordinator';
+import {
+  createConversationMetadataShell,
+  SessionMetadataCoordinator,
+} from './app/conversations/SessionMetadataCoordinator';
 import { ClaudianProviderHost } from './app/providers/ClaudianProviderHost';
 import { ChatModelSelectionCoordinator } from './app/settings/ChatModelSelectionCoordinator';
 import { DEFAULT_CLAUDIAN_SETTINGS } from './app/settings/defaultSettings';
 import { PinnedLinkedNotePathCoordinator } from './app/settings/PinnedLinkedNotePathCoordinator';
+import { ProviderRuntimeSettingsCoordinator } from './app/settings/ProviderRuntimeSettingsCoordinator';
 import type {
   ConditionalSettingsMutation,
   SettingsCommit,
@@ -22,7 +31,6 @@ import type {
 import {
   SettingsCoordinator,
   type SettingsMutation,
-  SettingsPostCommitError,
 } from './app/settings/SettingsCoordinator';
 import { SharedStorageService } from './app/storage/SharedStorageService';
 import type { SessionMetadataReadResult } from './core/bootstrap/SessionStorage';
@@ -46,12 +54,10 @@ import type {
   ProviderCliResolutionContext,
   ProviderId,
 } from './core/providers/types';
-import { DEFAULT_CHAT_PROVIDER_ID } from './core/providers/types';
 import type {
   ClaudianSettings,
   Conversation,
   ConversationMeta,
-  SessionMetadata,
 } from './core/types';
 import {
   VIEW_TYPE_CLAUDIAN,
@@ -79,49 +85,6 @@ function isClaudianView(value: unknown): value is ClaudianView {
     && typeof (value as { getTabManager?: unknown }).getTabManager === 'function';
 }
 
-function readPendingProviderSessionInvalidations(
-  settings: Record<string, unknown>,
-): Map<ProviderId, number> {
-  const registeredProviderIds = new Set(ProviderRegistry.getRegisteredProviderIds());
-  const value = settings.pendingProviderSessionInvalidations;
-  const pending = new Map<ProviderId, number>();
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return pending;
-  }
-
-  for (const [providerId, generation] of Object.entries(value)) {
-    if (
-      registeredProviderIds.has(providerId)
-      && typeof generation === 'number'
-      && Number.isSafeInteger(generation)
-      && generation > 0
-    ) {
-      pending.set(providerId, generation);
-    }
-  }
-  return pending;
-}
-
-function serializePendingProviderSessionInvalidations(
-  pending: ReadonlyMap<ProviderId, number>,
-): Partial<Record<string, number>> {
-  return Object.fromEntries(
-    Array.from(pending.entries()).sort(([left], [right]) => left.localeCompare(right)),
-  );
-}
-
-function hasSamePendingProviderSessionInvalidations(
-  value: unknown,
-  pending: ReadonlyMap<ProviderId, number>,
-): boolean {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return false;
-  }
-  const entries = Object.entries(value);
-  return entries.length === pending.size
-    && entries.every(([providerId, generation]) => pending.get(providerId) === generation);
-}
-
 export default class ClaudianPlugin extends Plugin {
   settings!: ClaudianSettings;
   storage!: SharedAppStorage;
@@ -134,12 +97,12 @@ export default class ClaudianPlugin extends Plugin {
   private chatModelSelectionCoordinator!: ChatModelSelectionCoordinator;
   private pinnedLinkedNotePaths!: PinnedLinkedNotePathCoordinator;
   private conversationRepository!: ConversationRepository;
+  private sessionMetadataCoordinator!: SessionMetadataCoordinator;
+  private sessionInvalidationCoordinator!: SessionInvalidationCoordinator;
+  private providerRuntimeSettingsCoordinator!: ProviderRuntimeSettingsCoordinator;
   private pendingSessionMetadataScan = false;
-  private pendingEnvironmentInvalidationGenerations = new Map<ProviderId, number>();
-  private blockedEnvironmentInvalidationGenerations = new Map<ProviderId, number>();
   private environmentUpdateTail: Promise<void> = Promise.resolve();
   private agentSkillResourceGeneration = 0;
-  private isLoadingRemainingSessionMetadata = false;
   private hasLoadedAllSessionMetadata = false;
   private sessionMetadataLoadTimer: number | null = null;
   private remainingSessionMetadataLoad: Promise<void> | null = null;
@@ -152,6 +115,21 @@ export default class ClaudianPlugin extends Plugin {
 
   get chatModelSelection(): ChatModelSelectionCoordinator {
     return this.chatModelSelectionCoordinator;
+  }
+
+  getProviderSessionInvalidationStatus(
+    providerId: ProviderId,
+  ): ProviderSessionInvalidationStatus {
+    return this.sessionInvalidationCoordinator.getStatus(providerId);
+  }
+
+  isSessionMetadataLoaded(): boolean {
+    return this.hasLoadedAllSessionMetadata;
+  }
+
+  /** Re-scans deferred session metadata and publishes the resulting shells. */
+  async refreshSessionMetadata(): Promise<void> {
+    await this.loadRemainingSessionMetadata();
   }
 
   async onload() {
@@ -429,12 +407,39 @@ export default class ClaudianPlugin extends Plugin {
     this.pinnedLinkedNotePaths = new PinnedLinkedNotePathCoordinator(
       this.settingsCoordinator,
     );
-    const didNormalizePendingSessionInvalidations = this.syncPendingSessionInvalidations();
+    this.sessionInvalidationCoordinator = new SessionInvalidationCoordinator({
+      getSettings: () => this.settings,
+      mutateSettingsConditionally: (mutation) => this.mutateSettingsConditionally(mutation),
+    });
+    const didNormalizePendingSessionInvalidations = this.sessionInvalidationCoordinator
+      .sync(this.settings);
     this.conversationRepository = new ConversationRepository({
       getSettings: () => this.settings,
       getVaultPath: () => getVaultPath(this.app),
       persistence: sharedStorage.conversationPersistence,
       onConversationDeleted: (conversationId) => this.resetDeletedConversationTabs(conversationId),
+    });
+    this.providerRuntimeSettingsCoordinator = new ProviderRuntimeSettingsCoordinator({
+      repository: this.conversationRepository,
+      sessionInvalidation: this.sessionInvalidationCoordinator,
+      mutateSettings: (mutation, onCommitted) => this.mutateSettings(mutation, onCommitted),
+      reconcileModelWithEnvironment: (providerIds, invalidateConversations) => (
+        this.reconcileModelWithEnvironment(providerIds, invalidateConversations)
+      ),
+      isSessionMetadataLoaded: () => this.hasLoadedAllSessionMetadata,
+      isUnloading: () => this.isUnloading,
+    });
+    this.sessionMetadataCoordinator = new SessionMetadataCoordinator({
+      sessions: this.storage.sessions,
+      repository: this.conversationRepository,
+      getPendingInvalidationProviderIds: () => this.sessionInvalidationCoordinator
+        .getPendingProviderIds(),
+      isUnloading: () => this.isUnloading,
+      recoverMissingConversationModels: () => this.recoverMissingConversationModels(),
+      completePendingSessionInvalidations: () => this.sessionInvalidationCoordinator.complete(
+        this.sessionInvalidationCoordinator.getCompletable(),
+      ),
+      notifyConversationViewsChanged: () => this.notifyConversationViewsChanged(),
     });
 
     // Plan mode is ephemeral — normalize back to normal on load so the app
@@ -467,13 +472,13 @@ export default class ClaudianPlugin extends Plugin {
             complete: false,
             invalidMetadataCount: 0,
           }
-        : this.loadSessionMetadataWithSources(),
+        : this.sessionMetadataCoordinator.loadSessionMetadataWithSources(),
     );
     const initialModelRecoverySources = initialMetadataScan.records.map(({ metadata }) => (
-      this.createConversationMetadataShell(metadata)
+      createConversationMetadataShell(metadata)
     ));
     const initialEntries = initialMetadataScan.records.map(({ metadata, needsMigration, source }) => ({
-      conversation: this.createConversationMetadataShell(metadata),
+      conversation: createConversationMetadataShell(metadata),
       needsMigration,
       source,
     }));
@@ -488,8 +493,7 @@ export default class ClaudianPlugin extends Plugin {
       initialModelRecoverySources,
     );
     if (initialMetadataScan.complete) {
-      const recoveredModels = await this.conversationRepository
-        .recoverMissingSelectedModels();
+      const recoveredModels = await this.recoverMissingConversationModels();
       StartupProfiler.recordCount(
         'recovered-session-model-count',
         recoveredModels.length,
@@ -498,17 +502,18 @@ export default class ClaudianPlugin extends Plugin {
     setLocale(this.settings.locale as Locale);
 
     const reconciliation = this.reconcileModelWithEnvironment();
-    this.markPendingSessionInvalidations(
+    const initialInvalidationGenerations = this.sessionInvalidationCoordinator.stage(
       this.settings,
       reconciliation.sessionInvalidationProviderIds,
     );
+    this.sessionInvalidationCoordinator.commit(initialInvalidationGenerations);
     const pendingInvalidatedConversations = ProviderSettingsCoordinator
       .invalidateConversationSessions(
         this.conversationRepository.getAll(),
-        Array.from(this.pendingEnvironmentInvalidationGenerations.keys()),
+        this.sessionInvalidationCoordinator.getPendingProviderIds(),
       );
     const completedInvalidationGenerations = initialMetadataScan.complete
-      ? new Map(this.pendingEnvironmentInvalidationGenerations)
+      ? this.sessionInvalidationCoordinator.getPendingGenerations()
       : new Map<ProviderId, number>();
 
     ProviderSettingsCoordinator.projectActiveProviderState(
@@ -532,7 +537,7 @@ export default class ClaudianPlugin extends Plugin {
     await this.conversationRepository.persistConversations(
       Array.from(conversationsToSave),
     );
-    await this.completePendingSessionInvalidations(completedInvalidationGenerations);
+    await this.sessionInvalidationCoordinator.complete(completedInvalidationGenerations);
     this.hasLoadedAllSessionMetadata = initialMetadataScan.complete;
     this.pendingSessionMetadataScan = deferRemainingMetadata;
   }
@@ -544,30 +549,6 @@ export default class ClaudianPlugin extends Plugin {
 
     const record = await this.storage.sessions.load(currentTab.conversationId);
     return record ? [record] : [];
-  }
-
-  private async loadSessionMetadataWithSources(): Promise<{
-    records: SessionMetadataReadResult[];
-    complete: boolean;
-    invalidMetadataCount: number;
-  }> {
-    const scan = await this.storage.sessions.scanMetadata();
-    return {
-      records: await this.resolveMetadataSources(scan.metadata),
-      complete: scan.complete,
-      invalidMetadataCount: scan.invalidMetadataCount,
-    };
-  }
-
-  private async resolveMetadataSources(
-    metadata: SessionMetadata[],
-  ): Promise<SessionMetadataReadResult[]> {
-    const records = await Promise.all(
-      metadata.map(({ id }) => this.storage.sessions.load(id)),
-    );
-    return records.filter(
-      (record): record is SessionMetadataReadResult => record !== null,
-    );
   }
 
   private scheduleRemainingSessionMetadataLoad(): void {
@@ -616,291 +597,8 @@ export default class ClaudianPlugin extends Plugin {
   }
 
   private async loadRemainingSessionMetadata(): Promise<void> {
-    this.isLoadingRemainingSessionMetadata = true;
-    try {
-      const addedConversations: Conversation[] = [];
-      const invalidatedConversations: Conversation[] = [];
-      let didChangeConversationList = false;
-      const publishBatch = (metadata: SessionMetadata[]): void => {
-        if (this.isUnloading || metadata.length === 0) return;
-
-        const recoverySources = metadata.map((item) => (
-          this.createConversationMetadataShell(item)
-        ));
-        const shells = metadata
-          .map((item) => this.createConversationMetadataShell(item))
-          .filter((conversation) => (
-            this.conversationRepository.isSelectedModelPublicationSafe(conversation)
-          ));
-        const publishedIds = new Set(shells.map(({ id }) => id));
-        const invalidatedShells = ProviderSettingsCoordinator
-          .invalidateConversationSessions(
-            shells,
-            Array.from(this.pendingEnvironmentInvalidationGenerations.keys()),
-          );
-        const invalidatedIds = new Set(
-          invalidatedShells.map(({ id }) => id),
-        );
-        const added = this.conversationRepository.mergeMetadataConversations(shells);
-        this.conversationRepository.registerHistoricalModelRecoverySources(
-          recoverySources.filter(({ id }) => publishedIds.has(id)),
-        );
-        if (added.length === 0) return;
-
-        addedConversations.push(...added);
-        invalidatedConversations.push(
-          ...added.filter(({ id }) => invalidatedIds.has(id)),
-        );
-        didChangeConversationList = true;
-      };
-      const scan = await this.storage.sessions.scanMetadata({
-        onBatch: publishBatch,
-      });
-      if (this.isUnloading) {
-        return;
-      }
-
-      StartupProfiler.recordCount('session-metadata-count', scan.metadata.length);
-      StartupProfiler.recordCount(
-        'invalid-session-metadata-count',
-        scan.invalidMetadataCount,
-      );
-      const scannedShells = scan.metadata
-        .map(({ id }) => this.conversationRepository.getCachedConversation(id))
-        .filter((shell): shell is Conversation => shell !== null);
-      const records = await this.resolveMetadataSources(scan.metadata);
-      const resolvedIds = new Set(records.map(({ metadata }) => metadata.id));
-      const unresolvedShells = scannedShells.filter(
-        ({ id }) => !resolvedIds.has(id),
-      );
-      this.conversationRepository.discardUnresolvedMetadataShells(
-        unresolvedShells,
-      );
-      if (unresolvedShells.length > 0) {
-        didChangeConversationList = true;
-      }
-      publishBatch(records.map(({ metadata }) => metadata));
-      const entries = records.map(({ metadata, needsMigration, source }) => ({
-        conversation: this.createConversationMetadataShell(metadata),
-        needsMigration,
-        source,
-      }));
-      const shells = entries.map(({ conversation }) => conversation);
-      const invalidatedEntries = ProviderSettingsCoordinator
-        .invalidateConversationSessions(
-          shells,
-          Array.from(this.pendingEnvironmentInvalidationGenerations.keys()),
-        );
-      const invalidatedIds = new Set(
-        invalidatedEntries.map(({ id }) => id),
-      );
-      const existingIds = new Set(
-        this.conversationRepository.getAll().map(({ id }) => id),
-      );
-      await this.conversationRepository.adoptMetadataConversations(entries);
-      this.conversationRepository.registerHistoricalModelRecoverySources(
-        shells,
-      );
-      const adoptedConversations = shells.filter((conversation) => (
-        !existingIds.has(conversation.id)
-        && this.conversationRepository.getCachedConversation(conversation.id)
-          === conversation
-      ));
-      if (adoptedConversations.length > 0) {
-        addedConversations.push(...adoptedConversations);
-        invalidatedConversations.push(
-          ...adoptedConversations.filter(({ id }) => invalidatedIds.has(id)),
-        );
-        didChangeConversationList = true;
-      }
-      const currentAddedConversations = addedConversations.filter((conversation) => (
-        this.conversationRepository.getCachedConversation(conversation.id)
-          === conversation
-      ));
-      const currentInvalidatedConversations = invalidatedConversations.filter(
-        (conversation) => (
-          this.conversationRepository.getCachedConversation(conversation.id)
-            === conversation
-        ),
-      );
-      const uniqueCurrentInvalidatedConversations = currentInvalidatedConversations.filter(
-        ({ id }, index, conversations) => (
-          conversations.findIndex(conversation => conversation.id === id) === index
-        ),
-      );
-      StartupProfiler.recordCount('background-session-metadata-count', currentAddedConversations.length);
-      let recoveredModels: Conversation[] = [];
-      if (!this.isUnloading) {
-        recoveredModels = await this.conversationRepository
-          .recoverMissingSelectedModels();
-        StartupProfiler.recordCount(
-          'recovered-session-model-count',
-          recoveredModels.length,
-        );
-      }
-      await this.conversationRepository.persistConversations(
-        uniqueCurrentInvalidatedConversations,
-      );
-      if (
-        !this.isUnloading
-        && (didChangeConversationList || recoveredModels.length > 0)
-      ) {
-        this.notifyConversationViewsChanged();
-      }
-      if (scan.complete) {
-        this.hasLoadedAllSessionMetadata = true;
-        if (!this.isUnloading) {
-          await this.completePendingSessionInvalidations(
-            this.getCompletablePendingSessionInvalidations(),
-          );
-        }
-      }
-    } finally {
-      this.isLoadingRemainingSessionMetadata = false;
-    }
-  }
-
-  private syncPendingSessionInvalidations(): boolean {
-    const pending = readPendingProviderSessionInvalidations(this.settings);
-    const changed = !hasSamePendingProviderSessionInvalidations(
-      this.settings.pendingProviderSessionInvalidations,
-      pending,
-    );
-    this.settings.pendingProviderSessionInvalidations =
-      serializePendingProviderSessionInvalidations(pending);
-    this.pendingEnvironmentInvalidationGenerations = pending;
-    return changed;
-  }
-
-  private markPendingSessionInvalidations(
-    settings: ClaudianSettings,
-    providerIds: ProviderId[],
-  ): Map<ProviderId, number> {
-    const marked = this.stagePendingSessionInvalidations(settings, providerIds);
-    this.commitPendingSessionInvalidations(marked);
-    return marked;
-  }
-
-  private stagePendingSessionInvalidations(
-    settings: ClaudianSettings,
-    providerIds: ProviderId[],
-  ): Map<ProviderId, number> {
-    const pending = readPendingProviderSessionInvalidations(settings);
-    const marked = new Map<ProviderId, number>();
-    for (const providerId of new Set(providerIds)) {
-      const previousGeneration = Math.max(
-        pending.get(providerId) ?? 0,
-        this.pendingEnvironmentInvalidationGenerations.get(providerId) ?? 0,
-      );
-      const generation = Math.max(Date.now(), previousGeneration + 1);
-      pending.set(providerId, generation);
-      marked.set(providerId, generation);
-    }
-    settings.pendingProviderSessionInvalidations =
-      serializePendingProviderSessionInvalidations(pending);
-    return marked;
-  }
-
-  private commitPendingSessionInvalidations(
-    generations: ReadonlyMap<ProviderId, number>,
-  ): void {
-    for (const [providerId, generation] of generations) {
-      this.pendingEnvironmentInvalidationGenerations.set(providerId, generation);
-    }
-  }
-
-  private blockEnvironmentInvalidationCompletion(
-    generations: ReadonlyMap<ProviderId, number>,
-  ): void {
-    for (const [providerId, generation] of generations) {
-      this.blockedEnvironmentInvalidationGenerations.set(providerId, generation);
-    }
-  }
-
-  private releaseEnvironmentInvalidationCompletion(
-    generations: ReadonlyMap<ProviderId, number>,
-  ): void {
-    for (const [providerId, generation] of generations) {
-      if (this.blockedEnvironmentInvalidationGenerations.get(providerId) === generation) {
-        this.blockedEnvironmentInvalidationGenerations.delete(providerId);
-      }
-    }
-  }
-
-  private getCompletablePendingSessionInvalidations(): Map<ProviderId, number> {
-    return new Map(Array.from(
-      this.pendingEnvironmentInvalidationGenerations,
-      ([providerId, generation]) => [providerId, generation] as const,
-    ).filter(([providerId, generation]) => (
-      this.blockedEnvironmentInvalidationGenerations.get(providerId) !== generation
-    )));
-  }
-
-  private async completePendingSessionInvalidations(
-    completedGenerations: ReadonlyMap<ProviderId, number>,
-  ): Promise<void> {
-    if (completedGenerations.size === 0) {
-      return;
-    }
-
-    const removed = new Map<ProviderId, number>();
-    try {
-      await this.mutateSettingsConditionally((settings) => {
-        const pending = readPendingProviderSessionInvalidations(settings);
-        for (const [providerId, generation] of completedGenerations) {
-          if (pending.get(providerId) === generation) {
-            pending.delete(providerId);
-            removed.set(providerId, generation);
-          }
-        }
-        if (removed.size === 0) {
-          return false;
-        }
-        settings.pendingProviderSessionInvalidations =
-          serializePendingProviderSessionInvalidations(pending);
-        return true;
-      });
-    } catch (error) {
-      const pending = readPendingProviderSessionInvalidations(this.settings);
-      for (const [providerId, generation] of removed) {
-        if (this.pendingEnvironmentInvalidationGenerations.get(providerId) === generation) {
-          pending.set(providerId, generation);
-        }
-      }
-      this.settings.pendingProviderSessionInvalidations =
-        serializePendingProviderSessionInvalidations(pending);
-      throw error;
-    }
-
-    for (const [providerId, generation] of removed) {
-      if (this.pendingEnvironmentInvalidationGenerations.get(providerId) === generation) {
-        this.pendingEnvironmentInvalidationGenerations.delete(providerId);
-      }
-    }
-  }
-
-  private createConversationMetadataShell(meta: SessionMetadata): Conversation {
-    return {
-      id: meta.id,
-      providerId: meta.providerId ?? DEFAULT_CHAT_PROVIDER_ID,
-      title: meta.title,
-      createdAt: meta.createdAt,
-      lastActivityAt: meta.lastActivityAt,
-      sessionId: meta.sessionId !== undefined ? meta.sessionId : meta.id,
-      selectedModel: meta.selectedModel,
-      providerState: meta.providerState,
-      task: meta.task,
-      modelRecoverySource: meta.modelRecoverySource,
-      messages: [],
-      currentNote: meta.currentNote,
-      isPinned: meta.isPinned,
-      isArchived: meta.isArchived,
-      externalContextPaths: meta.externalContextPaths,
-      enabledMcpServers: meta.enabledMcpServers,
-      usage: meta.usage,
-      titleGenerationStatus: meta.titleGenerationStatus,
-      resumeAtMessageId: meta.resumeAtMessageId,
-    };
+    this.hasLoadedAllSessionMetadata = await this.sessionMetadataCoordinator
+      .loadRemainingSessionMetadata();
   }
 
   normalizeModelVariantSettings(): boolean {
@@ -964,7 +662,7 @@ export default class ClaudianPlugin extends Plugin {
   ): Promise<void> {
     const uniqueProviderIds = Array.from(new Set(providerIds));
     await this.runProviderExecutionTransition(uniqueProviderIds, async () => {
-      await this.commitProviderRuntimeSettings(
+      await this.providerRuntimeSettingsCoordinator.commit(
         uniqueProviderIds,
         mutation,
         {
@@ -973,112 +671,6 @@ export default class ClaudianPlugin extends Plugin {
         },
       );
     });
-  }
-
-  private async commitProviderRuntimeSettings(
-    providerIds: ProviderId[],
-    mutation: SettingsMutation<ClaudianSettings>,
-    options: {
-      failureMessage: string;
-      onInvalidationsPersisted?: (
-        reconciliation: SettingsReconciliationResult,
-      ) => void | Promise<void>;
-      onSettingsCommitted?: (
-        reconciliation: SettingsReconciliationResult,
-      ) => void | Promise<void>;
-    },
-  ): Promise<SettingsReconciliationResult> {
-    let reconciliation: SettingsReconciliationResult = {
-      changed: false,
-      environmentChangedProviderIds: [],
-      invalidatedConversations: [],
-      sessionInvalidationProviderIds: [],
-    };
-    let invalidationGenerations = new Map<ProviderId, number>();
-    let invalidationPublished = false;
-    let settingsCommitted = false;
-    const errors: unknown[] = [];
-
-    try {
-      await this.mutateSettings(async (settings) => {
-        await mutation(settings);
-        reconciliation = this.reconcileModelWithEnvironment(providerIds, false);
-        invalidationGenerations = this.stagePendingSessionInvalidations(
-          settings,
-          reconciliation.sessionInvalidationProviderIds,
-        );
-      }, () => {
-        this.commitPendingSessionInvalidations(invalidationGenerations);
-        this.blockEnvironmentInvalidationCompletion(invalidationGenerations);
-        ProviderSettingsCoordinator.invalidateConversationSessions(
-          this.conversationRepository.getAll(),
-          reconciliation.sessionInvalidationProviderIds,
-        );
-        invalidationPublished = true;
-      });
-      settingsCommitted = true;
-    } catch (error) {
-      if (error instanceof SettingsPostCommitError) {
-        settingsCommitted = true;
-        errors.push(error.cause);
-      } else {
-        errors.push(error);
-      }
-    }
-
-    if (settingsCommitted) {
-      try {
-        await options.onSettingsCommitted?.(reconciliation);
-      } catch (error) {
-        errors.push(error);
-      }
-    }
-
-    if (invalidationPublished && invalidationGenerations.size > 0) {
-      let invalidationMetadataPersisted = false;
-      try {
-        const invalidatedProviderIds = new Set(invalidationGenerations.keys());
-        const conversationsToPersist = this.conversationRepository.getAll().filter(
-          conversation => invalidatedProviderIds.has(conversation.providerId),
-        );
-        await this.conversationRepository.persistConversations(
-          conversationsToPersist.filter(
-            (conversation) =>
-              this.conversationRepository.getCachedConversation(conversation.id)
-              === conversation,
-          ),
-        );
-        invalidationMetadataPersisted = true;
-      } catch (error) {
-        errors.push(error);
-      }
-      if (invalidationMetadataPersisted) {
-        this.releaseEnvironmentInvalidationCompletion(invalidationGenerations);
-        if (this.hasLoadedAllSessionMetadata && !this.isUnloading) {
-          try {
-            await this.completePendingSessionInvalidations(invalidationGenerations);
-          } catch (error) {
-            errors.push(error);
-          }
-        }
-      }
-    }
-
-    if (settingsCommitted) {
-      try {
-        await options.onInvalidationsPersisted?.(reconciliation);
-      } catch (error) {
-        errors.push(error);
-      }
-    }
-
-    if (errors.length === 1) {
-      throw errors[0];
-    }
-    if (errors.length > 1) {
-      throw new AggregateError(errors, options.failureMessage);
-    }
-    return reconciliation;
   }
 
   private async applyEnvironmentVariablesBatchNow(
@@ -1101,7 +693,7 @@ export default class ClaudianPlugin extends Plugin {
     await this.runProviderExecutionTransition(providersToQuiesce, async () => {
       let affectedProviderIds: ProviderId[] = [];
       const modelCatalogDiagnostics: string[] = [];
-      await this.commitProviderRuntimeSettings(
+      await this.providerRuntimeSettingsCoordinator.commit(
         providersToQuiesce,
         (settings) => {
           const settingsBag = settings as unknown as Record<string, unknown>;
@@ -1357,6 +949,18 @@ export default class ClaudianPlugin extends Plugin {
     this.notifyConversationViewsChanged();
   }
 
+  async reconcileConversationModels(providerId: ProviderId): Promise<Conversation[]> {
+    return this.conversationRepository
+      ? this.conversationRepository.reconcileSelectedModels(providerId)
+      : [];
+  }
+
+  async recoverMissingConversationModels(): Promise<Conversation[]> {
+    return this.conversationRepository
+      ? this.conversationRepository.recoverMissingSelectedModels()
+      : [];
+  }
+
   private notifyConversationViewsChanged(): void {
     for (const view of this.getAllViews()) {
       view.notifyConversationListChanged();
@@ -1367,9 +971,7 @@ export default class ClaudianPlugin extends Plugin {
     const reconcileAndRefresh = async (): Promise<void> => {
       let didReconcile = false;
       try {
-        const changedConversations = this.conversationRepository
-          ? await this.conversationRepository.reconcileSelectedModels(providerId)
-          : [];
+        const changedConversations = await this.reconcileConversationModels(providerId);
         didReconcile = true;
         if (changedConversations.length > 0) {
           this.notifyConversationViewsChanged();

--- a/tests/helpers/TestHttpServer.ts
+++ b/tests/helpers/TestHttpServer.ts
@@ -1,0 +1,58 @@
+import * as http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+export interface TestHttpRequest {
+  method: string;
+  url: string;
+  headers: http.IncomingHttpHeaders;
+  body: string;
+}
+
+export interface TestHttpServer {
+  server: http.Server;
+  getUrl: () => string;
+  received: TestHttpRequest[];
+}
+
+export async function createTestHttpServer(
+  handler?: (request: TestHttpRequest, response: http.ServerResponse) => void,
+): Promise<TestHttpServer> {
+  const received: TestHttpRequest[] = [];
+  const server = http.createServer((request, response) => {
+    const chunks: Buffer[] = [];
+    request.on('data', (chunk: Buffer) => chunks.push(chunk));
+    request.on('end', () => {
+      const entry: TestHttpRequest = {
+        method: request.method ?? 'GET',
+        url: request.url ?? '/',
+        headers: request.headers,
+        body: Buffer.concat(chunks).toString('utf-8'),
+      };
+      received.push(entry);
+
+      if (handler) {
+        handler(entry, response);
+      } else {
+        response.writeHead(200, { 'Content-Type': 'application/json' });
+        response.end(JSON.stringify({ ok: true }));
+      }
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  return {
+    server,
+    getUrl: () => {
+      const address = server.address() as AddressInfo;
+      return `http://127.0.0.1:${address.port}`;
+    },
+    received,
+  };
+}

--- a/tests/helpers/testFilesystem.ts
+++ b/tests/helpers/testFilesystem.ts
@@ -1,0 +1,27 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface TestFileHandle {
+  filePath: string;
+  cleanup: () => void;
+}
+
+/**
+ * Creates a file outside the operating system temp roots without touching the
+ * user's home directory. This is useful for path-trust tests that need an
+ * intentionally untrusted location.
+ */
+export function createUntrustedTestFile(fileName: string): TestFileHandle {
+  const directory = mkdtempSync(join(process.cwd(), '.claudian-untrusted-'));
+  const filePath = join(directory, fileName);
+  let cleaned = false;
+
+  return {
+    filePath,
+    cleanup: () => {
+      if (cleaned) return;
+      cleaned = true;
+      rmSync(directory, { recursive: true, force: true });
+    },
+  };
+}

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -1,6 +1,7 @@
 
 import { TFile, TFolder } from 'obsidian';
 
+import { createConversationMetadataShell } from '@/app/conversations/SessionMetadataCoordinator';
 import { ConversationPersistenceStore } from '@/core/bootstrap/ConversationPersistenceStore';
 import { ProviderRegistry } from '@/core/providers/ProviderRegistry';
 import { ProviderSettingsCoordinator } from '@/core/providers/ProviderSettingsCoordinator';
@@ -341,7 +342,7 @@ describe('ClaudianPlugin', () => {
           }
         });
 
-      const load = (plugin as any).loadRemainingSessionMetadata();
+      const load = plugin.refreshSessionMetadata();
       await writeStarted;
       expect(notifyConversationListChanged).not.toHaveBeenCalled();
 
@@ -391,7 +392,7 @@ describe('ClaudianPlugin', () => {
           events.push('delete-legacy');
         });
 
-      await (plugin as any).loadRemainingSessionMetadata();
+      await plugin.refreshSessionMetadata();
 
       expect(events).toEqual(['scan', 'save-current', 'delete-legacy']);
       expect(plugin.getCachedConversation(legacyMetadata.id)?.title)
@@ -411,11 +412,10 @@ describe('ClaudianPlugin', () => {
           complete: true,
           invalidMetadataCount: 0,
         });
-      const repository = (plugin as any).conversationRepository;
-      const recoverySpy = jest.spyOn(repository, 'recoverMissingSelectedModels')
+      const recoverySpy = jest.spyOn(plugin, 'recoverMissingConversationModels')
         .mockResolvedValue([]);
 
-      await (plugin as any).loadRemainingSessionMetadata();
+      await plugin.refreshSessionMetadata();
 
       expect(recoverySpy).toHaveBeenCalledTimes(1);
 
@@ -433,8 +433,12 @@ describe('ClaudianPlugin', () => {
         sessionId: 'thread-before-invalidation',
         providerState: { threadId: 'thread-before-invalidation' },
       };
+      installVaultFiles({
+        '.claudian/claudian-settings.json': JSON.stringify({
+          pendingProviderSessionInvalidations: { codex: 1 },
+        }),
+      });
       await plugin.onload();
-      (plugin as any).pendingEnvironmentInvalidationGenerations.set('codex', 1);
       const scanSpy = jest.spyOn(SessionStorage.prototype, 'scanMetadata')
         .mockResolvedValue({
           metadata: [metadata],
@@ -466,7 +470,7 @@ describe('ClaudianPlugin', () => {
           persistedRecoverySources.push(conversations[0]?.modelRecoverySource);
         });
 
-      await (plugin as any).loadRemainingSessionMetadata();
+      await plugin.refreshSessionMetadata();
 
       expect(registeredSources).toContainEqual(expect.objectContaining({
         id: metadata.id,
@@ -546,7 +550,7 @@ describe('ClaudianPlugin', () => {
       );
 
       await plugin.onload();
-      await (plugin as any).loadRemainingSessionMetadata();
+      await plugin.refreshSessionMetadata();
 
       const restored = plugin.getCachedConversation(restoredMetadata.id);
       const deferred = plugin.getCachedConversation(deferredMetadata.id);
@@ -617,7 +621,7 @@ describe('ClaudianPlugin', () => {
 
       try {
         await plugin.onload();
-        await (plugin as any).loadRemainingSessionMetadata();
+        await plugin.refreshSessionMetadata();
       } finally {
         delete claudeReconciler.environmentSessionPolicy;
         reconcileSpy.mockRestore();
@@ -680,7 +684,7 @@ describe('ClaudianPlugin', () => {
         });
       const loadSourceSpy = mockMetadataSources(firstMetadata, laterMetadata);
 
-      const load = (plugin as any).loadRemainingSessionMetadata();
+      const load = plugin.refreshSessionMetadata();
       await firstBatchPublished;
       await plugin.applyEnvironmentVariables(
         'provider:claude',
@@ -767,7 +771,7 @@ describe('ClaudianPlugin', () => {
           }
         });
 
-      const load = (plugin as any).loadRemainingSessionMetadata();
+      const load = plugin.refreshSessionMetadata();
       await firstBatchPublished;
       const apply = plugin.applyEnvironmentVariables(
         'provider:claude',
@@ -825,16 +829,14 @@ describe('ClaudianPlugin', () => {
             invalidMetadataCount: 0,
           };
         });
-      (plugin as any).pendingSessionMetadataScan = false;
-
-      await (plugin as any).loadRemainingSessionMetadata();
+      await plugin.refreshSessionMetadata();
 
       const persistedSettings = JSON.parse(files.get(settingsPath) ?? '{}');
       scanSpy.mockRestore();
 
       expect(persistedSettings.pendingProviderSessionInvalidations?.claude)
         .toBe(pendingGeneration);
-      expect((plugin as any).hasLoadedAllSessionMetadata).toBe(false);
+      expect(plugin.isSessionMetadataLoaded()).toBe(false);
     });
 
     it('does not persist a background metadata shell deleted before reconciliation', async () => {
@@ -871,7 +873,7 @@ describe('ClaudianPlugin', () => {
       ).mockImplementation((conversations) => [...conversations]);
       const saveMetadataSpy = jest.spyOn(getConversationPersistence(plugin), 'saveMetadata');
 
-      const load = (plugin as any).loadRemainingSessionMetadata();
+      const load = plugin.refreshSessionMetadata();
       await batchPublished;
       await plugin.deleteConversation(backgroundMetadata.id);
       saveMetadataSpy.mockClear();
@@ -910,7 +912,7 @@ describe('ClaudianPlugin', () => {
       const loadSpy = jest.spyOn(SessionStorage.prototype, 'load')
         .mockResolvedValue(null);
 
-      await (plugin as any).loadRemainingSessionMetadata();
+      await plugin.refreshSessionMetadata();
 
       expect(loadSpy).toHaveBeenCalledWith(tombstonedMetadata.id);
       expect(plugin.getCachedConversation(tombstonedMetadata.id)).toBeNull();
@@ -929,9 +931,7 @@ describe('ClaudianPlugin', () => {
       };
 
       await plugin.onload();
-      const shell = (plugin as any).createConversationMetadataShell(
-        tombstonedMetadata,
-      );
+      const shell = createConversationMetadataShell(tombstonedMetadata);
       (plugin as any).conversationRepository.mergeMetadataConversations([shell]);
       const scanSpy = jest.spyOn(SessionStorage.prototype, 'scanMetadata')
         .mockImplementation(async (options) => {
@@ -945,7 +945,7 @@ describe('ClaudianPlugin', () => {
       const loadSpy = jest.spyOn(SessionStorage.prototype, 'load')
         .mockResolvedValue(null);
 
-      await (plugin as any).loadRemainingSessionMetadata();
+      await plugin.refreshSessionMetadata();
 
       expect(plugin.getCachedConversation(tombstonedMetadata.id)).toBeNull();
 
@@ -1000,7 +1000,7 @@ describe('ClaudianPlugin', () => {
       const loadSourceSpy = mockMetadataSources(deferredMetadata);
 
       await restartedPlugin.onload();
-      await (restartedPlugin as any).loadRemainingSessionMetadata();
+      await restartedPlugin.refreshSessionMetadata();
 
       const restartedConversation = restartedPlugin.getCachedConversation(deferredMetadata.id);
       const persistedMetadata = JSON.parse(
@@ -1063,11 +1063,9 @@ describe('ClaudianPlugin', () => {
       const loadSourceSpy = mockMetadataSources(deferredMetadata);
       const saveMetadataSpy = jest.spyOn(getConversationPersistence(plugin), 'saveMetadata')
         .mockRejectedValueOnce(new Error('metadata write failed'));
-      (plugin as any).pendingSessionMetadataScan = false;
-
       let loadError: unknown;
       try {
-        await (plugin as any).loadRemainingSessionMetadata();
+        await plugin.refreshSessionMetadata();
       } catch (error) {
         loadError = error;
       }
@@ -1391,8 +1389,7 @@ describe('ClaudianPlugin', () => {
     it('reconciles durable conversation models before refreshing views', async () => {
       await plugin.onload();
       const events: string[] = [];
-      const repository = (plugin as any).conversationRepository;
-      jest.spyOn(repository, 'reconcileSelectedModels').mockImplementation(async () => {
+      const reconcile = jest.spyOn(plugin, 'reconcileConversationModels').mockImplementation(async () => {
         events.push('reconcile');
         return [];
       });
@@ -1400,24 +1397,22 @@ describe('ClaudianPlugin', () => {
         refreshModelSelector: jest.fn(() => events.push('refresh')),
       } as any]);
 
-      plugin.notifyProviderChatOptionsChanged('claude');
-      await (plugin as any).providerChatOptionsChangeTail;
+      await plugin.notifyProviderChatOptionsChanged('claude');
 
       expect(events).toEqual(['reconcile', 'refresh']);
+      expect(reconcile).toHaveBeenCalledWith('claude');
     });
 
     it('does not refresh model selectors when durable reconciliation fails', async () => {
       await plugin.onload();
-      const repository = (plugin as any).conversationRepository;
-      jest.spyOn(repository, 'reconcileSelectedModels')
+      jest.spyOn(plugin, 'reconcileConversationModels')
         .mockRejectedValue(new Error('disk full'));
       const refreshModelSelector = jest.fn();
       jest.spyOn(plugin, 'getAllViews').mockReturnValue([{
         refreshModelSelector,
       } as any]);
 
-      plugin.notifyProviderChatOptionsChanged('claude');
-      await (plugin as any).providerChatOptionsChangeTail;
+      await plugin.notifyProviderChatOptionsChanged('claude');
 
       expect(refreshModelSelector).not.toHaveBeenCalled();
     });
@@ -1449,8 +1444,7 @@ describe('ClaudianPlugin', () => {
     it('reconciles affected conversation models before refreshing after environment changes', async () => {
       await plugin.onload();
       const events: string[] = [];
-      const repository = (plugin as any).conversationRepository;
-      jest.spyOn(repository, 'reconcileSelectedModels').mockImplementation(async () => {
+      const reconcile = jest.spyOn(plugin, 'reconcileConversationModels').mockImplementation(async () => {
         events.push('reconcile');
         return [];
       });
@@ -1465,7 +1459,7 @@ describe('ClaudianPlugin', () => {
       );
 
       expect(events).toEqual(['invalidate', 'reconcile', 'refresh']);
-      expect(repository.reconcileSelectedModels).toHaveBeenCalledWith('claude');
+      expect(reconcile).toHaveBeenCalledWith('claude');
     });
 
     it('lets an initialized transition owner resolve CLI without reinitializing services', async () => {
@@ -1648,7 +1642,7 @@ describe('ClaudianPlugin', () => {
 
     it('retains a committed invalidation generation when publication fails before invalidation', async () => {
       await plugin.onload();
-      (plugin as any).hasLoadedAllSessionMetadata = true;
+      await plugin.refreshSessionMetadata();
       const conversation = await plugin.createConversation({
         providerId: 'claude',
         sessionId: 'pre-invalidation-session',
@@ -1671,10 +1665,8 @@ describe('ClaudianPlugin', () => {
 
         const generation = plugin.settings.pendingProviderSessionInvalidations.claude;
         expect(generation).toEqual(expect.any(Number));
-        expect((plugin as any).pendingEnvironmentInvalidationGenerations.get('claude'))
-          .toBe(generation);
-        expect((plugin as any).blockedEnvironmentInvalidationGenerations.get('claude'))
-          .toBe(generation);
+        expect(plugin.getProviderSessionInvalidationStatus('claude'))
+          .toEqual({ pendingGeneration: generation, blockedGeneration: generation });
         expect(conversation.sessionId).toBe('pre-invalidation-session');
         const persistedFailureSettings = JSON.parse(
           [...mockApp.vault.adapter.write.mock.calls]
@@ -1694,8 +1686,8 @@ describe('ClaudianPlugin', () => {
 
         expect(conversation.sessionId).toBeNull();
         expect(plugin.settings.pendingProviderSessionInvalidations.claude).toBeUndefined();
-        expect((plugin as any).pendingEnvironmentInvalidationGenerations.has('claude')).toBe(false);
-        expect((plugin as any).blockedEnvironmentInvalidationGenerations.has('claude')).toBe(false);
+        expect(plugin.getProviderSessionInvalidationStatus('claude'))
+          .toEqual({ pendingGeneration: undefined, blockedGeneration: undefined });
         expect(invalidateSpy).toHaveBeenCalledTimes(2);
         expect(plugin.executionLifecycleRegistry.getProviderGeneration('claude'))
           .toBe(initialGeneration + 2);
@@ -1706,7 +1698,7 @@ describe('ClaudianPlugin', () => {
 
     it('keeps invalidation pending until every invalidated metadata write succeeds', async () => {
       await plugin.onload();
-      (plugin as any).hasLoadedAllSessionMetadata = true;
+      await plugin.refreshSessionMetadata();
       const first = await plugin.createConversation({
         providerId: 'claude',
         sessionId: 'partial-write-first',
@@ -1730,10 +1722,8 @@ describe('ClaudianPlugin', () => {
         expect(first.sessionId).toBeNull();
         expect(second.sessionId).toBeNull();
         expect(generation).toEqual(expect.any(Number));
-        expect((plugin as any).pendingEnvironmentInvalidationGenerations.get('claude'))
-          .toBe(generation);
-        expect((plugin as any).blockedEnvironmentInvalidationGenerations.get('claude'))
-          .toBe(generation);
+        expect(plugin.getProviderSessionInvalidationStatus('claude'))
+          .toEqual({ pendingGeneration: generation, blockedGeneration: generation });
         const persistedFailureSettings = JSON.parse(
           [...mockApp.vault.adapter.write.mock.calls]
             .reverse()
@@ -1754,8 +1744,8 @@ describe('ClaudianPlugin', () => {
           expect.objectContaining({ id: second.id, sessionId: null }),
         ]));
         expect(plugin.settings.pendingProviderSessionInvalidations.claude).toBeUndefined();
-        expect((plugin as any).pendingEnvironmentInvalidationGenerations.has('claude')).toBe(false);
-        expect((plugin as any).blockedEnvironmentInvalidationGenerations.has('claude')).toBe(false);
+        expect(plugin.getProviderSessionInvalidationStatus('claude'))
+          .toEqual({ pendingGeneration: undefined, blockedGeneration: undefined });
       } finally {
         saveMetadataSpy.mockRestore();
       }
@@ -1877,7 +1867,7 @@ describe('ClaudianPlugin', () => {
       } | null = null;
       const afterTransition = jest.fn(() => {
         stateAtRelease = {
-          blocked: (plugin as any).blockedEnvironmentInvalidationGenerations.has('claude'),
+          blocked: plugin.getProviderSessionInvalidationStatus('claude').blockedGeneration !== undefined,
           deferredSessionId: plugin.getCachedConversation(deferredMetadata.id)?.sessionId,
           liveSessionId: live.sessionId,
           pending: plugin.settings.pendingProviderSessionInvalidations.claude,
@@ -1893,7 +1883,7 @@ describe('ClaudianPlugin', () => {
         'ANTHROPIC_BASE_URL=https://failed.example.com',
       ).catch(error => error);
       await writeStarted;
-      const scan = (plugin as any).loadRemainingSessionMetadata();
+      const scan = plugin.refreshSessionMetadata();
       await batchPublished;
       rejectWrite(writeError);
       expect(await apply).toBe(writeError);
@@ -1922,8 +1912,8 @@ describe('ClaudianPlugin', () => {
         resumeAtMessageId: 'deferred-resume-message',
       }));
       expect(plugin.settings.pendingProviderSessionInvalidations.claude).toBeUndefined();
-      expect((plugin as any).pendingEnvironmentInvalidationGenerations.has('claude')).toBe(false);
-      expect((plugin as any).blockedEnvironmentInvalidationGenerations.has('claude')).toBe(false);
+      expect(plugin.getProviderSessionInvalidationStatus('claude'))
+        .toEqual({ pendingGeneration: undefined, blockedGeneration: undefined });
       expect(saveMetadataSpy).not.toHaveBeenCalledWith(expect.objectContaining({
         id: deferredMetadata.id,
         sessionId: null,
@@ -2002,7 +1992,7 @@ describe('ClaudianPlugin', () => {
 
     it('serializes overlapping environment invalidation writes', async () => {
       await plugin.onload();
-      (plugin as any).hasLoadedAllSessionMetadata = true;
+      await plugin.refreshSessionMetadata();
       await plugin.createConversation({ sessionId: 'overlapping-session' });
       let finishFirstWrite!: () => void;
       const firstWriteRelease = new Promise<void>((resolve) => {
@@ -2051,7 +2041,7 @@ describe('ClaudianPlugin', () => {
 
     it('flushes already-invalidated sessions after an earlier environment write fails', async () => {
       await plugin.onload();
-      (plugin as any).hasLoadedAllSessionMetadata = true;
+      await plugin.refreshSessionMetadata();
       await plugin.createConversation({ sessionId: 'failed-overlap-session' });
       const saveMetadataSpy = jest.spyOn(getConversationPersistence(plugin), 'saveMetadata')
         .mockRejectedValueOnce(new Error('metadata write failed'));
@@ -2176,7 +2166,6 @@ describe('ClaudianPlugin', () => {
       const reconcileSpy = jest.spyOn(claudeReconciler, 'reconcileModelWithEnvironment')
         .mockReturnValue({ changed: true, invalidatedConversations: [] });
       claudeReconciler.environmentSessionPolicy = 'reload';
-      const stagePendingSpy = jest.spyOn(plugin as any, 'stagePendingSessionInvalidations');
       const getTabManager = jest.fn();
       const mockView = {
         getTabManager,
@@ -2200,11 +2189,10 @@ describe('ClaudianPlugin', () => {
 
       const preserved = await plugin.getConversationById(reloadConversation.id);
       const invalidated = await plugin.getConversationById(invalidatedConversation.id);
-      expect(stagePendingSpy).toHaveBeenCalledWith(
-        expect.anything(),
-        ['codex'],
-      );
-      expect(stagePendingSpy).toHaveBeenCalledTimes(1);
+      expect(plugin.getProviderSessionInvalidationStatus('codex').pendingGeneration)
+        .toEqual(expect.any(Number));
+      expect(plugin.getProviderSessionInvalidationStatus('claude').pendingGeneration)
+        .toBeUndefined();
       expect(preserved).toEqual(expect.objectContaining({
         sessionId: 'preserved-session',
         providerState: { providerSessionId: 'preserved-provider-session' },
@@ -2289,7 +2277,6 @@ describe('ClaudianPlugin', () => {
       });
 
       await plugin.onload();
-      (plugin as any).hasLoadedAllSessionMetadata = false;
       const hostnameKey = getHostnameKey();
       await plugin.applyProviderRuntimeSettings(['codex'], (settings) => {
         updateCodexProviderSettings(settings, {
@@ -2325,7 +2312,7 @@ describe('ClaudianPlugin', () => {
       const loadSourceSpy = mockMetadataSources(deferredMetadata);
 
       await restartedPlugin.onload();
-      await (restartedPlugin as any).loadRemainingSessionMetadata();
+      await restartedPlugin.refreshSessionMetadata();
 
       const restartedConversation = restartedPlugin.getCachedConversation(deferredMetadata.id);
       const persistedMetadata = JSON.parse(
@@ -2385,7 +2372,7 @@ describe('ClaudianPlugin', () => {
 
     it('finishes durable invalidation when a post-commit apply hook fails', async () => {
       await plugin.onload();
-      (plugin as any).hasLoadedAllSessionMetadata = true;
+      await plugin.refreshSessionMetadata();
       const conversation = await plugin.createConversation({
         providerId: 'codex',
         sessionId: 'post-commit-thread',

--- a/tests/unit/core/mcp/createNodeFetch.test.ts
+++ b/tests/unit/core/mcp/createNodeFetch.test.ts
@@ -2,71 +2,32 @@ import {
   Client,
   StreamableHTTPClientTransport,
 } from '@modelcontextprotocol/client';
-import * as http from 'http';
-import type { AddressInfo } from 'net';
+import {
+  createTestHttpServer,
+  type TestHttpRequest,
+  type TestHttpServer,
+} from '@test/helpers/TestHttpServer';
+import type * as http from 'http';
 
 import { createNodeFetch } from '@/core/mcp/McpTester';
 
-interface ReceivedRequest {
-  method: string;
-  url: string;
-  headers: http.IncomingHttpHeaders;
-  body: string;
-}
-
-function createTestServer(handler?: (req: ReceivedRequest, res: http.ServerResponse) => void): {
-  server: http.Server;
-  getUrl: () => string;
-  received: ReceivedRequest[];
-} {
-  const received: ReceivedRequest[] = [];
-
-  const server = http.createServer((req, res) => {
-    const chunks: Buffer[] = [];
-    req.on('data', (chunk: Buffer) => chunks.push(chunk));
-    req.on('end', () => {
-      const entry: ReceivedRequest = {
-        method: req.method ?? 'GET',
-        url: req.url ?? '/',
-        headers: req.headers,
-        body: Buffer.concat(chunks).toString('utf-8'),
-      };
-      received.push(entry);
-
-      if (handler) {
-        handler(entry, res);
-      } else {
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ ok: true }));
-      }
-    });
-  });
-
-  server.listen(0);
-
-  return {
-    server,
-    getUrl: () => {
-      const addr = server.address() as AddressInfo;
-      return `http://127.0.0.1:${addr.port}`;
-    },
-    received,
-  };
-}
-
 describe('createNodeFetch', () => {
-  let server: http.Server;
+  let server: TestHttpServer['server'] | null = null;
   let getUrl: () => string;
-  let received: ReceivedRequest[];
+  let received: TestHttpRequest[] = [];
   let nodeFetch: ReturnType<typeof createNodeFetch>;
   const serversToClose: http.Server[] = [];
 
-  beforeAll(() => {
-    ({ server, getUrl, received } = createTestServer());
+  beforeAll(async () => {
+    ({ server, getUrl, received } = await createTestHttpServer());
     nodeFetch = createNodeFetch();
   });
 
   afterAll(() => new Promise<void>((resolve) => {
+    if (!server) {
+      resolve();
+      return;
+    }
     server.close(() => resolve());
   }));
 
@@ -138,7 +99,7 @@ describe('createNodeFetch', () => {
   });
 
   it('should handle non-200 responses', async () => {
-    const { server: errorServer, getUrl: errorUrl, received: errorReceived } = createTestServer(
+    const { server: errorServer, getUrl: errorUrl, received: errorReceived } = await createTestHttpServer(
       (_req, res) => {
         res.writeHead(404, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: 'not found' }));
@@ -166,7 +127,7 @@ describe('createNodeFetch', () => {
   });
 
   it('should stop a hanging MCP HTTP discovery probe at the SDK request timeout', async () => {
-    const { server: hangingServer, getUrl: hangingUrl, received: hangingReceived } = createTestServer(
+    const { server: hangingServer, getUrl: hangingUrl, received: hangingReceived } = await createTestHttpServer(
       () => {
         // Accept the discovery request without ever sending a response.
       },

--- a/tests/unit/features/chat/services/SubagentManager.test.ts
+++ b/tests/unit/features/chat/services/SubagentManager.test.ts
@@ -1,5 +1,6 @@
 import '@/providers';
 
+import { createUntrustedTestFile } from '@test/helpers/testFilesystem';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -947,9 +948,9 @@ ${inlineOutput}
       const { manager } = createManager();
       setupLinkedAgentOutput(manager, 'task-1', 'agent-untrusted-output', 'out-1');
 
-      const homeDir = process.env.HOME ?? process.cwd();
-      const untrustedDir = mkdtempSync(join(homeDir, '.claudian-untrusted-'));
-      const fullOutputFile = join(untrustedDir, 'agent-untrusted.output');
+      const { filePath: fullOutputFile, cleanup } = createUntrustedTestFile(
+        'agent-untrusted.output',
+      );
       const fullOutput = [
         JSON.stringify({
           type: 'assistant',
@@ -973,7 +974,7 @@ ${inlineOutput}
         const result = manager.handleAgentOutputToolResult('out-1', xmlPayload, false);
         expect(result?.result).toBe(inlineOutput);
       } finally {
-        rmSync(untrustedDir, { recursive: true, force: true });
+        cleanup();
       }
     });
 


### PR DESCRIPTION
## Summary
- extract deferred session metadata loading into SessionMetadataCoordinator
- centralize session invalidation generations and completion in SessionInvalidationCoordinator
- extract provider runtime settings transaction handling
- harden test filesystem and HTTP adapters

## Validation
- 387 test suites / 6881 tests passed
- typecheck passed
- build passed with external Obsidian vault copy disabled
- lint has 8 pre-existing warnings and no errors