### PR TITLE
chore: prepare 2.1.19 release

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.1.18",
+  "version": "2.1.19",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claudian",
-  "version": "2.1.18",
+  "version": "2.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claudian",
-      "version": "2.1.18",
+      "version": "2.1.19",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "2.1.18",
+  "version": "2.1.19",
   "description": "Oh My Claudian - provider-backed coding agents embedded in the Obsidian sidebar",
   "main": "main.js",
   "engines": {


### PR DESCRIPTION
## Summary

- Bump package.json, package-lock.json, and manifest.json to 2.1.19

## Validation

- Release version validation passed
- GitHub Release workflow for tag 2.1.19 completed successfully

## Note

The 2.1.19 release was generated from this exact release commit; this PR brings the version commit into main.