### PR TITLE
perf: defer provider registration

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,8 +3,6 @@ import { StartupProfiler } from './core/performance/StartupProfiler';
 import { patchSetMaxListenersForElectron } from './utils/electronCompat';
 patchSetMaxListenersForElectron();
 
-import './providers';
-
 StartupProfiler.finishModuleEvaluation();
 
 import type { Editor, TAbstractFile, WorkspaceLeaf } from 'obsidian';
@@ -83,6 +81,20 @@ function isClaudianView(value: unknown): value is ClaudianView {
   return !!value
     && typeof value === 'object'
     && typeof (value as { getTabManager?: unknown }).getTabManager === 'function';
+}
+
+let providerModulesLoad: Promise<void> | null = null;
+
+function ensureProviderModulesLoaded(): Promise<void> {
+  if (!providerModulesLoad) {
+    providerModulesLoad = import('./providers')
+      .then(() => undefined)
+      .catch((error) => {
+        providerModulesLoad = null;
+        throw error;
+      });
+  }
+  return providerModulesLoad;
 }
 
 export default class ClaudianPlugin extends Plugin {
@@ -379,6 +391,7 @@ export default class ClaudianPlugin extends Plugin {
   }
 
   async loadSettings(options: { deferNonRestoredSessionMetadata?: boolean } = {}) {
+    await ensureProviderModulesLoaded();
     this.hasLoadedAllSessionMetadata = false;
     const sharedStorage = new SharedStorageService(this);
     this.storage = sharedStorage;


### PR DESCRIPTION
## Summary

- defer built-in provider module evaluation until settings load
- preserve provider registration before settings reconciliation
- keep the single-file Obsidian bundle

## Validation

- npm run typecheck
- npm run lint (8 pre-existing warnings, 0 errors)
- npm run test -- --runInBand (387 suites, 6881 tests)
- isolated npm run build
- npm run check:performance (cold evaluation improved from 69.1 ms to 59.9 ms)