### PR TITLE
refactor: deepen history rendering

### DIFF
--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -1161,6 +1161,9 @@ export class ConversationController {
       allowConversationSelection: options.allowConversationSelection !== false,
       hasOpenConversationInNewTab: typeof options.onOpenConversationInNewTab === 'function',
     }));
+    if (options.showMetadataPopover) {
+      item.setAttribute('data-history-render-reuse', 'false');
+    }
     item.setAttribute('data-running', isRunning ? 'true' : 'false');
     item.setAttribute('data-tab-location', conversationStatus.location ?? 'current-view');
     if (typeof conversationStatus.tabIndex === 'number') {

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -25,10 +25,10 @@ import { cleanupThinkingBlock } from '../rendering/ThinkingBlockRenderer';
 import { createWelcomeElement, renderWelcomeContent } from '../rendering/WelcomeRenderer';
 import { findRewindContext } from '../rewind';
 import type { SubagentManager } from '../services/SubagentManager';
+import { projectHistory } from '../session-manager/HistoryProjection';
 import {
   getLinkedNoteTitle,
   isProvisionalNotePath,
-  organizeSessionList,
   type SessionListSection,
 } from '../session-manager/SessionListOrganizer';
 import type { ChatState } from '../state/ChatState';
@@ -44,7 +44,6 @@ function runConversationAction(action: () => Promise<void>, failureMessage: stri
   });
 }
 
-const DEFAULT_HISTORY_PAGE_SIZE = 100;
 const MAX_REWIND_CONFLICT_PATHS = 5;
 
 function buildRewindConflictConfirmation(conflicts: readonly ChatRewindConflict[]): string {
@@ -778,70 +777,35 @@ export class ConversationController {
 
     container.empty();
 
-    const allConversations = plugin.getConversationList();
-    const scopedConversations = options.sessionScope === 'archived'
-      ? allConversations.filter(conversation => conversation.isArchived)
-      : options.sessionScope === 'active'
-        ? allConversations.filter(conversation => !conversation.isArchived)
-        : allConversations;
-    const searchTerms = (options.searchQuery ?? '')
-      .trim()
-      .toLocaleLowerCase()
-      .split(/\s+/)
-      .filter(Boolean);
-    const filteredConversations = searchTerms.length === 0
-      ? scopedConversations
-      : scopedConversations.filter((conversation) => {
-          const searchableText = [conversation.title, conversation.currentNote ?? '']
-            .join('\n')
-            .toLocaleLowerCase();
-          return searchTerms.every(term => searchableText.includes(term));
-        });
-    const conversationsByLinkedNote = new Map<string, ConversationMeta[]>();
-    for (const conversation of scopedConversations) {
-      if (!conversation.currentNote) continue;
-      const noteConversations = conversationsByLinkedNote.get(conversation.currentNote) ?? [];
-      noteConversations.push(conversation);
-      conversationsByLinkedNote.set(conversation.currentNote, noteConversations);
-    }
-    const pinnedLinkedNotePaths = organization === 'linked-note'
-      && options.showPinnedSection
-      && options.sessionScope !== 'archived'
-      ? options.pinnedLinkedNotePaths ?? new Set<string>()
-      : new Set<string>();
-    const isInPinnedNoteGroup = (conversation: ConversationMeta): boolean => (
-      !!conversation.currentNote
-      && pinnedLinkedNotePaths.has(conversation.currentNote)
-    );
-    const pinnedNoteConversations = filteredConversations.filter(isInPinnedNoteGroup);
-    const pinnedConversations = options.showPinnedSection
-      ? filteredConversations.filter(conversation => (
-          conversation.isPinned && !isInPinnedNoteGroup(conversation)
-        ))
-      : [];
-    const sessionConversations = options.showPinnedSection
-      ? filteredConversations.filter(conversation => (
-          !conversation.isPinned && !isInPinnedNoteGroup(conversation)
-        ))
-      : filteredConversations;
-    const pinnedPathsWithMatchingSessions = new Set(
-      pinnedNoteConversations.flatMap(conversation => (
-        conversation.currentNote ? [conversation.currentNote] : []
-      )),
-    );
-    const visiblePinnedNotePaths = [...pinnedLinkedNotePaths].filter((notePath) => (
-      searchTerms.length === 0
-      || pinnedPathsWithMatchingSessions.has(notePath)
-      || searchTerms.every(term => notePath.toLocaleLowerCase().includes(term))
-    ));
-    const pinnedNoteSections = organizeSessionList(pinnedNoteConversations, {
-      organization: 'linked-note',
+    const projection = projectHistory({
+      conversations: plugin.getConversationList(),
+      organization,
       sort: options.sort ?? 'last-updated',
       language: options.language ?? 'en',
-      includeNotePaths: visiblePinnedNotePaths,
+      sessionScope: options.sessionScope,
+      searchQuery: options.searchQuery,
       noteExists: options.noteExists,
-    }).filter(section => section.notePath !== undefined);
-    const showSessionSections = options.showPinnedSection || options.showArchivedSection;
+      pinnedLinkedNotePaths: options.pinnedLinkedNotePaths,
+      showPinnedSection: options.showPinnedSection,
+      showArchivedSection: options.showArchivedSection,
+      collapsedGroupKeys: options.collapsedGroupKeys,
+      previousVisibleCount,
+      visibleCount: options.visibleCount,
+      pageSize: options.pageSize,
+    });
+    const {
+      conversationsByLinkedNote,
+      filteredConversations,
+      pinnedConversations,
+      pinnedNoteSections,
+      sortedPinnedConversations,
+      sections,
+      visibleConversationTotal,
+      visibleCount,
+      pageSize,
+      showSessionSections,
+      searchTerms,
+    } = projection;
 
     let list: HTMLElement;
     let sessionList: HTMLElement;
@@ -893,11 +857,6 @@ export class ConversationController {
       sessionList = list;
     }
 
-    const pageSize = Math.max(1, options.pageSize ?? DEFAULT_HISTORY_PAGE_SIZE);
-    const visibleCount = Math.max(
-      pageSize,
-      options.visibleCount ?? previousVisibleCount,
-    );
     list.dataset.visibleCount = String(visibleCount);
 
     if (filteredConversations.length === 0 && pinnedNoteSections.length === 0) {
@@ -918,38 +877,12 @@ export class ConversationController {
       return;
     }
 
-    const sortedPinnedConversations = organizeSessionList(pinnedConversations, {
-      organization: 'list',
-      sort: options.sort ?? 'last-updated',
-      language: options.language ?? 'en',
-    })[0]?.conversations ?? [];
-    const sections = organizeSessionList(sessionConversations, {
-      organization,
-      sort: options.sort ?? 'last-updated',
-      language: options.language ?? 'en',
-      noteExists: options.noteExists,
-    });
     if (organization === 'linked-note') {
       options.onGroupKeysChange?.([
         ...pinnedNoteSections.map(({ key }) => key),
         ...sections.map(({ key }) => key),
       ]);
     }
-    const visiblePinnedNoteConversationTotal = pinnedNoteSections.reduce((total, section) => (
-      options.collapsedGroupKeys?.has(section.key)
-        ? total
-        : total + section.conversations.length
-    ), 0);
-    const visibleSessionConversationTotal = organization === 'linked-note'
-      ? sections.reduce((total, section) => (
-          options.collapsedGroupKeys?.has(section.key)
-            ? total
-            : total + section.conversations.length
-        ), 0)
-      : sessionConversations.length;
-    const visibleConversationTotal = visiblePinnedNoteConversationTotal
-      + pinnedConversations.length
-      + visibleSessionConversationTotal;
     let renderedConversationCount = 0;
 
     if (pinnedList) {

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -26,7 +26,10 @@ import { createWelcomeElement, renderWelcomeContent } from '../rendering/Welcome
 import { findRewindContext } from '../rewind';
 import type { SubagentManager } from '../services/SubagentManager';
 import { projectHistory } from '../session-manager/HistoryProjection';
-import { HistoryViewport } from '../session-manager/HistoryViewport';
+import {
+  buildHistoryRenderKey,
+  HistoryViewport,
+} from '../session-manager/HistoryViewport';
 import {
   getLinkedNoteTitle,
   isProvisionalNotePath,
@@ -752,9 +755,11 @@ export class ConversationController {
       container,
       options.preserveListState === true,
     );
+    const renderRoot = this.historyViewport.beginRender(
+      container,
+      options.preserveListState === true,
+    );
     const organization = options.organization ?? 'list';
-
-    container.empty();
 
     const projection = projectHistory({
       conversations: plugin.getConversationList(),
@@ -786,7 +791,7 @@ export class ConversationController {
       searchTerms,
     } = projection;
 
-    const { list, sessionList, pinnedList } = this.historyViewport.createLayout(container, {
+    const { list, sessionList, pinnedList } = this.historyViewport.createLayout(renderRoot, {
       showSessionSections,
       showArchivedSection: options.showArchivedSection === true,
       hasPinnedSection: pinnedConversations.length > 0 || pinnedNoteSections.length > 0,
@@ -803,6 +808,7 @@ export class ConversationController {
         cls: 'claudian-history-empty',
         text: searchTerms.length > 0 ? 'No matching sessions' : 'No conversations',
       });
+      this.historyViewport.commit(container, renderRoot);
       options.onBeforeRestoreListState?.(container);
       this.historyViewport.restore({ sessionList, pinnedList }, viewportSnapshot);
       return;
@@ -894,6 +900,7 @@ export class ConversationController {
       });
     }
 
+    this.historyViewport.commit(container, renderRoot);
     options.onBeforeRestoreListState?.(container);
     this.historyViewport.restore({ sessionList, pinnedList }, viewportSnapshot);
   }
@@ -1132,6 +1139,28 @@ export class ConversationController {
     });
     item.setAttribute('data-open-state', openState);
     item.setAttribute('data-conversation-id', conversation.id);
+    item.setAttribute('data-history-render-key', buildHistoryRenderKey({
+      id: conversation.id,
+      title: conversation.title,
+      createdAt: conversation.createdAt,
+      lastActivityAt: conversation.lastActivityAt,
+      messageCount: conversation.messageCount,
+      currentNote: conversation.currentNote ?? null,
+      isArchived: conversation.isArchived === true,
+      isPinned: conversation.isPinned === true,
+      titleGenerationStatus: conversation.titleGenerationStatus ?? null,
+      openState,
+      isRunning,
+      attention: conversationStatus.attention ?? null,
+      location: conversationStatus.location ?? null,
+      tabIndex: conversationStatus.tabIndex ?? null,
+      showAttentionState,
+      sessionActionMode: options.sessionActionMode ?? null,
+      showMetadataPopover: options.showMetadataPopover === true,
+      showOpenStateLabels: options.showOpenStateLabels !== false,
+      allowConversationSelection: options.allowConversationSelection !== false,
+      hasOpenConversationInNewTab: typeof options.onOpenConversationInNewTab === 'function',
+    }));
     item.setAttribute('data-running', isRunning ? 'true' : 'false');
     item.setAttribute('data-tab-location', conversationStatus.location ?? 'current-view');
     if (typeof conversationStatus.tabIndex === 'number') {

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -1178,7 +1178,9 @@ export class ConversationController {
       cls: 'claudian-history-item-title',
       text: conversation.title,
     });
-    titleEl.setAttribute('title', conversation.title);
+    if (!options.showMetadataPopover) {
+      titleEl.setAttribute('title', conversation.title);
+    }
     if (options.showMetadataPopover) {
       const focusTarget = isSelectable ? content : item;
       focusTarget.setAttribute('tabindex', '0');

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -26,6 +26,7 @@ import { createWelcomeElement, renderWelcomeContent } from '../rendering/Welcome
 import { findRewindContext } from '../rewind';
 import type { SubagentManager } from '../services/SubagentManager';
 import { projectHistory } from '../session-manager/HistoryProjection';
+import { HistoryViewport } from '../session-manager/HistoryViewport';
 import {
   getLinkedNoteTitle,
   isProvisionalNotePath,
@@ -152,14 +153,10 @@ type HistorySurfaceRenderOptions = Omit<HistoryRenderOptions, 'onRerender'> & {
   onRerender?: () => void;
 };
 
-type HistoryScrollAnchor = {
-  conversationId: string;
-  viewportOffset: number;
-};
-
 export class ConversationController {
   private deps: ConversationControllerDeps;
   private callbacks: ConversationCallbacks;
+  private readonly historyViewport = new HistoryViewport();
   private metadataPopoverCleanup: (() => void) | null = null;
   private metadataPopoverCloseTimer: number | null = null;
   private metadataPopoverEl: HTMLElement | null = null;
@@ -751,28 +748,10 @@ export class ConversationController {
       this.closeSessionMetadataPopover();
     }
 
-    const previousList = options.preserveListState
-      ? container.querySelector<HTMLElement>('.claudian-history-list')
-      : null;
-    const previousSessionList = previousList?.querySelector<HTMLElement>(
-      '.claudian-session-list-items',
-    ) ?? previousList;
-    const previousPinnedSection = previousList?.querySelector<HTMLElement>(
-      '.claudian-history-section--pinned',
+    const viewportSnapshot = this.historyViewport.capture(
+      container,
+      options.preserveListState === true,
     );
-    const previousPinnedList = previousPinnedSection?.querySelector<HTMLElement>(
-      '.claudian-history-section-items',
-    );
-    const previousSessionScrollTop = previousSessionList?.scrollTop ?? 0;
-    const previousPinnedScrollTop = previousPinnedList?.scrollTop ?? 0;
-    const previousVisibleCountFromState = Number(previousList?.dataset.visibleCount);
-    const previousVisibleCount = Number.isFinite(previousVisibleCountFromState)
-      && previousVisibleCountFromState > 0
-      ? previousVisibleCountFromState
-      : previousList?.querySelectorAll('.claudian-history-item').length ?? 0;
-    const previousScrollAnchors = previousSessionList
-      ? this.captureHistoryScrollAnchors(previousSessionList)
-      : [];
     const organization = options.organization ?? 'list';
 
     container.empty();
@@ -789,7 +768,7 @@ export class ConversationController {
       showPinnedSection: options.showPinnedSection,
       showArchivedSection: options.showArchivedSection,
       collapsedGroupKeys: options.collapsedGroupKeys,
-      previousVisibleCount,
+      previousVisibleCount: viewportSnapshot.previousVisibleCount,
       visibleCount: options.visibleCount,
       pageSize: options.pageSize,
     });
@@ -807,57 +786,14 @@ export class ConversationController {
       searchTerms,
     } = projection;
 
-    let list: HTMLElement;
-    let sessionList: HTMLElement;
-    let pinnedList: HTMLElement | null = null;
-    if (showSessionSections) {
-      list = container.createDiv({ cls: 'claudian-history-list' });
-      if (pinnedConversations.length > 0 || pinnedNoteSections.length > 0) {
-        const pinnedSection = list.createDiv({
-          cls: 'claudian-history-section claudian-history-section--pinned',
-        });
-        const pinnedHeader = pinnedSection.createDiv({
-          cls: 'claudian-history-header claudian-session-section-header',
-        });
-        pinnedHeader.createSpan({
-          cls: 'claudian-history-section-label',
-          text: 'Pinned',
-        });
-        pinnedList = pinnedSection.createDiv({
-          cls: 'claudian-history-section-items',
-        });
-      }
+    const { list, sessionList, pinnedList } = this.historyViewport.createLayout(container, {
+      showSessionSections,
+      showArchivedSection: options.showArchivedSection === true,
+      hasPinnedSection: pinnedConversations.length > 0 || pinnedNoteSections.length > 0,
+      historyHeaderLabel: options.historyHeaderLabel,
+    });
 
-      const sessionsSection = list.createDiv({
-        cls: [
-          'claudian-history-section',
-          options.showArchivedSection
-            ? 'claudian-history-section--archived'
-            : 'claudian-history-section--sessions',
-        ].join(' '),
-      });
-      const sessionsHeader = sessionsSection.createDiv({
-        cls: [
-          'claudian-history-header',
-          'claudian-session-section-header',
-          'claudian-session-list-header',
-        ].join(' '),
-      });
-      sessionsHeader.createSpan({
-        cls: 'claudian-history-section-label',
-        text: options.showArchivedSection ? 'Archived' : 'Sessions',
-      });
-      sessionList = sessionsSection.createDiv({
-        cls: 'claudian-history-section-items claudian-session-list-items',
-      });
-    } else {
-      const dropdownHeader = container.createDiv({ cls: 'claudian-history-header' });
-      dropdownHeader.createSpan({ text: options.historyHeaderLabel ?? 'Sessions' });
-      list = container.createDiv({ cls: 'claudian-history-list' });
-      sessionList = list;
-    }
-
-    list.dataset.visibleCount = String(visibleCount);
+    this.historyViewport.setVisibleCount(list, visibleCount);
 
     if (filteredConversations.length === 0 && pinnedNoteSections.length === 0) {
       if (organization === 'linked-note') {
@@ -868,12 +804,7 @@ export class ConversationController {
         text: searchTerms.length > 0 ? 'No matching sessions' : 'No conversations',
       });
       options.onBeforeRestoreListState?.(container);
-      if (pinnedList) pinnedList.scrollTop = previousPinnedScrollTop;
-      this.restoreHistoryListPosition(
-        sessionList,
-        previousSessionScrollTop,
-        previousScrollAnchors,
-      );
+      this.historyViewport.restore({ sessionList, pinnedList }, viewportSnapshot);
       return;
     }
 
@@ -952,7 +883,7 @@ export class ConversationController {
         if (options.signal?.aborted) return;
         const nextVisibleCount = visibleCount + pageSize;
         if (options.preserveListState) {
-          list.dataset.visibleCount = String(nextVisibleCount);
+          this.historyViewport.setVisibleCount(list, nextVisibleCount);
           options.onRerender();
           return;
         }
@@ -964,12 +895,7 @@ export class ConversationController {
     }
 
     options.onBeforeRestoreListState?.(container);
-    if (pinnedList) pinnedList.scrollTop = previousPinnedScrollTop;
-    this.restoreHistoryListPosition(
-      sessionList,
-      previousSessionScrollTop,
-      previousScrollAnchors,
-    );
+    this.historyViewport.restore({ sessionList, pinnedList }, viewportSnapshot);
   }
 
   private renderLinkedNoteSection(
@@ -1170,53 +1096,6 @@ export class ConversationController {
 
     for (const conversation of visibleConversations) {
       this.renderHistoryConversationItem(groupBody, conversation, options);
-    }
-  }
-
-  private captureHistoryScrollAnchors(list: HTMLElement): HistoryScrollAnchor[] {
-    const listRect = list.getBoundingClientRect();
-    if (listRect.height <= 0) return [];
-
-    return Array.from(list.querySelectorAll<HTMLElement>('.claudian-history-item'))
-      .map((item): HistoryScrollAnchor | null => {
-        const conversationId = item.getAttribute('data-conversation-id');
-        const itemRect = item.getBoundingClientRect();
-        if (
-          !conversationId
-          || itemRect.height <= 0
-          || itemRect.bottom <= listRect.top
-          || itemRect.top >= listRect.bottom
-        ) return null;
-        return {
-          conversationId,
-          viewportOffset: itemRect.top - listRect.top,
-        };
-      })
-      .filter((anchor): anchor is HistoryScrollAnchor => anchor !== null);
-  }
-
-  private restoreHistoryListPosition(
-    list: HTMLElement,
-    previousScrollTop: number,
-    anchors: readonly HistoryScrollAnchor[],
-  ): void {
-    list.scrollTop = previousScrollTop;
-    if (anchors.length === 0) return;
-
-    const items = Array.from(
-      list.querySelectorAll<HTMLElement>('.claudian-history-item'),
-    );
-    const listTop = list.getBoundingClientRect().top;
-    for (const anchor of anchors) {
-      const item = items.find(candidate => (
-        candidate.getAttribute('data-conversation-id') === anchor.conversationId
-      ));
-      if (!item) continue;
-
-      const itemRect = item.getBoundingClientRect();
-      if (itemRect.height <= 0) continue;
-      list.scrollTop += itemRect.top - listTop - anchor.viewportOffset;
-      return;
     }
   }
 

--- a/src/features/chat/session-manager/HistoryProjection.ts
+++ b/src/features/chat/session-manager/HistoryProjection.ts
@@ -29,8 +29,6 @@ export interface HistoryProjection {
   conversationsByLinkedNote: ReadonlyMap<string, ConversationMeta[]>;
   filteredConversations: ConversationMeta[];
   pinnedConversations: ConversationMeta[];
-  sessionConversations: ConversationMeta[];
-  visiblePinnedNotePaths: string[];
   visibleCount: number;
   pageSize: number;
   visibleConversationTotal: number;
@@ -140,8 +138,6 @@ export function projectHistory(options: HistoryProjectionOptions): HistoryProjec
     conversationsByLinkedNote,
     filteredConversations,
     pinnedConversations,
-    sessionConversations,
-    visiblePinnedNotePaths,
     visibleCount,
     pageSize,
     visibleConversationTotal,

--- a/src/features/chat/session-manager/HistoryProjection.ts
+++ b/src/features/chat/session-manager/HistoryProjection.ts
@@ -1,0 +1,152 @@
+import type {
+  ConversationMeta,
+  SessionManagerOrganization,
+  SessionManagerSort,
+} from '../../../core/types';
+import { organizeSessionList, type SessionListSection } from './SessionListOrganizer';
+
+export interface HistoryProjectionOptions {
+  conversations: readonly ConversationMeta[];
+  organization: SessionManagerOrganization;
+  sort: SessionManagerSort;
+  language: string;
+  sessionScope?: 'active' | 'archived';
+  searchQuery?: string;
+  noteExists?: (notePath: string) => boolean;
+  pinnedLinkedNotePaths?: ReadonlySet<string>;
+  showPinnedSection?: boolean;
+  showArchivedSection?: boolean;
+  collapsedGroupKeys?: ReadonlySet<string>;
+  previousVisibleCount?: number;
+  visibleCount?: number;
+  pageSize?: number;
+}
+
+export interface HistoryProjection {
+  sections: SessionListSection[];
+  pinnedNoteSections: SessionListSection[];
+  sortedPinnedConversations: ConversationMeta[];
+  conversationsByLinkedNote: ReadonlyMap<string, ConversationMeta[]>;
+  filteredConversations: ConversationMeta[];
+  pinnedConversations: ConversationMeta[];
+  sessionConversations: ConversationMeta[];
+  visiblePinnedNotePaths: string[];
+  visibleCount: number;
+  pageSize: number;
+  visibleConversationTotal: number;
+  showSessionSections: boolean;
+  searchTerms: string[];
+  hasResults: boolean;
+}
+
+export function projectHistory(options: HistoryProjectionOptions): HistoryProjection {
+  const scopedConversations = options.sessionScope === 'archived'
+    ? options.conversations.filter(conversation => conversation.isArchived)
+    : options.sessionScope === 'active'
+      ? options.conversations.filter(conversation => !conversation.isArchived)
+      : [...options.conversations];
+  const searchTerms = (options.searchQuery ?? '')
+    .trim()
+    .toLocaleLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+  const filteredConversations = searchTerms.length === 0
+    ? scopedConversations
+    : scopedConversations.filter((conversation) => {
+        const searchableText = [conversation.title, conversation.currentNote ?? '']
+          .join('\n')
+          .toLocaleLowerCase();
+        return searchTerms.every(term => searchableText.includes(term));
+      });
+  const conversationsByLinkedNote = new Map<string, ConversationMeta[]>();
+  for (const conversation of scopedConversations) {
+    if (!conversation.currentNote) continue;
+    const noteConversations = conversationsByLinkedNote.get(conversation.currentNote) ?? [];
+    noteConversations.push(conversation);
+    conversationsByLinkedNote.set(conversation.currentNote, noteConversations);
+  }
+  const showPinnedSection = options.showPinnedSection === true;
+  const pinnedLinkedNotePaths = options.organization === 'linked-note'
+    && showPinnedSection
+    && options.sessionScope !== 'archived'
+    ? options.pinnedLinkedNotePaths ?? new Set<string>()
+    : new Set<string>();
+  const isInPinnedNoteGroup = (conversation: ConversationMeta): boolean => (
+    !!conversation.currentNote
+    && pinnedLinkedNotePaths.has(conversation.currentNote)
+  );
+  const pinnedNoteConversations = filteredConversations.filter(isInPinnedNoteGroup);
+  const pinnedConversations = showPinnedSection
+    ? filteredConversations.filter(conversation => (
+        conversation.isPinned && !isInPinnedNoteGroup(conversation)
+      ))
+    : [];
+  const sessionConversations = showPinnedSection
+    ? filteredConversations.filter(conversation => (
+        !conversation.isPinned && !isInPinnedNoteGroup(conversation)
+      ))
+    : filteredConversations;
+  const pinnedPathsWithMatchingSessions = new Set(
+    pinnedNoteConversations.flatMap(conversation => (
+      conversation.currentNote ? [conversation.currentNote] : []
+    )),
+  );
+  const visiblePinnedNotePaths = [...pinnedLinkedNotePaths].filter((notePath) => (
+    searchTerms.length === 0
+    || pinnedPathsWithMatchingSessions.has(notePath)
+    || searchTerms.every(term => notePath.toLocaleLowerCase().includes(term))
+  ));
+  const pinnedNoteSections = organizeSessionList(pinnedNoteConversations, {
+    organization: 'linked-note',
+    sort: options.sort,
+    language: options.language,
+    includeNotePaths: visiblePinnedNotePaths,
+    noteExists: options.noteExists,
+  }).filter(section => section.notePath !== undefined);
+  const sortedPinnedConversations = organizeSessionList(pinnedConversations, {
+    organization: 'list',
+    sort: options.sort,
+    language: options.language,
+  })[0]?.conversations ?? [];
+  const sections = organizeSessionList(sessionConversations, {
+    organization: options.organization,
+    sort: options.sort,
+    language: options.language,
+    noteExists: options.noteExists,
+  });
+  const collapsedGroupKeys = options.collapsedGroupKeys ?? new Set<string>();
+  const visiblePinnedNoteConversationTotal = pinnedNoteSections.reduce((total, section) => (
+    collapsedGroupKeys.has(section.key) ? total : total + section.conversations.length
+  ), 0);
+  const visibleSessionConversationTotal = options.organization === 'linked-note'
+    ? sections.reduce((total, section) => (
+        collapsedGroupKeys.has(section.key) ? total : total + section.conversations.length
+      ), 0)
+    : sessionConversations.length;
+  const visibleConversationTotal = visiblePinnedNoteConversationTotal
+    + pinnedConversations.length
+    + visibleSessionConversationTotal;
+  const pageSize = Math.max(1, options.pageSize ?? 100);
+  const visibleCount = Math.max(
+    pageSize,
+    options.visibleCount ?? options.previousVisibleCount ?? 0,
+  );
+  const showSessionSections = options.showPinnedSection === true || options.showArchivedSection === true;
+
+  return {
+    sections,
+    pinnedNoteSections,
+    sortedPinnedConversations,
+    conversationsByLinkedNote,
+    filteredConversations,
+    pinnedConversations,
+    sessionConversations,
+    visiblePinnedNotePaths,
+    visibleCount,
+    pageSize,
+    visibleConversationTotal,
+    showSessionSections,
+    searchTerms,
+    hasResults: filteredConversations.length > 0 || pinnedNoteSections.length > 0,
+  };
+}

--- a/src/features/chat/session-manager/HistoryViewport.ts
+++ b/src/features/chat/session-manager/HistoryViewport.ts
@@ -1,0 +1,170 @@
+export interface HistoryViewportOptions {
+  showSessionSections: boolean;
+  showArchivedSection: boolean;
+  hasPinnedSection?: boolean;
+  historyHeaderLabel?: string;
+}
+
+export interface HistoryViewportLayout {
+  list: HTMLElement;
+  sessionList: HTMLElement;
+  pinnedList: HTMLElement | null;
+}
+
+export interface HistoryScrollAnchor {
+  conversationId: string;
+  viewportOffset: number;
+}
+
+export interface HistoryViewportSnapshot {
+  sessionScrollTop: number;
+  pinnedScrollTop: number;
+  previousVisibleCount: number;
+  sessionScrollAnchors: HistoryScrollAnchor[];
+}
+
+export class HistoryViewport {
+  capture(container: HTMLElement, preserveListState: boolean): HistoryViewportSnapshot {
+    const previousList = preserveListState
+      ? container.querySelector<HTMLElement>('.claudian-history-list')
+      : null;
+    const previousSessionList = previousList?.querySelector<HTMLElement>(
+      '.claudian-session-list-items',
+    ) ?? previousList;
+    const previousPinnedSection = previousList?.querySelector<HTMLElement>(
+      '.claudian-history-section--pinned',
+    );
+    const previousPinnedList = previousPinnedSection?.querySelector<HTMLElement>(
+      '.claudian-history-section-items',
+    );
+    const previousVisibleCountFromState = Number(previousList?.dataset.visibleCount);
+    const previousVisibleCount = Number.isFinite(previousVisibleCountFromState)
+      && previousVisibleCountFromState > 0
+      ? previousVisibleCountFromState
+      : previousList?.querySelectorAll('.claudian-history-item').length ?? 0;
+
+    return {
+      sessionScrollTop: previousSessionList?.scrollTop ?? 0,
+      pinnedScrollTop: previousPinnedList?.scrollTop ?? 0,
+      previousVisibleCount,
+      sessionScrollAnchors: previousSessionList
+        ? this.captureScrollAnchors(previousSessionList)
+        : [],
+    };
+  }
+
+  createLayout(
+    container: HTMLElement,
+    options: HistoryViewportOptions,
+  ): HistoryViewportLayout {
+    let list: HTMLElement;
+    let sessionList: HTMLElement;
+    let pinnedList: HTMLElement | null = null;
+
+    if (options.showSessionSections) {
+      list = container.createDiv({ cls: 'claudian-history-list' });
+      if (options.hasPinnedSection) {
+        const pinnedSection = list.createDiv({
+          cls: 'claudian-history-section claudian-history-section--pinned',
+        });
+        pinnedSection.createDiv({
+          cls: 'claudian-history-header claudian-session-section-header',
+        }).createSpan({
+          cls: 'claudian-history-section-label',
+          text: 'Pinned',
+        });
+        pinnedList = pinnedSection.createDiv({
+          cls: 'claudian-history-section-items',
+        });
+      }
+
+      const sessionsSection = list.createDiv({
+        cls: [
+          'claudian-history-section',
+          options.showArchivedSection
+            ? 'claudian-history-section--archived'
+            : 'claudian-history-section--sessions',
+        ].join(' '),
+      });
+      sessionsSection.createDiv({
+        cls: 'claudian-history-header claudian-session-section-header claudian-session-list-header',
+      }).createSpan({
+        cls: 'claudian-history-section-label',
+        text: options.showArchivedSection ? 'Archived' : 'Sessions',
+      });
+      sessionList = sessionsSection.createDiv({
+        cls: 'claudian-history-section-items claudian-session-list-items',
+      });
+    } else {
+      const dropdownHeader = container.createDiv({ cls: 'claudian-history-header' });
+      dropdownHeader.createSpan({ text: options.historyHeaderLabel ?? 'Sessions' });
+      list = container.createDiv({ cls: 'claudian-history-list' });
+      sessionList = list;
+    }
+
+    return { list, sessionList, pinnedList };
+  }
+
+  setVisibleCount(list: HTMLElement, visibleCount: number): void {
+    list.dataset.visibleCount = String(visibleCount);
+  }
+
+  restore(
+    layout: Pick<HistoryViewportLayout, 'sessionList' | 'pinnedList'>,
+    snapshot: HistoryViewportSnapshot,
+  ): void {
+    if (layout.pinnedList) layout.pinnedList.scrollTop = snapshot.pinnedScrollTop;
+    this.restoreScrollPosition(
+      layout.sessionList,
+      snapshot.sessionScrollTop,
+      snapshot.sessionScrollAnchors,
+    );
+  }
+
+  private captureScrollAnchors(list: HTMLElement): HistoryScrollAnchor[] {
+    const listRect = list.getBoundingClientRect();
+    if (listRect.height <= 0) return [];
+
+    return Array.from(list.querySelectorAll<HTMLElement>('.claudian-history-item'))
+      .map((item): HistoryScrollAnchor | null => {
+        const conversationId = item.getAttribute('data-conversation-id');
+        const itemRect = item.getBoundingClientRect();
+        if (
+          !conversationId
+          || itemRect.height <= 0
+          || itemRect.bottom <= listRect.top
+          || itemRect.top >= listRect.bottom
+        ) return null;
+        return {
+          conversationId,
+          viewportOffset: itemRect.top - listRect.top,
+        };
+      })
+      .filter((anchor): anchor is HistoryScrollAnchor => anchor !== null);
+  }
+
+  private restoreScrollPosition(
+    list: HTMLElement,
+    previousScrollTop: number,
+    anchors: readonly HistoryScrollAnchor[],
+  ): void {
+    list.scrollTop = previousScrollTop;
+    if (anchors.length === 0) return;
+
+    const items = Array.from(
+      list.querySelectorAll<HTMLElement>('.claudian-history-item'),
+    );
+    const listTop = list.getBoundingClientRect().top;
+    for (const anchor of anchors) {
+      const item = items.find(candidate => (
+        candidate.getAttribute('data-conversation-id') === anchor.conversationId
+      ));
+      if (!item) continue;
+
+      const itemRect = item.getBoundingClientRect();
+      if (itemRect.height <= 0) continue;
+      list.scrollTop += itemRect.top - listTop - anchor.viewportOffset;
+      return;
+    }
+  }
+}

--- a/src/features/chat/session-manager/HistoryViewport.ts
+++ b/src/features/chat/session-manager/HistoryViewport.ts
@@ -23,7 +23,44 @@ export interface HistoryViewportSnapshot {
   sessionScrollAnchors: HistoryScrollAnchor[];
 }
 
+export function buildHistoryRenderKey(value: Record<string, unknown>): string {
+  return JSON.stringify(value);
+}
+
 export class HistoryViewport {
+  beginRender(container: HTMLElement, preserveListState: boolean): HTMLElement {
+    if (!preserveListState) {
+      container.empty();
+      return container;
+    }
+
+    const staging = container.createDiv({ cls: 'claudian-history-render-staging' });
+    return staging;
+  }
+
+  commit(container: HTMLElement, renderRoot: HTMLElement): void {
+    if (renderRoot === container) return;
+
+    const previousItems = new Map(
+      Array.from(container.querySelectorAll<HTMLElement>('[data-history-render-key]'))
+        .map(item => [item.getAttribute('data-history-render-key'), item] as const)
+        .filter((entry): entry is readonly [string, HTMLElement] => entry[0] !== null),
+    );
+    for (const item of Array.from(renderRoot.querySelectorAll<HTMLElement>('[data-history-render-key]'))) {
+      const renderKey = item.getAttribute('data-history-render-key');
+      const previousItem = renderKey ? previousItems.get(renderKey) : undefined;
+      if (!previousItem || typeof item.replaceWith !== 'function') continue;
+      item.replaceWith(previousItem);
+    }
+
+    const stagedChildren = Array.from(renderRoot.children);
+    container.empty();
+    for (const child of stagedChildren) {
+      container.appendChild(child);
+    }
+    renderRoot.remove();
+  }
+
   capture(container: HTMLElement, preserveListState: boolean): HistoryViewportSnapshot {
     const previousList = preserveListState
       ? container.querySelector<HTMLElement>('.claudian-history-list')

--- a/src/features/chat/session-manager/HistoryViewport.ts
+++ b/src/features/chat/session-manager/HistoryViewport.ts
@@ -49,7 +49,11 @@ export class HistoryViewport {
     for (const item of Array.from(renderRoot.querySelectorAll<HTMLElement>('[data-history-render-key]'))) {
       const renderKey = item.getAttribute('data-history-render-key');
       const previousItem = renderKey ? previousItems.get(renderKey) : undefined;
-      if (!previousItem || typeof item.replaceWith !== 'function') continue;
+      if (
+        item.getAttribute('data-history-render-reuse') === 'false'
+        || !previousItem
+        || typeof item.replaceWith !== 'function'
+      ) continue;
       item.replaceWith(previousItem);
     }
 

--- a/src/providers/cursor/ui/CursorChatUIConfig.ts
+++ b/src/providers/cursor/ui/CursorChatUIConfig.ts
@@ -3,6 +3,7 @@ import type {
   ProviderPermissionModeToggleConfig,
 } from '../../../core/providers/types';
 import { t } from '../../../i18n/i18n';
+import { CURSOR_PROVIDER_ICON } from '../../../shared/icons';
 import { buildInitialCursorUsageInfo } from '../execution/CursorExecutionSession';
 import {
   decodeCursorModelId,
@@ -11,6 +12,9 @@ import {
 import { getCursorProviderSettings } from '../settings';
 
 export const cursorChatUIConfig: ProviderChatUIConfig = {
+  getProviderIcon() {
+    return CURSOR_PROVIDER_ICON;
+  },
   getModelOptions(settings) {
     const provider = getCursorProviderSettings(settings);
     const discovered = new Map(provider.discoveredModels.map(model => [model.rawId, model]));

--- a/src/providers/omp/ui/OmpChatUIConfig.ts
+++ b/src/providers/omp/ui/OmpChatUIConfig.ts
@@ -3,6 +3,7 @@ import type {
   ProviderPermissionModeToggleConfig,
 } from '../../../core/providers/types';
 import { t } from '../../../i18n/i18n';
+import { OMP_PROVIDER_ICON } from '../../../shared/icons';
 import { buildInitialOmpUsageInfo } from '../execution/OmpExecutionSession';
 import {
   decodeOmpModelId,
@@ -11,6 +12,9 @@ import {
 import { getOmpProviderSettings } from '../settings';
 
 export const ompChatUIConfig: ProviderChatUIConfig = {
+  getProviderIcon() {
+    return OMP_PROVIDER_ICON;
+  },
   getModelOptions(settings) {
     const provider = getOmpProviderSettings(settings);
     const discovered = new Map(provider.discoveredModels.map(model => [model.rawId, model]));

--- a/src/shared/icons.ts
+++ b/src/shared/icons.ts
@@ -110,6 +110,18 @@ export const PI_PROVIDER_ICON: ProviderIconSvg = {
   ],
 };
 
+/** Cursor Agent's cursor mark. */
+export const CURSOR_PROVIDER_ICON: ProviderIconSvg = {
+  viewBox: '0 0 24 24',
+  path: 'M3 2.5 20.5 12l-6.35 1.45L12.7 20 3 2.5Z',
+};
+
+/** Oh My Pi uses the Pi mark for its provider identity. */
+export const OMP_PROVIDER_ICON: ProviderIconSvg = {
+  viewBox: '0 0 24 24',
+  path: 'M3 4h18v2H3V4Zm3 4h2v6.5c0 1.38 1.12 2.5 2.5 2.5h5c1.38 0 2.5-1.12 2.5-2.5V8h2v6.5a4.5 4.5 0 0 1-4.5 4.5h-5A4.5 4.5 0 0 1 6 14.5V8Zm-3 12h18v2H3v-2Z',
+};
+
 export const GROK_PROVIDER_ICON: ProviderIconSvg = {
   viewBox: '0 0 24 24',
   path: 'M3.25 3h4.18l4.8 6.64L17.88 3h3.17l-7.36 8.65L20.44 21h-4.18l-5.16-7.14L5.02 21H1.85l7.79-9.16L3.25 3Zm3.03 1.7 10.85 14.6h1.28L7.56 4.7H6.28Z',

--- a/src/style/components/history.css
+++ b/src/style/components/history.css
@@ -639,6 +639,10 @@ body.theme-dark .claudian-session-metadata-popover {
   overflow-anchor: none;
 }
 
+.claudian-history-render-staging {
+  display: none;
+}
+
 .claudian-history-empty {
   padding: 16px;
   text-align: center;

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -2,6 +2,7 @@ import { createMockEl } from '@test/helpers/MockElement';
 import { Menu, Notice, setIcon } from 'obsidian';
 
 import { ConversationController, type ConversationControllerDeps } from '@/features/chat/controllers/ConversationController';
+import { HistoryViewport } from '@/features/chat/session-manager/HistoryViewport';
 import { ChatState } from '@/features/chat/state/ChatState';
 import { OPENAI_PROVIDER_ICON } from '@/shared/icons';
 import { confirm } from '@/shared/modals/ConfirmModal';
@@ -1872,7 +1873,7 @@ describe('ConversationController', () => {
       it('installs surface controls before restoring preserved list position', () => {
         const container = createMockEl();
         const order: string[] = [];
-        const restoreSpy = jest.spyOn(controller as any, 'restoreHistoryListPosition')
+        const restoreSpy = jest.spyOn(HistoryViewport.prototype, 'restore')
           .mockImplementation(() => {
             order.push('restore');
           });

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -1171,6 +1171,8 @@ describe('ConversationController', () => {
         expect(item.getAttribute('role')).toBeNull();
         expect(content.getAttribute('tabindex')).toBe('0');
         expect(content.getAttribute('role')).toBe('button');
+        expect(content.querySelector('.claudian-history-item-title')?.getAttribute('title'))
+          .toBeNull();
         expect(item.querySelector('.claudian-history-item-date')).toBeNull();
 
         item.dispatchEvent({ type: 'mouseenter' });

--- a/tests/unit/features/chat/session-manager/HistoryProjection.test.ts
+++ b/tests/unit/features/chat/session-manager/HistoryProjection.test.ts
@@ -79,4 +79,25 @@ describe('HistoryProjection', () => {
     expect(projection.visibleConversationTotal).toBe(2);
     expect(projection.visibleCount).toBe(1);
   });
+
+  it('keeps archived filtering and pagination state independent', () => {
+    const projection = projectHistory({
+      conversations: [
+        createConversation('archived', { isArchived: true, lastActivityAt: 30 }),
+        createConversation('active', { lastActivityAt: 20 }),
+      ],
+      organization: 'list',
+      sort: 'last-updated',
+      language: 'en',
+      sessionScope: 'archived',
+      previousVisibleCount: 50,
+      visibleCount: 75,
+      pageSize: 20,
+    });
+
+    expect(projection.sections[0]?.conversations.map(({ id }) => id)).toEqual(['archived']);
+    expect(projection.visibleCount).toBe(75);
+    expect(projection.pageSize).toBe(20);
+    expect(projection.showSessionSections).toBe(false);
+  });
 });

--- a/tests/unit/features/chat/session-manager/HistoryProjection.test.ts
+++ b/tests/unit/features/chat/session-manager/HistoryProjection.test.ts
@@ -1,0 +1,82 @@
+import type { ConversationMeta } from '@/core/types';
+import { projectHistory } from '@/features/chat/session-manager/HistoryProjection';
+
+function createConversation(
+  id: string,
+  overrides: Partial<ConversationMeta> = {},
+): ConversationMeta {
+  return {
+    id,
+    providerId: 'claude',
+    title: id,
+    createdAt: 1,
+    lastActivityAt: 1,
+    messageCount: 0,
+    preview: '',
+    ...overrides,
+  };
+}
+
+describe('HistoryProjection', () => {
+  it('filters by session scope and all search terms before sorting', () => {
+    const projection = projectHistory({
+      conversations: [
+        createConversation('archived-plan', {
+          isArchived: true,
+          title: 'Archived release plan',
+          lastActivityAt: 30,
+        }),
+        createConversation('active-old', {
+          title: 'Release notes',
+          lastActivityAt: 10,
+        }),
+        createConversation('active-new', {
+          title: 'Release plan',
+          lastActivityAt: 20,
+        }),
+      ],
+      sessionScope: 'active',
+      searchQuery: 'release plan',
+      organization: 'list',
+      sort: 'last-updated',
+      language: 'en',
+    });
+
+    expect(projection.sections[0]?.conversations.map(({ id }) => id)).toEqual(['active-new']);
+    expect(projection.hasResults).toBe(true);
+    expect(projection.searchTerms).toEqual(['release', 'plan']);
+  });
+
+  it('separates pinned linked-note sessions and counts collapsed groups', () => {
+    const projection = projectHistory({
+      conversations: [
+        createConversation('pinned-note', {
+          currentNote: 'Projects/Plan.md',
+          lastActivityAt: 30,
+        }),
+        createConversation('pinned-session', {
+          isPinned: true,
+          lastActivityAt: 20,
+        }),
+        createConversation('regular', {
+          currentNote: 'Projects/Other.md',
+          lastActivityAt: 10,
+        }),
+      ],
+      organization: 'linked-note',
+      sort: 'last-updated',
+      language: 'en',
+      noteExists: () => true,
+      pinnedLinkedNotePaths: new Set(['Projects/Plan.md']),
+      showPinnedSection: true,
+      collapsedGroupKeys: new Set(['note:Projects/Other.md']),
+      pageSize: 1,
+    });
+
+    expect(projection.pinnedNoteSections.map(({ notePath }) => notePath)).toEqual(['Projects/Plan.md']);
+    expect(projection.sortedPinnedConversations.map(({ id }) => id)).toEqual(['pinned-session']);
+    expect(projection.sections.map(({ notePath }) => notePath)).toEqual(['Projects/Other.md']);
+    expect(projection.visibleConversationTotal).toBe(2);
+    expect(projection.visibleCount).toBe(1);
+  });
+});

--- a/tests/unit/features/chat/session-manager/HistoryViewport.test.ts
+++ b/tests/unit/features/chat/session-manager/HistoryViewport.test.ts
@@ -38,4 +38,34 @@ describe('HistoryViewport', () => {
     expect(layout.list.querySelector('.claudian-history-section--archived')).not.toBeNull();
     expect(layout.sessionList.hasClass('claudian-session-list-items')).toBe(true);
   });
+
+  it('reuses keyed history items while committing a staged render', () => {
+    const viewport = new HistoryViewport();
+    const previousItem = {
+      getAttribute: () => 'session-1',
+    } as unknown as HTMLElement;
+    const renderRoot = {
+      children: [] as HTMLElement[],
+      querySelectorAll: () => renderRoot.children,
+      remove: jest.fn(),
+    } as unknown as HTMLElement & { children: HTMLElement[] };
+    const nextItem = {
+      getAttribute: () => 'session-1',
+      replaceWith: jest.fn((replacement: HTMLElement) => {
+        renderRoot.children[0] = replacement;
+      }),
+    } as unknown as HTMLElement;
+    renderRoot.children.push(nextItem);
+    const container = {
+      children: [previousItem],
+      querySelectorAll: () => [previousItem],
+      empty: jest.fn(() => { container.children.length = 0; }),
+      appendChild: jest.fn((child: HTMLElement) => { container.children.push(child); }),
+    } as unknown as HTMLElement & { children: HTMLElement[] };
+
+    viewport.commit(container, renderRoot);
+
+    expect(container.children[0]).toBe(previousItem);
+    expect(nextItem.replaceWith).toHaveBeenCalledWith(previousItem);
+  });
 });

--- a/tests/unit/features/chat/session-manager/HistoryViewport.test.ts
+++ b/tests/unit/features/chat/session-manager/HistoryViewport.test.ts
@@ -1,0 +1,41 @@
+import { createMockEl } from '@test/helpers/MockElement';
+
+import { HistoryViewport } from '@/features/chat/session-manager/HistoryViewport';
+
+describe('HistoryViewport', () => {
+  it('captures and restores list scroll state and visible count', () => {
+    const viewport = new HistoryViewport();
+    const container = createMockEl();
+    const list = container.createDiv({ cls: 'claudian-history-list' });
+    const sessionList = list.createDiv({ cls: 'claudian-session-list-items' });
+    list.dataset.visibleCount = '50';
+    sessionList.scrollTop = 320;
+
+    const snapshot = viewport.capture(container, true);
+    const layout = viewport.createLayout(container, {
+      showSessionSections: false,
+      showArchivedSection: false,
+    });
+    viewport.setVisibleCount(layout.list, snapshot.previousVisibleCount);
+    viewport.restore(layout, snapshot);
+
+    expect(snapshot.previousVisibleCount).toBe(50);
+    expect(layout.list.dataset.visibleCount).toBe('50');
+    expect(layout.sessionList.scrollTop).toBe(320);
+  });
+
+  it('creates separate pinned and session viewports for sectioned history', () => {
+    const viewport = new HistoryViewport();
+    const container = createMockEl();
+
+    const layout = viewport.createLayout(container, {
+      showSessionSections: true,
+      showArchivedSection: true,
+      hasPinnedSection: true,
+    });
+
+    expect(layout.pinnedList).not.toBeNull();
+    expect(layout.list.querySelector('.claudian-history-section--archived')).not.toBeNull();
+    expect(layout.sessionList.hasClass('claudian-session-list-items')).toBe(true);
+  });
+});

--- a/tests/unit/features/chat/session-manager/HistoryViewport.test.ts
+++ b/tests/unit/features/chat/session-manager/HistoryViewport.test.ts
@@ -42,7 +42,7 @@ describe('HistoryViewport', () => {
   it('reuses keyed history items while committing a staged render', () => {
     const viewport = new HistoryViewport();
     const previousItem = {
-      getAttribute: () => 'session-1',
+      getAttribute: (name: string) => name === 'data-history-render-key' ? 'session-1' : null,
     } as unknown as HTMLElement;
     const renderRoot = {
       children: [] as HTMLElement[],
@@ -50,7 +50,7 @@ describe('HistoryViewport', () => {
       remove: jest.fn(),
     } as unknown as HTMLElement & { children: HTMLElement[] };
     const nextItem = {
-      getAttribute: () => 'session-1',
+      getAttribute: (name: string) => name === 'data-history-render-key' ? 'session-1' : null,
       replaceWith: jest.fn((replacement: HTMLElement) => {
         renderRoot.children[0] = replacement;
       }),
@@ -67,5 +67,37 @@ describe('HistoryViewport', () => {
 
     expect(container.children[0]).toBe(previousItem);
     expect(nextItem.replaceWith).toHaveBeenCalledWith(previousItem);
+  });
+
+  it('rebuilds interactive history items so hover handlers reflect the current render', () => {
+    const viewport = new HistoryViewport();
+    const previousItem = {
+      getAttribute: (name: string) => name === 'data-history-render-key' ? 'session-1' : null,
+    } as unknown as HTMLElement;
+    const renderRoot = {
+      children: [] as HTMLElement[],
+      querySelectorAll: () => renderRoot.children,
+      remove: jest.fn(),
+    } as unknown as HTMLElement & { children: HTMLElement[] };
+    const nextItem = {
+      getAttribute: (name: string) => {
+        if (name === 'data-history-render-key') return 'session-1';
+        if (name === 'data-history-render-reuse') return 'false';
+        return null;
+      },
+      replaceWith: jest.fn(),
+    } as unknown as HTMLElement;
+    renderRoot.children.push(nextItem);
+    const container = {
+      children: [previousItem],
+      querySelectorAll: () => [previousItem],
+      empty: jest.fn(() => { container.children.length = 0; }),
+      appendChild: jest.fn((child: HTMLElement) => { container.children.push(child); }),
+    } as unknown as HTMLElement & { children: HTMLElement[] };
+
+    viewport.commit(container, renderRoot);
+
+    expect(container.children[0]).toBe(nextItem);
+    expect(nextItem.replaceWith).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/shared/icons.test.ts
+++ b/tests/unit/shared/icons.test.ts
@@ -2,6 +2,8 @@
 
 import {
   createProviderIconSvg,
+  CURSOR_PROVIDER_ICON,
+  OMP_PROVIDER_ICON,
   OPENAI_PROVIDER_ICON,
   OPENCODE_PROVIDER_ICON,
   PI_PROVIDER_ICON,
@@ -52,5 +54,14 @@ describe('createProviderIconSvg', () => {
     expect(paths).toHaveLength(2);
     expect(paths[0].getAttribute('fill-rule')).toBe('evenodd');
     expect(paths.every(path => path.getAttribute('fill') === 'currentColor')).toBe(true);
+  });
+
+  it.each([
+    ['cursor', CURSOR_PROVIDER_ICON],
+    ['omp', OMP_PROVIDER_ICON],
+  ] as const)('renders the %s provider icon', (_provider, icon) => {
+    const svg = createProviderIconSvg(icon, { parent: document.body });
+    expect(svg.getAttribute('viewBox')).toBe(icon.viewBox);
+    expect(svg.querySelector('path')).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Extract history projection and viewport responsibilities
- Add paginated, grouped history layout with scroll restoration
- Reconcile unchanged history rows through keyed staged commits
- Preserve hover metadata interactions and remove duplicate native title tooltips
- Add Cursor and OMP provider icons

## Validation

- 6906 tests passed
- Typecheck passed
- Lint passed with existing warnings only
- Production build passed
