### PR TITLE
perf: batch storage reads

### DIFF
--- a/src/core/bootstrap/SessionStorage.ts
+++ b/src/core/bootstrap/SessionStorage.ts
@@ -117,7 +117,9 @@ export class SessionStorage implements SessionMetadataReader {
   async scan(
     options: SessionMetadataReadOptions = {},
   ): Promise<SessionMetadataReadScanResult> {
-    const currentListing = await this.listFiles(SESSIONS_PATH);
+    const currentListingPromise = this.listFiles(SESSIONS_PATH);
+    const legacyListingPromise = this.listFiles(LEGACY_SESSIONS_PATH);
+    const currentListing = await currentListingPromise;
     if (!currentListing.complete) {
       return {
         records: [],
@@ -126,7 +128,7 @@ export class SessionStorage implements SessionMetadataReader {
       };
     }
 
-    const legacyListing = await this.listFiles(LEGACY_SESSIONS_PATH);
+    const legacyListing = await legacyListingPromise;
     const deletedIds = new Set(
       currentListing.files
         .map((path) => this.getIdFromPath(path, DELETION_MARKER_SUFFIX))

--- a/src/providers/claude/storage/AgentVaultStorage.ts
+++ b/src/providers/claude/storage/AgentVaultStorage.ts
@@ -1,39 +1,46 @@
 import type { VaultFileAdapter } from '../../../core/storage/VaultFileAdapter';
 import type { AgentDefinition } from '../../../core/types';
 import { serializeAgent } from '../../../utils/agent';
+import { mapWithConcurrency } from '../../../utils/concurrency';
 import { buildAgentFromFrontmatter, parseAgentFile } from '../agents/AgentStorage';
 
 export const AGENTS_PATH = '.claude/agents';
+const AGENT_READ_CONCURRENCY = 8;
 
 export class AgentVaultStorage {
   constructor(private adapter: VaultFileAdapter) {}
 
   async loadAll(): Promise<AgentDefinition[]> {
-    const agents: AgentDefinition[] = [];
-
     try {
       const files = await this.adapter.listFiles(AGENTS_PATH);
+      const markdownFiles = files.filter(filePath => filePath.endsWith('.md'));
+      const agents = await mapWithConcurrency(
+        markdownFiles,
+        async (filePath) => {
+          try {
+            const content = await this.adapter.read(filePath);
+            const parsed = parseAgentFile(content);
+            if (!parsed) return null;
 
-      for (const filePath of files) {
-        if (!filePath.endsWith('.md')) continue;
+            const { frontmatter, body } = parsed;
 
-        try {
-          const content = await this.adapter.read(filePath);
-          const parsed = parseAgentFile(content);
-          if (!parsed) continue;
-
-          const { frontmatter, body } = parsed;
-
-          agents.push(buildAgentFromFrontmatter(frontmatter, body, {
-            id: frontmatter.name,
-            source: 'vault',
-            filePath,
-          }));
-        } catch { /* Non-critical: skip malformed agent files */ }
-      }
+            return buildAgentFromFrontmatter(frontmatter, body, {
+              id: frontmatter.name,
+              source: 'vault',
+              filePath,
+            });
+          } catch {
+            return null;
+          }
+        },
+        AGENT_READ_CONCURRENCY,
+      );
+      return agents.filter(
+        (agent): agent is AgentDefinition => agent !== null,
+      );
     } catch { /* Non-critical: directory may not exist yet */ }
 
-    return agents;
+    return [];
   }
 
   async load(agent: AgentDefinition): Promise<AgentDefinition | null> {

--- a/src/providers/claude/storage/SlashCommandStorage.ts
+++ b/src/providers/claude/storage/SlashCommandStorage.ts
@@ -1,35 +1,38 @@
 import type { VaultFileAdapter } from '../../../core/storage/VaultFileAdapter';
 import type { SlashCommand } from '../../../core/types';
+import { mapWithConcurrency } from '../../../utils/concurrency';
 import { parsedToSlashCommand, parseSlashCommandContent, serializeCommand } from '../../../utils/slashCommand';
 
 export const COMMANDS_PATH = '.claude/commands';
+const COMMAND_READ_CONCURRENCY = 8;
 
 export class SlashCommandStorage {
   constructor(private adapter: VaultFileAdapter) {}
 
   async loadAll(): Promise<SlashCommand[]> {
-    const commands: SlashCommand[] = [];
-
     try {
       const files = await this.adapter.listFilesRecursive(COMMANDS_PATH);
-
-      for (const filePath of files) {
-        if (!filePath.endsWith('.md')) continue;
-
-        try {
-          const command = await this.loadFromFile(filePath);
-          if (command) {
-            commands.push(command);
+      const markdownFiles = files.filter(filePath => filePath.endsWith('.md'));
+      const commands = await mapWithConcurrency(
+        markdownFiles,
+        async (filePath) => {
+          try {
+            return await this.loadFromFile(filePath);
+          } catch {
+            // Non-critical: skip malformed command files
+            return null;
           }
-        } catch {
-          // Non-critical: skip malformed command files
-        }
-      }
+        },
+        COMMAND_READ_CONCURRENCY,
+      );
+      return commands.filter(
+        (command): command is SlashCommand => command !== null,
+      );
     } catch {
       // Non-critical: directory may not exist yet
     }
 
-    return commands;
+    return [];
   }
 
   private async loadFromFile(filePath: string): Promise<SlashCommand | null> {

--- a/src/providers/codex/storage/CodexSubagentStorage.ts
+++ b/src/providers/codex/storage/CodexSubagentStorage.ts
@@ -1,6 +1,7 @@
 import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
 
 import type { VaultFileAdapter } from '../../../core/storage/VaultFileAdapter';
+import { mapWithConcurrency } from '../../../utils/concurrency';
 import {
   CODEX_SUBAGENT_KNOWN_KEYS,
   type CodexSubagentDefinition,
@@ -8,6 +9,7 @@ import {
 
 export const CODEX_AGENTS_PATH = '.codex/agents';
 const SUBAGENT_PERSISTENCE_PREFIX = 'codex-subagent';
+const CODEX_SUBAGENT_READ_CONCURRENCY = 8;
 
 export interface CodexSubagentLocation {
   fileName: string;
@@ -99,25 +101,29 @@ export class CodexSubagentStorage {
   private async scanAdapter(
     adapter: Pick<VaultFileAdapter, 'read' | 'listFiles'>,
   ): Promise<CodexSubagentDefinition[]> {
-    const results: CodexSubagentDefinition[] = [];
-
     try {
       const files = await adapter.listFiles(CODEX_AGENTS_PATH);
-      for (const filePath of files) {
-        if (!filePath.endsWith('.toml')) continue;
-        try {
-          const content = await adapter.read(filePath);
-          const agent = parseSubagentToml(content, filePath);
-          if (agent) results.push(agent);
-        } catch {
-          // Skip malformed files
-        }
-      }
+      const tomlFiles = files.filter(filePath => filePath.endsWith('.toml'));
+      const results = await mapWithConcurrency(
+        tomlFiles,
+        async (filePath) => {
+          try {
+            const content = await adapter.read(filePath);
+            return parseSubagentToml(content, filePath);
+          } catch {
+            // Skip malformed files
+            return null;
+          }
+        },
+        CODEX_SUBAGENT_READ_CONCURRENCY,
+      );
+      return results.filter(
+        (agent): agent is CodexSubagentDefinition => agent !== null,
+      );
     } catch {
       // Directory doesn't exist yet
+      return [];
     }
-
-    return results;
   }
 }
 

--- a/tests/unit/providers/claude/storage/SessionStorage.test.ts
+++ b/tests/unit/providers/claude/storage/SessionStorage.test.ts
@@ -456,6 +456,27 @@ describe('SessionStorage', () => {
       expect(metas).toEqual([]);
     });
 
+    it('starts current and legacy directory scans concurrently', async () => {
+      let releaseCurrent!: () => void;
+      const currentListing = new Promise<string[]>((resolve) => {
+        releaseCurrent = () => resolve([]);
+      });
+      mockAdapter.listFiles.mockImplementation((path: string) => (
+        path === SESSIONS_PATH ? currentListing : Promise.resolve([])
+      ));
+
+      const scan = storage.scanMetadata();
+      expect(mockAdapter.listFiles).toHaveBeenCalledWith(SESSIONS_PATH);
+      expect(mockAdapter.listFiles).toHaveBeenCalledWith(LEGACY_SESSIONS_PATH);
+
+      releaseCurrent();
+      await expect(scan).resolves.toEqual({
+        metadata: [],
+        complete: true,
+        invalidMetadataCount: 0,
+      });
+    });
+
     it('handles listFiles error gracefully', async () => {
       mockAdapter.listFiles.mockRejectedValue(new Error('List error'));
 

--- a/tests/unit/providers/codex/storage/CodexSubagentStorage.test.ts
+++ b/tests/unit/providers/codex/storage/CodexSubagentStorage.test.ts
@@ -248,6 +248,30 @@ describe('CodexSubagentStorage', () => {
 
       expect(agents).toEqual([]);
     });
+
+    it('reads multiple subagent files concurrently', async () => {
+      const adapter = createMockAdapter({
+        '.codex/agents/reviewer.toml': BASIC_TOML,
+        '.codex/agents/explorer.toml': FULL_TOML,
+      });
+      let releaseFirst!: () => void;
+      const firstRead = new Promise<string>((resolve) => {
+        releaseFirst = () => resolve(BASIC_TOML);
+      });
+      let readCount = 0;
+      (adapter.read as jest.Mock).mockImplementation((path: string) => {
+        readCount += 1;
+        return readCount === 1 ? firstRead : Promise.resolve(FULL_TOML);
+      });
+
+      const storage = new CodexSubagentStorage(adapter);
+      const load = storage.loadAll();
+      await new Promise<void>(resolve => setImmediate(resolve));
+
+      expect(readCount).toBe(2);
+      releaseFirst();
+      await expect(load).resolves.toHaveLength(2);
+    });
   });
 
   describe('load', () => {


### PR DESCRIPTION
## Summary

Batch storage I/O improvements:

- start current and legacy session directory scans concurrently
- read Codex subagent files with bounded concurrency
- read Claude agent files with bounded concurrency
- read Claude slash-command files with bounded concurrency
- preserve source ordering and per-file failure isolation

## Validation

- npm run typecheck
- npm run lint (8 pre-existing warnings, 0 errors)
- npm run test -- --runInBand (387 suites, 6887 tests)
- isolated npm run build
- npm run check:performance