### PR TITLE
perf: parallelize provider initialization

### DIFF
--- a/src/core/providers/ProviderWorkspaceRegistry.ts
+++ b/src/core/providers/ProviderWorkspaceRegistry.ts
@@ -38,13 +38,13 @@ export class ProviderWorkspaceRegistry {
   }
 
   static async initializeAll(plugin: ProviderHost): Promise<void> {
-    for (const providerId of this.boundary.getRegisteredProviderIds()) {
+    await Promise.all(this.boundary.getRegisteredProviderIds().map(async (providerId) => {
       try {
         await this.ensureInitialized(plugin, providerId, 'startup');
       } catch {
         // Compatibility path only: one provider must not block the remaining providers.
       }
-    }
+    }));
   }
 
   static async ensureInitialized(

--- a/tests/integration/startup/StartupOptimization.test.ts
+++ b/tests/integration/startup/StartupOptimization.test.ts
@@ -103,6 +103,35 @@ describe('Startup optimization', () => {
     expect(discoveryResolved).toBe(true);
   });
 
+  it('workspace registry initializes independent providers concurrently', async () => {
+    let releaseFirst!: () => void;
+    let secondStarted = false;
+    const firstReady = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    ProviderWorkspaceRegistry.register('claude', {
+      initialize: async () => {
+        await firstReady;
+        return {};
+      },
+    });
+    ProviderWorkspaceRegistry.register('codex', {
+      initialize: async () => {
+        secondStarted = true;
+        return {};
+      },
+    });
+
+    const host = createFakeHost();
+    const initPromise = ProviderWorkspaceRegistry.initializeAll(host);
+    await new Promise<void>(resolve => setTimeout(resolve, 0));
+
+    expect(secondStarted).toBe(true);
+    releaseFirst();
+    await initPromise;
+  });
+
   it('profiler captures provider initialization span', async () => {
     ProviderWorkspaceRegistry.register('codex', {
       initialize: async () => ({


### PR DESCRIPTION
## Summary

- initialize independent provider workspace services concurrently
- preserve per-provider failure isolation
- add an integration test proving a slow provider does not delay another provider from starting

## Validation

- npm run typecheck
- npm run lint (8 pre-existing warnings, 0 errors)
- npm run test -- --runInBand (387 suites, 6882 tests)
- isolated npm run build
- npm run check:performance