### PR TITLE
chore: prepare 2.1.20 release

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.1.19",
+  "version": "2.1.20",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claudian",
-  "version": "2.1.19",
+  "version": "2.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claudian",
-      "version": "2.1.19",
+      "version": "2.1.20",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "2.1.19",
+  "version": "2.1.20",
   "description": "Oh My Claudian - provider-backed coding agents embedded in the Obsidian sidebar",
   "main": "main.js",
   "engines": {


### PR DESCRIPTION
## Summary
- bump package.json, package-lock.json, and manifest.json to 2.1.20
- release includes the merged Claudian coexistence style isolation fixes from PR #67

## Validation
- release version check passed
- style tests passed
- OBSIDIAN_VAULT=/nonexistent npm run build passed