### PR TITLE
perf: optimize metadata reconciliation pipeline

### DIFF
--- a/src/app/conversations/ConversationRepository.ts
+++ b/src/app/conversations/ConversationRepository.ts
@@ -240,14 +240,15 @@ export class ConversationRepository {
       }
     }
     const registeredProviderIds = new Set(ProviderRegistry.getRegisteredProviderIds());
-    for (const { conversation } of entries) {
-      if (
-        !this.getSync(conversation.id)
-        && registeredProviderIds.has(conversation.providerId)
-      ) {
-        await this.reconcileIncomingSelectedModel(conversation);
-      }
-    }
+    const incomingModelReconciliations = entries.filter(({ conversation }) => (
+      !this.getSync(conversation.id)
+      && registeredProviderIds.has(conversation.providerId)
+    ));
+    await mapWithConcurrency(
+      incomingModelReconciliations,
+      ({ conversation }) => this.reconcileIncomingSelectedModel(conversation),
+      MODEL_RECONCILIATION_CONCURRENCY,
+    );
     const added = this.mergeMetadataConversations(
       entries.map(({ conversation }) => conversation),
     );

--- a/src/app/conversations/ConversationRepository.ts
+++ b/src/app/conversations/ConversationRepository.ts
@@ -256,9 +256,9 @@ export class ConversationRepository {
     const providerIds = new Set(entries
       .map(({ conversation }) => conversation.providerId)
       .filter(providerId => registeredProviderIds.has(providerId)));
-    for (const providerId of providerIds) {
-      await this.reconcileSelectedModels(providerId);
-    }
+    await Promise.all(
+      [...providerIds].map(providerId => this.reconcileSelectedModels(providerId)),
+    );
     const migrations = entries
       .filter(
         ({ conversation, needsMigration, source }) =>

--- a/src/app/conversations/SessionMetadataCoordinator.ts
+++ b/src/app/conversations/SessionMetadataCoordinator.ts
@@ -10,7 +10,10 @@ import type {
   Conversation,
   SessionMetadata,
 } from '../../core/types';
+import { mapWithConcurrency } from '../../utils/concurrency';
 import type { ConversationRepository } from './ConversationRepository';
+
+const SESSION_METADATA_SOURCE_READ_CONCURRENCY = 8;
 
 export interface SessionMetadataCoordinatorOptions {
   sessions: SessionMetadataReader;
@@ -187,8 +190,10 @@ export class SessionMetadataCoordinator {
   private async resolveMetadataSources(
     metadata: SessionMetadata[],
   ): Promise<SessionMetadataReadResult[]> {
-    const records = await Promise.all(
-      metadata.map(({ id }) => this.sessions.load(id)),
+    const records = await mapWithConcurrency(
+      metadata,
+      ({ id }) => this.sessions.load(id),
+      SESSION_METADATA_SOURCE_READ_CONCURRENCY,
     );
     return records.filter(
       (record): record is SessionMetadataReadResult => record !== null,

--- a/tests/unit/app/conversations/ConversationRepository.test.ts
+++ b/tests/unit/app/conversations/ConversationRepository.test.ts
@@ -615,6 +615,35 @@ describe('ConversationRepository hydration', () => {
     expect(repository.getCachedConversation(second.id)).toBe(second);
   });
 
+  it('reconciles adopted providers without waiting on another provider', async () => {
+    const { repository } = createRepository(createConversation('existing'));
+    const claude = createConversation('claude-adoption');
+    const codex = createConversation('codex-adoption');
+    codex.providerId = 'codex';
+    let releaseFirst!: () => void;
+    const firstReconciliation = new Promise<Conversation[]>((resolve) => {
+      releaseFirst = () => resolve([]);
+    });
+    let secondStarted = false;
+    const reconcile = jest.spyOn(repository, 'reconcileSelectedModels')
+      .mockImplementationOnce(async () => firstReconciliation)
+      .mockImplementationOnce(async () => {
+        secondStarted = true;
+        return [];
+      });
+
+    const adoption = repository.adoptMetadataConversations([
+      { conversation: claude, needsMigration: false, source: 'current' },
+      { conversation: codex, needsMigration: false, source: 'current' },
+    ]);
+    await new Promise<void>(resolve => setImmediate(resolve));
+
+    expect(secondStarted).toBe(true);
+    releaseFirst();
+    reconcile.mockRestore();
+    await expect(adoption).resolves.toBeUndefined();
+  });
+
   it('keeps failed deferred metadata unpublished so adoption can retry persistence', async () => {
     const { repository, persistence } = createRepository(createConversation('existing'));
     const deferred = createConversation('deferred-failed-fallback');

--- a/tests/unit/app/conversations/ConversationRepository.test.ts
+++ b/tests/unit/app/conversations/ConversationRepository.test.ts
@@ -585,6 +585,36 @@ describe('ConversationRepository hydration', () => {
     }));
   });
 
+  it('adopts multiple deferred models without waiting on one persistence write', async () => {
+    const { repository, persistence } = createRepository(createConversation('existing'));
+    const first = createConversation('first-deferred-model');
+    first.selectedModel = 'claude-code/retired-model';
+    const second = createConversation('second-deferred-model');
+    second.selectedModel = 'claude-code/retired-model';
+
+    let releaseFirst!: () => void;
+    const firstSave = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let saveCount = 0;
+    persistence.saveMetadata.mockImplementation(() => {
+      saveCount += 1;
+      return saveCount === 1 ? firstSave : Promise.resolve();
+    });
+
+    const adoption = repository.adoptMetadataConversations([
+      { conversation: first, needsMigration: false, source: 'current' },
+      { conversation: second, needsMigration: false, source: 'current' },
+    ]);
+    await new Promise<void>(resolve => setImmediate(resolve));
+
+    expect(saveCount).toBe(2);
+    releaseFirst();
+    await adoption;
+    expect(repository.getCachedConversation(first.id)).toBe(first);
+    expect(repository.getCachedConversation(second.id)).toBe(second);
+  });
+
   it('keeps failed deferred metadata unpublished so adoption can retry persistence', async () => {
     const { repository, persistence } = createRepository(createConversation('existing'));
     const deferred = createConversation('deferred-failed-fallback');


### PR DESCRIPTION
## Summary

Batch metadata reconciliation improvements:

- reconcile deferred conversation models with bounded concurrency
- reconcile independent providers concurrently after adoption
- bound metadata source reads to avoid saturating the Vault adapter
- preserve publication safety, result ordering, and existing error propagation

## Validation

- npm run typecheck
- npm run lint (8 pre-existing warnings, 0 errors)
- npm run test -- --runInBand (387 suites, 6885 tests)
- isolated npm run build
- npm run check:performance