### PR TITLE
perf: parallelize model reconciliation

### DIFF
--- a/src/app/conversations/ConversationRepository.ts
+++ b/src/app/conversations/ConversationRepository.ts
@@ -98,6 +98,7 @@ type HistoricalModelRecovery = NonNullable<
 >;
 
 const HISTORICAL_MODEL_RECOVERY_CONCURRENCY = 2;
+const MODEL_RECONCILIATION_CONCURRENCY = 4;
 
 function getStoredModelSelection(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
@@ -1141,22 +1142,22 @@ export class ConversationRepository {
   }
 
   async reconcileSelectedModels(providerId: ProviderId): Promise<Conversation[]> {
-    const changed: Conversation[] = [];
-    for (const conversation of this.conversations) {
-      if (
-        conversation.providerId !== providerId
-        || !getStoredModelSelection(conversation.selectedModel)
-      ) {
-        continue;
-      }
-
-      const previousModel = conversation.selectedModel;
-      await this.ensureSelectedModel(conversation);
-      if (conversation.selectedModel !== previousModel) {
-        changed.push(conversation);
-      }
-    }
-    return changed;
+    const candidates = this.conversations.filter((conversation) => (
+      conversation.providerId === providerId
+      && getStoredModelSelection(conversation.selectedModel)
+    ));
+    const changed = await mapWithConcurrency(
+      candidates,
+      async (conversation): Promise<Conversation | null> => {
+        const previousModel = conversation.selectedModel;
+        await this.ensureSelectedModel(conversation);
+        return conversation.selectedModel !== previousModel ? conversation : null;
+      },
+      MODEL_RECONCILIATION_CONCURRENCY,
+    );
+    return changed.filter(
+      (conversation): conversation is Conversation => conversation !== null,
+    );
   }
 
   private applyNotePathRenames(conversation: Conversation): boolean {

--- a/tests/unit/app/conversations/ConversationRepository.test.ts
+++ b/tests/unit/app/conversations/ConversationRepository.test.ts
@@ -522,6 +522,32 @@ describe('ConversationRepository hydration', () => {
     expect(persistence.saveMetadata).toHaveBeenCalledTimes(1);
   });
 
+  it('reconciles multiple conversations without waiting on one persistence write', async () => {
+    const first = createConversation('first-reconciliation');
+    first.selectedModel = 'claude-code/retired-model';
+    const second = createConversation('second-reconciliation');
+    second.selectedModel = 'claude-code/retired-model';
+    const { repository, persistence } = createRepository(first);
+    repository.replaceAll([first, second]);
+
+    let releaseFirst!: () => void;
+    const firstSave = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let saveCount = 0;
+    persistence.saveMetadata.mockImplementation(() => {
+      saveCount += 1;
+      return saveCount === 1 ? firstSave : Promise.resolve();
+    });
+
+    const reconciliation = repository.reconcileSelectedModels('claude');
+    await new Promise<void>(resolve => setImmediate(resolve));
+
+    expect(saveCount).toBe(2);
+    releaseFirst();
+    await expect(reconciliation).resolves.toEqual([first, second]);
+  });
+
   it('reports whether selected-model metadata is safe for incremental publication', () => {
     const conversation = createConversation('publication-safety');
     const { repository } = createRepository(conversation);


### PR DESCRIPTION
## Summary

- reconcile selected models with bounded concurrency across conversations
- preserve deterministic result ordering and existing error propagation
- avoid one slow persistence write blocking all later conversations

## Validation

- npm run typecheck
- npm run lint (8 pre-existing warnings, 0 errors)
- npm run test -- --runInBand (387 suites, 6883 tests)
- isolated npm run build
- npm run check:performance