### PR TITLE
fix: isolate Oh My Claudian when running with Claudian

### DIFF
--- a/src/core/types/chat.ts
+++ b/src/core/types/chat.ts
@@ -9,7 +9,10 @@ export interface ForkSource {
 }
 
 /** View type identifier for Obsidian. */
-export const VIEW_TYPE_CLAUDIAN = 'claudian-view';
+export const VIEW_TYPE_CLAUDIAN = 'oh-my-claudian-view';
+
+/** Root class used to identify Oh My Claudian-owned view DOM. */
+export const OH_MY_CLAUDIAN_ROOT_CLASS = 'oh-my-claudian-root';
 
 /** Supported image media types for attachments. */
 export type ImageMediaType = 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp';

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -21,6 +21,7 @@ export {
   type ImageAttachment,
   type ImageMediaType,
   isCanonicalUserMessage,
+  OH_MY_CLAUDIAN_ROOT_CLASS,
   type SessionMetadata,
   type StreamChunk,
   type UsageInfo,

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -10,7 +10,11 @@ import {
 import { ProviderRegistry } from '../../core/providers/ProviderRegistry';
 import { ProviderSettingsCoordinator } from '../../core/providers/ProviderSettingsCoordinator';
 import { type AppTabManagerState, DEFAULT_CHAT_PROVIDER_ID, type ProviderId } from '../../core/providers/types';
-import { type ConversationMeta, VIEW_TYPE_CLAUDIAN } from '../../core/types';
+import {
+  type ConversationMeta,
+  OH_MY_CLAUDIAN_ROOT_CLASS,
+  VIEW_TYPE_CLAUDIAN,
+} from '../../core/types';
 import {
   cancelScheduledAnimationFrame,
   scheduleAnimationFrame,
@@ -263,7 +267,7 @@ export class ClaudianView extends ItemView {
 
     this.viewContainerEl = container;
     this.viewContainerEl.empty();
-    this.viewContainerEl.addClass('claudian-container');
+    this.viewContainerEl.addClass('claudian-container', OH_MY_CLAUDIAN_ROOT_CLASS);
 
     this.navRowContent = this.buildNavRowContent();
     this.buildViewLayout();

--- a/src/features/settings/ClaudianSettings.ts
+++ b/src/features/settings/ClaudianSettings.ts
@@ -659,11 +659,11 @@ export class ClaudianSettingTab extends PluginSettingTab {
     new Setting(container).setName(t('settings.hotkeys')).setHeading();
 
     const hotkeyGrid = container.createDiv({ cls: 'claudian-hotkey-grid' });
-    addHotkeySettingRow(hotkeyGrid, this.app, 'claudian:inline-edit', 'settings.inlineEditHotkey');
-    addHotkeySettingRow(hotkeyGrid, this.app, 'claudian:open-view', 'settings.openChatHotkey');
-    addHotkeySettingRow(hotkeyGrid, this.app, 'claudian:new-session', 'settings.newSessionHotkey');
-    addHotkeySettingRow(hotkeyGrid, this.app, 'claudian:new-tab', 'settings.newTabHotkey');
-    addHotkeySettingRow(hotkeyGrid, this.app, 'claudian:close-current-tab', 'settings.closeTabHotkey');
+    addHotkeySettingRow(hotkeyGrid, this.app, 'oh-my-claudian:inline-edit', 'settings.inlineEditHotkey');
+    addHotkeySettingRow(hotkeyGrid, this.app, 'oh-my-claudian:open-view', 'settings.openChatHotkey');
+    addHotkeySettingRow(hotkeyGrid, this.app, 'oh-my-claudian:new-session', 'settings.newSessionHotkey');
+    addHotkeySettingRow(hotkeyGrid, this.app, 'oh-my-claudian:new-tab', 'settings.newTabHotkey');
+    addHotkeySettingRow(hotkeyGrid, this.app, 'oh-my-claudian:close-current-tab', 'settings.closeTabHotkey');
 
     // --- Environment ---
 

--- a/src/shared/settings/EnvSnippetManager.ts
+++ b/src/shared/settings/EnvSnippetManager.ts
@@ -7,7 +7,11 @@ import {
 } from '../../core/providers/providerEnvironment';
 import type { ProviderHost } from '../../core/providers/ProviderHost';
 import { ProviderRegistry } from '../../core/providers/ProviderRegistry';
-import type { EnvironmentScope, EnvSnippet } from '../../core/types';
+import {
+  type EnvironmentScope,
+  type EnvSnippet,
+  VIEW_TYPE_CLAUDIAN,
+} from '../../core/types';
 import { t } from '../../i18n/i18n';
 import { formatContextLimit, parseContextLimit, parseEnvironmentVariables } from '../../utils/env';
 import { confirmDelete } from '../modals/ConfirmModal';
@@ -377,7 +381,7 @@ export class EnvSnippetManager {
     });
 
     this.onContextLimitsChange?.();
-    const view = this.plugin.app.workspace.getLeavesOfType('claudian-view')[0]?.view as {
+    const view = this.plugin.app.workspace.getLeavesOfType(VIEW_TYPE_CLAUDIAN)[0]?.view as {
       refreshModelSelector?(): void;
     } | undefined;
     view?.refreshModelSelector?.();

--- a/src/style/base/variables.css
+++ b/src/style/base/variables.css
@@ -1,5 +1,5 @@
 /* Brand & semantic color tokens */
-.claudian-container {
+.oh-my-claudian-root.claudian-container {
   --claudian-brand: #D97757;
   --claudian-brand-rgb: 217, 119, 87;
   --claudian-brand-claude: #D97757;
@@ -21,7 +21,7 @@
   --claudian-compact: #5bc0de;
 }
 
-body.theme-light .claudian-container {
+body.theme-light .oh-my-claudian-root.claudian-container {
   --claudian-brand-codex: #000000;
   --claudian-brand-codex-rgb: 0, 0, 0;
   --claudian-brand-opencode: #707070;
@@ -35,37 +35,37 @@ body.theme-light .claudian-container {
 }
 
 /* Active-provider alias for single-provider surfaces. */
-.claudian-container[data-provider="claude"] {
+.oh-my-claudian-root.claudian-container[data-provider="claude"] {
   --claudian-brand: var(--claudian-brand-claude);
   --claudian-brand-rgb: var(--claudian-brand-claude-rgb);
 }
 
-.claudian-container[data-provider="codex"] {
+.oh-my-claudian-root.claudian-container[data-provider="codex"] {
   --claudian-brand: var(--claudian-brand-codex);
   --claudian-brand-rgb: var(--claudian-brand-codex-rgb);
 }
 
-.claudian-container[data-provider="opencode"] {
+.oh-my-claudian-root.claudian-container[data-provider="opencode"] {
   --claudian-brand: var(--claudian-brand-opencode);
   --claudian-brand-rgb: var(--claudian-brand-opencode-rgb);
 }
 
-.claudian-container[data-provider="omp"] {
+.oh-my-claudian-root.claudian-container[data-provider="omp"] {
   --claudian-brand: var(--claudian-brand-omp);
   --claudian-brand-rgb: var(--claudian-brand-omp-rgb);
 }
 
-.claudian-container[data-provider="pi"] {
+.oh-my-claudian-root.claudian-container[data-provider="pi"] {
   --claudian-brand: var(--claudian-brand-pi);
   --claudian-brand-rgb: var(--claudian-brand-pi-rgb);
 }
 
-.claudian-container[data-provider="grok"] {
+.oh-my-claudian-root.claudian-container[data-provider="grok"] {
   --claudian-brand: var(--claudian-brand-grok);
   --claudian-brand-rgb: var(--claudian-brand-grok-rgb);
 }
 
-.claudian-container[data-provider="cursor"] {
+.oh-my-claudian-root.claudian-container[data-provider="cursor"] {
   --claudian-brand: var(--claudian-brand-cursor);
   --claudian-brand-rgb: var(--claudian-brand-cursor-rgb);
 }

--- a/src/style/base/variables.css
+++ b/src/style/base/variables.css
@@ -1,5 +1,21 @@
 /* Brand & semantic color tokens */
 .oh-my-claudian-root.claudian-container {
+  --oh-my-claudian-brand: #D97757;
+  --oh-my-claudian-brand-rgb: 217, 119, 87;
+  --oh-my-claudian-brand-claude: #D97757;
+  --oh-my-claudian-brand-claude-rgb: 217, 119, 87;
+  --oh-my-claudian-brand-codex: #d0d0d0;
+  --oh-my-claudian-brand-codex-rgb: 208, 208, 208;
+  --oh-my-claudian-brand-opencode: #B8B8B8;
+  --oh-my-claudian-brand-opencode-rgb: 184, 184, 184;
+  --oh-my-claudian-brand-omp: #00B8D9;
+  --oh-my-claudian-brand-omp-rgb: 0, 184, 217;
+  --oh-my-claudian-brand-pi: #ffffff;
+  --oh-my-claudian-brand-pi-rgb: 255, 255, 255;
+  --oh-my-claudian-brand-grok: #ffffff;
+  --oh-my-claudian-brand-grok-rgb: 255, 255, 255;
+  --oh-my-claudian-brand-cursor: #7C5CFC;
+  --oh-my-claudian-brand-cursor-rgb: 124, 92, 252;
   --claudian-brand: #D97757;
   --claudian-brand-rgb: 217, 119, 87;
   --claudian-brand-claude: #D97757;
@@ -22,6 +38,16 @@
 }
 
 body.theme-light .oh-my-claudian-root.claudian-container {
+  --oh-my-claudian-brand-codex: #000000;
+  --oh-my-claudian-brand-codex-rgb: 0, 0, 0;
+  --oh-my-claudian-brand-opencode: #707070;
+  --oh-my-claudian-brand-opencode-rgb: 112, 112, 112;
+  --oh-my-claudian-brand-pi: #000000;
+  --oh-my-claudian-brand-pi-rgb: 0, 0, 0;
+  --oh-my-claudian-brand-grok: #000000;
+  --oh-my-claudian-brand-grok-rgb: 0, 0, 0;
+  --oh-my-claudian-brand-cursor: #5B3FC4;
+  --oh-my-claudian-brand-cursor-rgb: 91, 63, 196;
   --claudian-brand-codex: #000000;
   --claudian-brand-codex-rgb: 0, 0, 0;
   --claudian-brand-opencode: #707070;
@@ -36,36 +62,50 @@ body.theme-light .oh-my-claudian-root.claudian-container {
 
 /* Active-provider alias for single-provider surfaces. */
 .oh-my-claudian-root.claudian-container[data-provider="claude"] {
+  --oh-my-claudian-brand: var(--oh-my-claudian-brand-claude);
+  --oh-my-claudian-brand-rgb: var(--oh-my-claudian-brand-claude-rgb);
   --claudian-brand: var(--claudian-brand-claude) !important;
   --claudian-brand-rgb: var(--claudian-brand-claude-rgb) !important;
 }
 
 .oh-my-claudian-root.claudian-container[data-provider="codex"] {
+  --oh-my-claudian-brand: var(--oh-my-claudian-brand-codex);
+  --oh-my-claudian-brand-rgb: var(--oh-my-claudian-brand-codex-rgb);
   --claudian-brand: var(--claudian-brand-codex) !important;
   --claudian-brand-rgb: var(--claudian-brand-codex-rgb) !important;
 }
 
 .oh-my-claudian-root.claudian-container[data-provider="opencode"] {
+  --oh-my-claudian-brand: var(--oh-my-claudian-brand-opencode);
+  --oh-my-claudian-brand-rgb: var(--oh-my-claudian-brand-opencode-rgb);
   --claudian-brand: var(--claudian-brand-opencode) !important;
   --claudian-brand-rgb: var(--claudian-brand-opencode-rgb) !important;
 }
 
 .oh-my-claudian-root.claudian-container[data-provider="omp"] {
+  --oh-my-claudian-brand: var(--oh-my-claudian-brand-omp);
+  --oh-my-claudian-brand-rgb: var(--oh-my-claudian-brand-omp-rgb);
   --claudian-brand: var(--claudian-brand-omp) !important;
   --claudian-brand-rgb: var(--claudian-brand-omp-rgb) !important;
 }
 
 .oh-my-claudian-root.claudian-container[data-provider="pi"] {
+  --oh-my-claudian-brand: var(--oh-my-claudian-brand-pi);
+  --oh-my-claudian-brand-rgb: var(--oh-my-claudian-brand-pi-rgb);
   --claudian-brand: var(--claudian-brand-pi) !important;
   --claudian-brand-rgb: var(--claudian-brand-pi-rgb) !important;
 }
 
 .oh-my-claudian-root.claudian-container[data-provider="grok"] {
+  --oh-my-claudian-brand: var(--oh-my-claudian-brand-grok);
+  --oh-my-claudian-brand-rgb: var(--oh-my-claudian-brand-grok-rgb);
   --claudian-brand: var(--claudian-brand-grok) !important;
   --claudian-brand-rgb: var(--claudian-brand-grok-rgb) !important;
 }
 
 .oh-my-claudian-root.claudian-container[data-provider="cursor"] {
+  --oh-my-claudian-brand: var(--oh-my-claudian-brand-cursor);
+  --oh-my-claudian-brand-rgb: var(--oh-my-claudian-brand-cursor-rgb);
   --claudian-brand: var(--claudian-brand-cursor) !important;
   --claudian-brand-rgb: var(--claudian-brand-cursor-rgb) !important;
 }

--- a/src/style/base/variables.css
+++ b/src/style/base/variables.css
@@ -36,36 +36,36 @@ body.theme-light .oh-my-claudian-root.claudian-container {
 
 /* Active-provider alias for single-provider surfaces. */
 .oh-my-claudian-root.claudian-container[data-provider="claude"] {
-  --claudian-brand: var(--claudian-brand-claude);
-  --claudian-brand-rgb: var(--claudian-brand-claude-rgb);
+  --claudian-brand: var(--claudian-brand-claude) !important;
+  --claudian-brand-rgb: var(--claudian-brand-claude-rgb) !important;
 }
 
 .oh-my-claudian-root.claudian-container[data-provider="codex"] {
-  --claudian-brand: var(--claudian-brand-codex);
-  --claudian-brand-rgb: var(--claudian-brand-codex-rgb);
+  --claudian-brand: var(--claudian-brand-codex) !important;
+  --claudian-brand-rgb: var(--claudian-brand-codex-rgb) !important;
 }
 
 .oh-my-claudian-root.claudian-container[data-provider="opencode"] {
-  --claudian-brand: var(--claudian-brand-opencode);
-  --claudian-brand-rgb: var(--claudian-brand-opencode-rgb);
+  --claudian-brand: var(--claudian-brand-opencode) !important;
+  --claudian-brand-rgb: var(--claudian-brand-opencode-rgb) !important;
 }
 
 .oh-my-claudian-root.claudian-container[data-provider="omp"] {
-  --claudian-brand: var(--claudian-brand-omp);
-  --claudian-brand-rgb: var(--claudian-brand-omp-rgb);
+  --claudian-brand: var(--claudian-brand-omp) !important;
+  --claudian-brand-rgb: var(--claudian-brand-omp-rgb) !important;
 }
 
 .oh-my-claudian-root.claudian-container[data-provider="pi"] {
-  --claudian-brand: var(--claudian-brand-pi);
-  --claudian-brand-rgb: var(--claudian-brand-pi-rgb);
+  --claudian-brand: var(--claudian-brand-pi) !important;
+  --claudian-brand-rgb: var(--claudian-brand-pi-rgb) !important;
 }
 
 .oh-my-claudian-root.claudian-container[data-provider="grok"] {
-  --claudian-brand: var(--claudian-brand-grok);
-  --claudian-brand-rgb: var(--claudian-brand-grok-rgb);
+  --claudian-brand: var(--claudian-brand-grok) !important;
+  --claudian-brand-rgb: var(--claudian-brand-grok-rgb) !important;
 }
 
 .oh-my-claudian-root.claudian-container[data-provider="cursor"] {
-  --claudian-brand: var(--claudian-brand-cursor);
-  --claudian-brand-rgb: var(--claudian-brand-cursor-rgb);
+  --claudian-brand: var(--claudian-brand-cursor) !important;
+  --claudian-brand-rgb: var(--claudian-brand-cursor-rgb) !important;
 }

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -181,6 +181,8 @@
 .oh-my-claudian-root .claudian-input-send-button {
   position: static;
   margin-inline-start: 8px;
+  border-color: var(--oh-my-claudian-brand);
+  background: var(--oh-my-claudian-brand);
 }
 
 .oh-my-claudian-root .claudian-input-toolbar {

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -125,16 +125,13 @@
 }
 
 .claudian-input-send-button {
-  position: absolute;
-  right: 10px;
-  bottom: 8px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex: 0 0 36px;
   width: 36px;
   height: 36px;
-  margin: 0;
+  margin-inline-start: 8px;
   padding: 0;
   border: 1px solid var(--claudian-brand);
   border-radius: 50%;
@@ -142,11 +139,6 @@
   color: var(--background-primary);
   cursor: pointer;
   transition: background 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
-}
-
-/* Keep the provider mode switch and the primary action together on the right. */
-.claudian-input-toolbar > .claudian-mode-selector {
-  margin-inline-start: auto;
 }
 
 .claudian-input-send-button:hover:not(:disabled) {
@@ -181,8 +173,8 @@
   justify-content: flex-start;
   flex-wrap: wrap;
   flex-shrink: 0;
-  row-gap: 8px;
-  padding: 4px 56px 8px 10px;
+  row-gap: 12px;
+  padding: 4px 6px 6px 6px;
 }
 
 /* Hide secondary text when the full toolbar would wrap. */

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -177,6 +177,21 @@
   padding: 4px 6px 6px 6px;
 }
 
+/* Keep the composer layout isolated when upstream Claudian is installed too. */
+.oh-my-claudian-root .claudian-input-send-button {
+  position: static;
+  margin-inline-start: 8px;
+}
+
+.oh-my-claudian-root .claudian-input-toolbar {
+  row-gap: 12px;
+  padding: 4px 6px 6px 6px;
+}
+
+.oh-my-claudian-root .claudian-input-toolbar > .claudian-mode-selector {
+  margin-inline-start: auto;
+}
+
 /* Hide secondary text when the full toolbar would wrap. */
 .claudian-input-toolbar--compact .claudian-thinking-effort > .claudian-thinking-label-text,
 .claudian-input-toolbar--compact .claudian-context-meter-percent {

--- a/src/style/components/messages.css
+++ b/src/style/components/messages.css
@@ -61,6 +61,11 @@
   border-end-end-radius: 6px;
 }
 
+.oh-my-claudian-root .claudian-message-user {
+  background: rgba(var(--oh-my-claudian-brand-rgb), 0.16);
+  border-color: rgba(var(--oh-my-claudian-brand-rgb), 0.22);
+}
+
 .claudian-message-user ol > li::marker {
   color: inherit;
 }

--- a/tests/unit/providers/claude/types/types.test.ts
+++ b/tests/unit/providers/claude/types/types.test.ts
@@ -29,7 +29,7 @@ import {
 describe('types.ts', () => {
   describe('VIEW_TYPE_CLAUDIAN', () => {
     it('should be defined as the correct view type', () => {
-      expect(VIEW_TYPE_CLAUDIAN).toBe('claudian-view');
+      expect(VIEW_TYPE_CLAUDIAN).toBe('oh-my-claudian-view');
     });
   });
 

--- a/tests/unit/providers/grok/ui/GrokBrandColor.test.ts
+++ b/tests/unit/providers/grok/ui/GrokBrandColor.test.ts
@@ -15,13 +15,13 @@ describe('Grok brand color', () => {
     expect(variablesCss).toContain('--claudian-brand-grok: #ffffff;');
     expect(variablesCss).toContain('--claudian-brand-grok-rgb: 255, 255, 255;');
     expect(variablesCss).toMatch(
-      /body\.theme-light \.claudian-container \{[\s\S]*?--claudian-brand-grok: #000000;[\s\S]*?--claudian-brand-grok-rgb: 0, 0, 0;[\s\S]*?\}/,
+      /body\.theme-light \.oh-my-claudian-root\.claudian-container \{[\s\S]*?--claudian-brand-grok: #000000;[\s\S]*?--claudian-brand-grok-rgb: 0, 0, 0;[\s\S]*?\}/,
     );
   });
 
   it('routes active and streaming Grok surfaces through its brand token', () => {
     expect(variablesCss).toMatch(
-      /\.claudian-container\[data-provider="grok"\] \{[\s\S]*?--claudian-brand: var\(--claudian-brand-grok\);[\s\S]*?--claudian-brand-rgb: var\(--claudian-brand-grok-rgb\);[\s\S]*?\}/,
+      /\.oh-my-claudian-root\.claudian-container\[data-provider="grok"\] \{[\s\S]*?--claudian-brand: var\(--claudian-brand-grok\);[\s\S]*?--claudian-brand-rgb: var\(--claudian-brand-grok-rgb\);[\s\S]*?\}/,
     );
     expect(tabsCss).toMatch(
       /\.claudian-tab-badge-streaming\[data-provider="grok"\] \{[\s\S]*?border-color: var\(--claudian-brand-grok, #ffffff\);[\s\S]*?\}/,

--- a/tests/unit/providers/grok/ui/GrokBrandColor.test.ts
+++ b/tests/unit/providers/grok/ui/GrokBrandColor.test.ts
@@ -21,7 +21,7 @@ describe('Grok brand color', () => {
 
   it('routes active and streaming Grok surfaces through its brand token', () => {
     expect(variablesCss).toMatch(
-      /\.oh-my-claudian-root\.claudian-container\[data-provider="grok"\] \{[\s\S]*?--claudian-brand: var\(--claudian-brand-grok\);[\s\S]*?--claudian-brand-rgb: var\(--claudian-brand-grok-rgb\);[\s\S]*?\}/,
+      /\.oh-my-claudian-root\.claudian-container\[data-provider="grok"\] \{[\s\S]*?--claudian-brand: var\(--claudian-brand-grok\) !important;[\s\S]*?--claudian-brand-rgb: var\(--claudian-brand-grok-rgb\) !important;[\s\S]*?\}/,
     );
     expect(tabsCss).toMatch(
       /\.claudian-tab-badge-streaming\[data-provider="grok"\] \{[\s\S]*?border-color: var\(--claudian-brand-grok, #ffffff\);[\s\S]*?\}/,

--- a/tests/unit/providers/omp/OmpBrandColor.test.ts
+++ b/tests/unit/providers/omp/OmpBrandColor.test.ts
@@ -18,7 +18,7 @@ describe('OMP brand color', () => {
 
   it('routes active and streaming OMP surfaces through its brand token', () => {
     expect(variablesCss).toMatch(
-      /\.oh-my-claudian-root\.claudian-container\[data-provider="omp"\] \{[\s\S]*?--claudian-brand: var\(--claudian-brand-omp\);[\s\S]*?--claudian-brand-rgb: var\(--claudian-brand-omp-rgb\);[\s\S]*?\}/,
+      /\.oh-my-claudian-root\.claudian-container\[data-provider="omp"\] \{[\s\S]*?--claudian-brand: var\(--claudian-brand-omp\) !important;[\s\S]*?--claudian-brand-rgb: var\(--claudian-brand-omp-rgb\) !important;[\s\S]*?\}/,
     );
     expect(tabsCss).toMatch(
       /\.claudian-tab-badge-streaming\[data-provider="omp"\] \{[\s\S]*?border-color: var\(--claudian-brand-omp, #00B8D9\);[\s\S]*?\}/,

--- a/tests/unit/providers/omp/OmpBrandColor.test.ts
+++ b/tests/unit/providers/omp/OmpBrandColor.test.ts
@@ -18,7 +18,7 @@ describe('OMP brand color', () => {
 
   it('routes active and streaming OMP surfaces through its brand token', () => {
     expect(variablesCss).toMatch(
-      /\.claudian-container\[data-provider="omp"\] \{[\s\S]*?--claudian-brand: var\(--claudian-brand-omp\);[\s\S]*?--claudian-brand-rgb: var\(--claudian-brand-omp-rgb\);[\s\S]*?\}/,
+      /\.oh-my-claudian-root\.claudian-container\[data-provider="omp"\] \{[\s\S]*?--claudian-brand: var\(--claudian-brand-omp\);[\s\S]*?--claudian-brand-rgb: var\(--claudian-brand-omp-rgb\);[\s\S]*?\}/,
     );
     expect(tabsCss).toMatch(
       /\.claudian-tab-badge-streaming\[data-provider="omp"\] \{[\s\S]*?border-color: var\(--claudian-brand-omp, #00B8D9\);[\s\S]*?\}/,

--- a/tests/unit/style/components/input.test.ts
+++ b/tests/unit/style/components/input.test.ts
@@ -1,0 +1,18 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+describe('Chat input toolbar styles', () => {
+  const css = fs.readFileSync(
+    path.join(process.cwd(), 'src/style/components/input.css'),
+    'utf8',
+  );
+
+  it('keeps the send button in toolbar flow so it cannot cover the mode selector', () => {
+    expect(css).not.toMatch(
+      /\.claudian-input-send-button\s*\{[\s\S]*?position:\s*absolute;/,
+    );
+    expect(css).toMatch(
+      /\.claudian-input-send-button\s*\{[\s\S]*?margin-inline-start:\s*8px;/,
+    );
+  });
+});

--- a/tests/unit/style/components/input.test.ts
+++ b/tests/unit/style/components/input.test.ts
@@ -24,4 +24,8 @@ describe('Chat input toolbar styles', () => {
       /\.oh-my-claudian-root \.claudian-input-toolbar > \.claudian-mode-selector\s*\{[\s\S]*?margin-inline-start:\s*auto;/,
     );
   });
+
+  it('uses Oh My Claudian-owned brand variables for the send button', () => {
+    expect(css).toContain('background: var(--oh-my-claudian-brand);');
+  });
 });

--- a/tests/unit/style/components/input.test.ts
+++ b/tests/unit/style/components/input.test.ts
@@ -15,4 +15,13 @@ describe('Chat input toolbar styles', () => {
       /\.claudian-input-send-button\s*\{[\s\S]*?margin-inline-start:\s*8px;/,
     );
   });
+
+  it('scopes the composer override for coexistence with upstream Claudian', () => {
+    expect(css).toMatch(
+      /\.oh-my-claudian-root \.claudian-input-send-button\s*\{[\s\S]*?position:\s*static;[\s\S]*?margin-inline-start:\s*8px;/,
+    );
+    expect(css).toMatch(
+      /\.oh-my-claudian-root \.claudian-input-toolbar > \.claudian-mode-selector\s*\{[\s\S]*?margin-inline-start:\s*auto;/,
+    );
+  });
 });

--- a/tests/unit/style/components/messages.test.ts
+++ b/tests/unit/style/components/messages.test.ts
@@ -9,4 +9,12 @@ describe('Message styles', () => {
       /\.claudian-message-user ol > li::marker\s*{\s*color:\s*inherit;\s*}/,
     );
   });
+
+  it('uses an Oh My Claudian-owned brand variable for user bubbles', () => {
+    const css = readFileSync(path.resolve('src/style/components/messages.css'), 'utf8');
+
+    expect(css).toMatch(
+      /\.oh-my-claudian-root \.claudian-message-user\s*\{[\s\S]*?background:\s*rgba\(var\(--oh-my-claudian-brand-rgb\), 0\.16\);/,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Use a unique Obsidian view type: `oh-my-claudian-view`
- Remove hard-coded upstream view and command identifiers
- Prevent the send button from covering the mode selector
- Scope composer styles for coexistence with upstream Claudian
- Use Oh My Claudian-owned provider brand tokens for chat bubbles and send controls
- Cover Claude, Codex, Cursor, Grok, OMP, OpenCode, and Pi

## Validation

- TypeScript typecheck passed
- CSS build passed
- Targeted style and provider tests passed
- Full unit suite has 385 passing suites; local MCP HTTP tests require loopback binding, which is unavailable in the sandbox

## Scope

This PR does not migrate the existing `.claudian` data directory.
