### PR TITLE
refactor: unify provider process lifecycles

### DIFF
--- a/src/core/process/ManagedCommandRunner.ts
+++ b/src/core/process/ManagedCommandRunner.ts
@@ -1,3 +1,4 @@
+import type { ManagedStdioProcessOptions } from './ManagedStdioProcess';
 import { ManagedSubprocess } from './ManagedSubprocess';
 
 export type ManagedCommandTermination = 'abort' | 'error' | 'output-limit' | 'timeout';
@@ -8,6 +9,7 @@ export interface ManagedCommandRequest {
   cwd: string;
   env: NodeJS.ProcessEnv;
   signal?: AbortSignal;
+  spawn?: ManagedStdioProcessOptions['spawn'];
   timeoutMs: number;
   stdoutLimitBytes: number;
 }
@@ -32,7 +34,8 @@ export class ManagedCommandRunner {
         env: request.env,
         finalShutdownTimeoutMs: 0,
         sigkillTimeoutMs: 0,
-        stdio: ['pipe', 'pipe', 'pipe'],
+        spawn: request.spawn,
+        stdio: ['ignore', 'pipe', 'ignore'],
       });
       const chunks: Buffer[] = [];
       let byteLength = 0;
@@ -62,7 +65,7 @@ export class ManagedCommandRunner {
       process.onClose(error => {
         if (error) finish({ exitCode: null, stdout: '', termination: 'error' });
       });
-      process.onExit(({ code, error }) => {
+      process.onCloseState(({ code, error }) => {
         if (error) {
           finish({ exitCode: null, stdout: '', termination: 'error' });
           return;

--- a/src/core/process/ManagedCommandRunner.ts
+++ b/src/core/process/ManagedCommandRunner.ts
@@ -1,0 +1,99 @@
+import { ManagedSubprocess } from './ManagedSubprocess';
+
+export type ManagedCommandTermination = 'abort' | 'error' | 'output-limit' | 'timeout';
+
+export interface ManagedCommandRequest {
+  args: string[];
+  command: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  signal?: AbortSignal;
+  timeoutMs: number;
+  stdoutLimitBytes: number;
+}
+
+export interface ManagedCommandResult {
+  exitCode: number | null;
+  stdout: string;
+  termination?: ManagedCommandTermination;
+}
+
+export class ManagedCommandRunner {
+  run(request: ManagedCommandRequest): Promise<ManagedCommandResult> {
+    if (request.signal?.aborted) {
+      return Promise.resolve({ exitCode: null, stdout: '', termination: 'abort' });
+    }
+
+    return new Promise(resolve => {
+      const process = new ManagedSubprocess({
+        args: request.args,
+        command: request.command,
+        cwd: request.cwd,
+        env: request.env,
+        finalShutdownTimeoutMs: 0,
+        sigkillTimeoutMs: 0,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      const chunks: Buffer[] = [];
+      let byteLength = 0;
+      let settled = false;
+      let timeout: number | null = null;
+
+      const finish = (result: ManagedCommandResult): void => {
+        if (settled) return;
+        settled = true;
+        if (timeout !== null) window.clearTimeout(timeout);
+        request.signal?.removeEventListener('abort', onAbort);
+        resolve(result);
+      };
+      const terminate = (result: ManagedCommandResult): void => {
+        void process.shutdown();
+        finish(result);
+      };
+      const onAbort = (): void => {
+        terminate({ exitCode: null, stdout: '', termination: 'abort' });
+      };
+
+      request.signal?.addEventListener('abort', onAbort, { once: true });
+      timeout = window.setTimeout(() => {
+        terminate({ exitCode: null, stdout: '', termination: 'timeout' });
+      }, request.timeoutMs);
+
+      process.onClose(error => {
+        if (error) finish({ exitCode: null, stdout: '', termination: 'error' });
+      });
+      process.onExit(({ code, error }) => {
+        if (error) {
+          finish({ exitCode: null, stdout: '', termination: 'error' });
+          return;
+        }
+        finish({
+          exitCode: code,
+          stdout: Buffer.concat(chunks).toString('utf8'),
+        });
+      });
+
+      try {
+        process.start();
+      } catch {
+        finish({ exitCode: null, stdout: '', termination: 'error' });
+        return;
+      }
+
+      if (request.signal?.aborted) {
+        onAbort();
+        return;
+      }
+
+      process.stdout.on('data', (chunk: Buffer | string) => {
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        byteLength += buffer.byteLength;
+        if (byteLength > request.stdoutLimitBytes) {
+          terminate({ exitCode: null, stdout: '', termination: 'output-limit' });
+          return;
+        }
+        chunks.push(buffer);
+      });
+    });
+  }
+}

--- a/src/core/process/ManagedCommandRunner.ts
+++ b/src/core/process/ManagedCommandRunner.ts
@@ -62,9 +62,6 @@ export class ManagedCommandRunner {
         terminate({ exitCode: null, stdout: '', termination: 'timeout' });
       }, request.timeoutMs);
 
-      process.onClose(error => {
-        if (error) finish({ exitCode: null, stdout: '', termination: 'error' });
-      });
       process.onCloseState(({ code, error }) => {
         if (error) {
           finish({ exitCode: null, stdout: '', termination: 'error' });

--- a/src/core/process/ManagedStdioProcess.ts
+++ b/src/core/process/ManagedStdioProcess.ts
@@ -1,4 +1,4 @@
-import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
+import { type ChildProcess, spawn } from 'node:child_process';
 import type { Readable, Writable } from 'node:stream';
 
 import {
@@ -19,7 +19,8 @@ export interface ManagedStdioProcessOptions {
   finalShutdownTimeoutMs?: number;
   sigkillTimeoutMs?: number;
   stderrBufferLimit?: number;
-  stdio?: 'pipe' | ['pipe', 'pipe', 'pipe'];
+  spawn?: typeof spawn;
+  stdio?: 'pipe' | ['ignore', 'pipe', 'ignore'] | ['pipe', 'pipe', 'pipe'];
 }
 
 export interface ManagedStdioProcessExitState {
@@ -38,7 +39,7 @@ export class ManagedStdioProcess {
   private readonly errorListeners = new Set<ErrorListener>();
   private exitState: ManagedStdioProcessExitState | null = null;
   private readonly exitListeners = new Set<LifecycleListener>();
-  private proc: ChildProcessWithoutNullStreams | null = null;
+  private proc: ChildProcess | null = null;
   private resolvedSpawnSpec: WindowsCmdShimSpawnSpec | null = null;
   private shutdownPromise: Promise<void> | null = null;
   private spawnConfirmed = false;
@@ -49,15 +50,21 @@ export class ManagedStdioProcess {
   constructor(private readonly options: ManagedStdioProcessOptions) {}
 
   get stdin(): Writable {
-    return this.requireProcess().stdin;
+    const stdin = this.requireProcess().stdin;
+    if (!stdin) throw new Error('Managed stdio process stdin is not available');
+    return stdin;
   }
 
   get stdout(): Readable {
-    return this.requireProcess().stdout;
+    const stdout = this.requireProcess().stdout;
+    if (!stdout) throw new Error('Managed stdio process stdout is not available');
+    return stdout;
   }
 
   get stderr(): Readable {
-    return this.requireProcess().stderr;
+    const stderr = this.requireProcess().stderr;
+    if (!stderr) throw new Error('Managed stdio process stderr is not available');
+    return stderr;
   }
 
   start(): void {
@@ -69,9 +76,9 @@ export class ManagedStdioProcess {
     const resolvedSpawnSpec = resolveWindowsCmdShimSpawnSpec(this.options);
     this.resolvedSpawnSpec = resolvedSpawnSpec;
 
-    let proc: ChildProcessWithoutNullStreams;
+    let proc: ChildProcess;
     try {
-      proc = spawn(resolvedSpawnSpec.command, resolvedSpawnSpec.args, {
+      proc = (this.options.spawn ?? spawn)(resolvedSpawnSpec.command, resolvedSpawnSpec.args, {
         cwd: this.options.cwd,
         env: this.options.env,
         stdio: this.options.stdio ?? 'pipe',
@@ -105,7 +112,7 @@ export class ManagedStdioProcess {
       const limit = this.options.stderrBufferLimit ?? DEFAULT_STDERR_BUFFER_LIMIT;
       this.stderrBuffer = `${this.stderrBuffer}${text}`.slice(-limit);
     };
-    proc.stderr.on('data', this.stderrDataListener);
+    proc.stderr?.on('data', this.stderrDataListener);
     proc.on('spawn', this.handleSpawn);
     proc.on('error', this.handleError);
     proc.on('exit', this.handleExit);
@@ -250,14 +257,14 @@ export class ManagedStdioProcess {
     this.clearLifecycleListeners();
   };
 
-  private requireProcess(): ChildProcessWithoutNullStreams {
+  private requireProcess(): ChildProcess {
     if (!this.proc) {
       throw new Error('Managed stdio process is not started');
     }
     return this.proc;
   }
 
-  private killProcess(proc: ChildProcessWithoutNullStreams, signal: NodeJS.Signals): boolean {
+  private killProcess(proc: ChildProcess, signal: NodeJS.Signals): boolean {
     try {
       return terminateSpawnedProcess(proc, signal, spawn, this.resolvedSpawnSpec);
     } catch {
@@ -271,14 +278,14 @@ export class ManagedStdioProcess {
     }
   }
 
-  private cleanupProcessListeners(proc: ChildProcessWithoutNullStreams | null): void {
+  private cleanupProcessListeners(proc: ChildProcess | null): void {
     if (!proc) return;
     proc.off('spawn', this.handleSpawn);
     proc.off('error', this.handleError);
     proc.off('exit', this.handleExit);
     proc.off('close', this.handleClose);
     if (this.stderrDataListener) {
-      proc.stderr.off('data', this.stderrDataListener);
+      proc.stderr?.off('data', this.stderrDataListener);
       this.stderrDataListener = null;
     }
   }
@@ -290,10 +297,10 @@ export class ManagedStdioProcess {
   }
 }
 
-function destroyStdio(proc: ChildProcessWithoutNullStreams): void {
+function destroyStdio(proc: ChildProcess): void {
   for (const stream of [proc.stdin, proc.stdout, proc.stderr]) {
     try {
-      stream.destroy();
+      stream?.destroy();
     } catch {
       // The final shutdown deadline remains bounded even if a stream misbehaves.
     }

--- a/src/core/process/ManagedSubprocess.ts
+++ b/src/core/process/ManagedSubprocess.ts
@@ -25,15 +25,21 @@ export class ManagedSubprocess {
   }
 
   get stdin(): Writable {
-    return this.requireStarted().stdin;
+    const stdin = this.requireStarted().stdin;
+    if (!stdin) throw new Error('Subprocess stdin is not available');
+    return stdin;
   }
 
   get stdout(): Readable {
-    return this.requireStarted().stdout;
+    const stdout = this.requireStarted().stdout;
+    if (!stdout) throw new Error('Subprocess stdout is not available');
+    return stdout;
   }
 
   get stderr(): Readable {
-    return this.requireStarted().stderr;
+    const stderr = this.requireStarted().stderr;
+    if (!stderr) throw new Error('Subprocess stderr is not available');
+    return stderr;
   }
 
   start(): void {
@@ -57,6 +63,10 @@ export class ManagedSubprocess {
 
   onExit(listener: SubprocessExitListener): () => void {
     return this.process.onExit(listener);
+  }
+
+  onCloseState(listener: SubprocessExitListener): () => void {
+    return this.process.onClose(listener);
   }
 
   shutdown(): Promise<void> {

--- a/src/core/process/ManagedSubprocess.ts
+++ b/src/core/process/ManagedSubprocess.ts
@@ -1,0 +1,95 @@
+import type { Readable, Writable } from 'node:stream';
+
+import {
+  ManagedStdioProcess,
+  type ManagedStdioProcessExitState,
+  type ManagedStdioProcessOptions,
+} from './ManagedStdioProcess';
+
+export type SubprocessCloseListener = (error?: Error) => void;
+
+export class ManagedSubprocess {
+  private closeError: Error | null = null;
+  private readonly closeListeners = new Set<SubprocessCloseListener>();
+  private notifiedClose = false;
+  private readonly process: ManagedStdioProcess;
+
+  constructor(options: ManagedStdioProcessOptions) {
+    this.process = new ManagedStdioProcess(options);
+    this.process.onError((error) => {
+      this.closeError = error;
+      this.notifyClose(error);
+    });
+    this.process.onExit((state) => this.handleExit(state));
+  }
+
+  get stdin(): Writable {
+    return this.requireStarted().stdin;
+  }
+
+  get stdout(): Readable {
+    return this.requireStarted().stdout;
+  }
+
+  get stderr(): Readable {
+    return this.requireStarted().stderr;
+  }
+
+  start(): void {
+    this.process.start();
+  }
+
+  isAlive(): boolean {
+    return this.process.isAlive();
+  }
+
+  getStderrSnapshot(): string {
+    return this.process.getStderrSnapshot();
+  }
+
+  onClose(listener: SubprocessCloseListener): () => void {
+    this.closeListeners.add(listener);
+    return () => {
+      this.closeListeners.delete(listener);
+    };
+  }
+
+  shutdown(): Promise<void> {
+    return this.process.shutdown();
+  }
+
+  private handleExit({ code, signal }: ManagedStdioProcessExitState): void {
+    const exitError = this.closeError ?? (
+      code === 0 && signal === null
+        ? undefined
+        : new Error(`Subprocess exited (${formatExit(code, signal)})`)
+    );
+    this.notifyClose(exitError);
+  }
+
+  private requireStarted(): ManagedStdioProcess {
+    if (!this.process.isStarted()) {
+      throw new Error('Subprocess is not started');
+    }
+    return this.process;
+  }
+
+  private notifyClose(error?: Error): void {
+    if (this.notifiedClose) return;
+    this.notifiedClose = true;
+    for (const listener of [...this.closeListeners]) {
+      try {
+        listener(error);
+      } catch {
+        // Close observers cannot interrupt process cleanup.
+      }
+    }
+    this.closeListeners.clear();
+  }
+}
+
+function formatExit(code: number | null, signal: NodeJS.Signals | null): string {
+  if (signal) return `signal ${signal}`;
+  if (code === null) return 'unknown';
+  return `code ${code}`;
+}

--- a/src/core/process/ManagedSubprocess.ts
+++ b/src/core/process/ManagedSubprocess.ts
@@ -7,6 +7,7 @@ import {
 } from './ManagedStdioProcess';
 
 export type SubprocessCloseListener = (error?: Error) => void;
+export type SubprocessExitListener = (state: ManagedStdioProcessExitState) => void;
 
 export class ManagedSubprocess {
   private closeError: Error | null = null;
@@ -52,6 +53,10 @@ export class ManagedSubprocess {
     return () => {
       this.closeListeners.delete(listener);
     };
+  }
+
+  onExit(listener: SubprocessExitListener): () => void {
+    return this.process.onExit(listener);
   }
 
   shutdown(): Promise<void> {

--- a/src/providers/acp/AcpSubprocess.ts
+++ b/src/providers/acp/AcpSubprocess.ts
@@ -1,6 +1,4 @@
-import type { Readable, Writable } from 'node:stream';
-
-import { ManagedStdioProcess } from '@/core/process/ManagedStdioProcess';
+import { ManagedSubprocess } from '@/core/process/ManagedSubprocess';
 
 const STDERR_BUFFER_LIMIT = 8_000;
 
@@ -11,93 +9,11 @@ export interface AcpSubprocessLaunchSpec {
   env: NodeJS.ProcessEnv;
 }
 
-type CloseListener = (error?: Error) => void;
-
-export class AcpSubprocess {
-  private closeError: Error | null = null;
-  private readonly closeListeners = new Set<CloseListener>();
-  private notifiedClose = false;
-  private readonly process: ManagedStdioProcess;
-
+export class AcpSubprocess extends ManagedSubprocess {
   constructor(launchSpec: AcpSubprocessLaunchSpec) {
-    this.process = new ManagedStdioProcess({
+    super({
       ...launchSpec,
       stderrBufferLimit: STDERR_BUFFER_LIMIT,
     });
-    this.process.onError((error) => {
-      this.closeError = error;
-      this.notifyClose(error);
-    });
-    this.process.onExit(({ code, signal }) => {
-      const exitError = this.closeError ?? (
-        code === 0 && signal === null
-          ? undefined
-          : new Error(`ACP subprocess exited (${formatExit(code, signal)})`)
-      );
-      this.notifyClose(exitError);
-    });
   }
-
-  get stdin(): Writable {
-    this.assertStarted();
-    return this.process.stdin;
-  }
-
-  get stdout(): Readable {
-    this.assertStarted();
-    return this.process.stdout;
-  }
-
-  get stderr(): Readable {
-    this.assertStarted();
-    return this.process.stderr;
-  }
-
-  start(): void {
-    this.process.start();
-  }
-
-  isAlive(): boolean {
-    return this.process.isAlive();
-  }
-
-  getStderrSnapshot(): string {
-    return this.process.getStderrSnapshot();
-  }
-
-  onClose(listener: CloseListener): () => void {
-    this.closeListeners.add(listener);
-    return () => {
-      this.closeListeners.delete(listener);
-    };
-  }
-
-  shutdown(): Promise<void> {
-    return this.process.shutdown();
-  }
-
-  private assertStarted(): void {
-    if (!this.process.isStarted()) {
-      throw new Error('ACP subprocess is not started');
-    }
-  }
-
-  private notifyClose(error?: Error): void {
-    if (this.notifiedClose) return;
-    this.notifiedClose = true;
-    for (const listener of [...this.closeListeners]) {
-      try {
-        listener(error);
-      } catch {
-        // Close observers cannot interrupt provider cleanup.
-      }
-    }
-    this.closeListeners.clear();
-  }
-}
-
-function formatExit(code: number | null, signal: string | null): string {
-  if (signal) return `signal ${signal}`;
-  if (code === null) return 'unknown';
-  return `code ${code}`;
 }

--- a/src/providers/cursor/history/CursorHistoryStore.ts
+++ b/src/providers/cursor/history/CursorHistoryStore.ts
@@ -1,8 +1,8 @@
-import { spawn as defaultSpawn } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
+import { ManagedCommandRunner } from '@/core/process/ManagedCommandRunner';
 import type { ProviderHistoryPathContext } from '@/core/providers/types';
 import type { ChatMessage, ContentBlock } from '@/core/types';
 
@@ -56,44 +56,16 @@ async function readCursorRowsWithSqliteCli(databasePath: string): Promise<Stored
 }
 
 function runSqliteQuery(databasePath: string, sql: string): Promise<string | null> {
-  return new Promise(resolve => {
-    let settled = false;
-    let size = 0;
-    let timer: number | null = null;
-    const chunks: Buffer[] = [];
-    let child: ReturnType<typeof defaultSpawn>;
-    try {
-      child = defaultSpawn('sqlite3', ['-json', databasePath, sql], {
-        stdio: ['ignore', 'pipe', 'ignore'],
-        windowsHide: true,
-      });
-    } catch {
-      resolve(null);
-      return;
-    }
-    const finish = (value: string | null): void => {
-      if (settled) return;
-      settled = true;
-      if (timer) window.clearTimeout(timer);
-      resolve(value);
-    };
-    child.stdout?.on('data', (chunk: Buffer | string) => {
-      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-      size += buffer.length;
-      if (size > MAX_SQLITE_OUTPUT_BYTES) {
-        child.kill('SIGKILL');
-        finish(null);
-        return;
-      }
-      chunks.push(buffer);
-    });
-    child.once('error', () => finish(null));
-    child.once('close', code => finish(code === 0 ? Buffer.concat(chunks).toString('utf8') : null));
-    timer = window.setTimeout(() => {
-      child.kill('SIGKILL');
-      finish(null);
-    }, 10_000);
-  });
+  return new ManagedCommandRunner().run({
+    args: ['-json', databasePath, sql],
+    command: 'sqlite3',
+    cwd: process.cwd(),
+    env: process.env,
+    stdoutLimitBytes: MAX_SQLITE_OUTPUT_BYTES,
+    timeoutMs: 10_000,
+  }).then(result => (
+    result.termination || result.exitCode !== 0 ? null : result.stdout
+  ));
 }
 
 export function resolveCursorSessionDatabase(

--- a/src/providers/grok/runtime/GrokModelCatalogService.ts
+++ b/src/providers/grok/runtime/GrokModelCatalogService.ts
@@ -1,14 +1,13 @@
-import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 
+import {
+  ManagedCommandRunner,
+  type ManagedCommandTermination,
+} from '../../../core/process/ManagedCommandRunner';
 import { getRuntimeEnvironmentVariables } from '../../../core/providers/providerEnvironment';
 import type { ProviderHost } from '../../../core/providers/ProviderHost';
 import type { ProviderTransitionOwnerContext } from '../../../core/providers/types';
 import { getVaultPath } from '../../../utils/path';
-import {
-  resolveWindowsCmdShimSpawnSpec,
-  terminateSpawnedProcess,
-} from '../../../utils/windowsCmdShim';
 import {
   type GrokDiscoveredModel,
   normalizeGrokDiscoveredModels,
@@ -37,7 +36,7 @@ export interface GrokCatalogCommandRequest {
 export interface GrokCatalogCommandResult {
   exitCode: number | null;
   stdout: string;
-  termination?: 'abort' | 'error' | 'output-limit' | 'timeout';
+  termination?: ManagedCommandTermination;
 }
 
 export interface GrokCatalogCommandRunner {
@@ -262,61 +261,9 @@ export class GrokModelCatalogService implements GrokModelCatalogServiceLike {
 
 export class SpawnGrokCatalogCommandRunner implements GrokCatalogCommandRunner {
   run(request: GrokCatalogCommandRequest): Promise<GrokCatalogCommandResult> {
-    if (request.signal?.aborted) {
-      return Promise.resolve({ exitCode: null, stdout: '', termination: 'abort' });
-    }
-
-    return new Promise((resolve) => {
-      const spawnSpec = resolveWindowsCmdShimSpawnSpec(request);
-      const proc = spawn(spawnSpec.command, spawnSpec.args, {
-        cwd: request.cwd,
-        env: request.env,
-        stdio: ['ignore', 'pipe', 'ignore'],
-        windowsHide: true,
-        ...(spawnSpec.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
-      });
-      const chunks: Buffer[] = [];
-      let byteLength = 0;
-      let settled = false;
-
-      const finish = (result: GrokCatalogCommandResult): void => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        window.clearTimeout(timeout);
-        request.signal?.removeEventListener('abort', onAbort);
-        resolve(result);
-      };
-      const terminate = (): void => {
-        terminateSpawnedProcess(proc, 'SIGKILL', spawn, spawnSpec);
-      };
-      const onAbort = (): void => {
-        terminate();
-        finish({ exitCode: null, stdout: '', termination: 'abort' });
-      };
-      const timeout = window.setTimeout(() => {
-        terminate();
-        finish({ exitCode: null, stdout: '', termination: 'timeout' });
-      }, request.timeoutMs);
-
-      request.signal?.addEventListener('abort', onAbort, { once: true });
-      proc.stdout.on('data', (chunk: Buffer | string) => {
-        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-        byteLength += buffer.byteLength;
-        if (byteLength > MAX_STDOUT_BYTES) {
-          terminate();
-          finish({ exitCode: null, stdout: '', termination: 'output-limit' });
-          return;
-        }
-        chunks.push(buffer);
-      });
-      proc.once('error', () => {
-        finish({ exitCode: null, stdout: '', termination: 'error' });
-      });
-      proc.once('close', (exitCode) => {
-        finish({ exitCode, stdout: Buffer.concat(chunks).toString('utf8') });
-      });
+    return new ManagedCommandRunner().run({
+      ...request,
+      stdoutLimitBytes: MAX_STDOUT_BYTES,
     });
   }
 }

--- a/src/providers/omp/metadata/OmpModelDiscoveryService.ts
+++ b/src/providers/omp/metadata/OmpModelDiscoveryService.ts
@@ -1,13 +1,8 @@
-import { spawn } from 'node:child_process';
-
 import type { ProviderInteractionPort, ProviderSessionConfig } from '../../../core/execution';
+import { ManagedCommandRunner, type ManagedCommandTermination } from '../../../core/process/ManagedCommandRunner';
 import { getRuntimeEnvironmentVariables } from '../../../core/providers/providerEnvironment';
 import type { ProviderHost } from '../../../core/providers/ProviderHost';
 import { getVaultPath } from '../../../utils/path';
-import {
-  resolveWindowsCmdShimSpawnSpec,
-  terminateSpawnedProcess,
-} from '../../../utils/windowsCmdShim';
 import {
   DefaultOmpAcpSessionKernel,
   type OmpAcpSessionKernel,
@@ -36,7 +31,7 @@ export interface OmpCatalogCommandRequest {
 export interface OmpCatalogCommandResult {
   exitCode: number | null;
   stdout: string;
-  termination?: 'abort' | 'error' | 'output-limit' | 'timeout';
+  termination?: ManagedCommandTermination;
 }
 
 export interface OmpCatalogCommandRunner {
@@ -155,74 +150,9 @@ function normalizeOmpCliModels(value: unknown): OmpDiscoveredModel[] {
 
 export class SpawnOmpCatalogCommandRunner implements OmpCatalogCommandRunner {
   run(request: OmpCatalogCommandRequest): Promise<OmpCatalogCommandResult> {
-    if (request.signal?.aborted) {
-      return Promise.resolve({ exitCode: null, stdout: '', termination: 'abort' });
-    }
-    return new Promise(resolve => {
-      const spawnSpec = resolveWindowsCmdShimSpawnSpec(request);
-      let child: ReturnType<typeof spawn> | null = null;
-      const chunks: Buffer[] = [];
-      let byteLength = 0;
-      let settled = false;
-      const finish = (result: OmpCatalogCommandResult): void => {
-        if (settled) return;
-        settled = true;
-        globalThis.clearTimeout(timeout);
-        request.signal?.removeEventListener('abort', onAbort);
-        resolve(result);
-      };
-      const terminate = (): void => {
-        if (child) terminateSpawnedProcess(child, 'SIGKILL', spawn, spawnSpec);
-      };
-      const onAbort = (): void => {
-        terminate();
-        finish({ exitCode: null, stdout: '', termination: 'abort' });
-      };
-      request.signal?.addEventListener('abort', onAbort, { once: true });
-      const timeout = globalThis.setTimeout(() => {
-        terminate();
-        finish({ exitCode: null, stdout: '', termination: 'timeout' });
-      }, request.timeoutMs);
-      if (request.signal?.aborted) {
-        finish({ exitCode: null, stdout: '', termination: 'abort' });
-        return;
-      }
-      try {
-        child = spawn(spawnSpec.command, spawnSpec.args, {
-          cwd: request.cwd,
-          env: request.env,
-          stdio: ['ignore', 'pipe', 'ignore'],
-          windowsHide: true,
-          ...(spawnSpec.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
-        });
-      } catch {
-        finish({ exitCode: null, stdout: '', termination: 'error' });
-        return;
-      }
-      if (request.signal?.aborted) {
-        onAbort();
-        return;
-      }
-      const spawnedChild = child;
-      if (!spawnedChild.stdout) {
-        finish({ exitCode: null, stdout: '', termination: 'error' });
-        return;
-      }
-      spawnedChild.stdout.on('data', (chunk: Buffer | string) => {
-        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-        byteLength += buffer.byteLength;
-        if (byteLength > MAX_STDOUT_BYTES) {
-          terminate();
-          finish({ exitCode: null, stdout: '', termination: 'output-limit' });
-          return;
-        }
-        chunks.push(buffer);
-      });
-      spawnedChild.once('error', () => finish({ exitCode: null, stdout: '', termination: 'error' }));
-      spawnedChild.once('close', exitCode => finish({
-        exitCode,
-        stdout: Buffer.concat(chunks).toString('utf8'),
-      }));
+    return new ManagedCommandRunner().run({
+      ...request,
+      stdoutLimitBytes: MAX_STDOUT_BYTES,
     });
   }
 }

--- a/src/providers/opencode/history/OpencodeSqliteReader.ts
+++ b/src/providers/opencode/history/OpencodeSqliteReader.ts
@@ -1,5 +1,6 @@
 import { spawn as defaultSpawn } from 'node:child_process';
 
+import { ManagedCommandRunner } from '../../../core/process/ManagedCommandRunner';
 import { findNodeExecutable } from '../../../utils/env';
 
 export type StoredRow = Record<string, unknown>;
@@ -197,47 +198,17 @@ function runBufferedChild(
   args: string[],
   spawn: typeof defaultSpawn,
 ): Promise<string | null> {
-  return new Promise((resolve) => {
-    let settled = false;
-    let size = 0;
-    let timer: number | null = null;
-    const chunks: Buffer[] = [];
-    let child: ReturnType<typeof defaultSpawn>;
-    try {
-      child = spawn(command, args, {
-        stdio: ['ignore', 'pipe', 'ignore'],
-        windowsHide: true,
-      });
-    } catch {
-      resolve(null);
-      return;
-    }
-    const finish = (value: string | null): void => {
-      if (settled) return;
-      settled = true;
-      if (timer !== null) window.clearTimeout(timer);
-      resolve(value);
-    };
-
-    child.stdout?.on('data', (chunk: Buffer | string) => {
-      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-      size += buffer.length;
-      if (size > OPENCODE_SQLITE_QUERY_MAX_BUFFER) {
-        child.kill('SIGKILL');
-        finish(null);
-        return;
-      }
-      chunks.push(buffer);
-    });
-    child.once('error', () => finish(null));
-    child.once('close', (code) => {
-      finish(code === 0 ? Buffer.concat(chunks).toString('utf8') : null);
-    });
-    timer = window.setTimeout(() => {
-      child.kill('SIGKILL');
-      finish(null);
-    }, 10_000);
-  });
+  return new ManagedCommandRunner().run({
+    args,
+    command,
+    cwd: process.cwd(),
+    env: process.env,
+    spawn,
+    stdoutLimitBytes: OPENCODE_SQLITE_QUERY_MAX_BUFFER,
+    timeoutMs: 10_000,
+  }).then(result => (
+    result.termination || result.exitCode !== 0 ? null : result.stdout
+  ));
 }
 
 function parseStoredSessionRows(value: string): StoredSessionRows | null {

--- a/src/providers/pi/runtime/PiSubprocess.ts
+++ b/src/providers/pi/runtime/PiSubprocess.ts
@@ -1,7 +1,6 @@
 import * as path from 'node:path';
-import type { Readable, Writable } from 'node:stream';
 
-import { ManagedStdioProcess } from '@/core/process/ManagedStdioProcess';
+import { ManagedSubprocess } from '@/core/process/ManagedSubprocess';
 import { getEnhancedPath } from '@/utils/env';
 
 const STDERR_BUFFER_LIMIT = 8_000;
@@ -13,16 +12,9 @@ export interface PiSubprocessLaunchSpec {
   env: NodeJS.ProcessEnv;
 }
 
-type CloseListener = (error?: Error) => void;
-
-export class PiSubprocess {
-  private closeError: Error | null = null;
-  private readonly closeListeners = new Set<CloseListener>();
-  private notifiedClose = false;
-  private readonly process: ManagedStdioProcess;
-
+export class PiSubprocess extends ManagedSubprocess {
   constructor(launchSpec: PiSubprocessLaunchSpec) {
-    this.process = new ManagedStdioProcess({
+    super({
       ...launchSpec,
       env: {
         ...launchSpec.env,
@@ -33,75 +25,5 @@ export class PiSubprocess {
       },
       stderrBufferLimit: STDERR_BUFFER_LIMIT,
     });
-    this.process.onError((error) => {
-      this.closeError = error;
-      this.notifyClose(error);
-    });
-    this.process.onExit(({ code, signal }) => {
-      const exitError = this.closeError ?? (
-        code === 0 && signal === null
-          ? undefined
-          : new Error(`Pi subprocess exited (${formatExit(code, signal)})`)
-      );
-      this.notifyClose(exitError);
-    });
   }
-
-  get stdin(): Writable {
-    this.assertStarted();
-    return this.process.stdin;
-  }
-
-  get stdout(): Readable {
-    this.assertStarted();
-    return this.process.stdout;
-  }
-
-  start(): void {
-    this.process.start();
-  }
-
-  isAlive(): boolean {
-    return this.process.isAlive();
-  }
-
-  getStderrSnapshot(): string {
-    return this.process.getStderrSnapshot();
-  }
-
-  onClose(listener: CloseListener): () => void {
-    this.closeListeners.add(listener);
-    return () => {
-      this.closeListeners.delete(listener);
-    };
-  }
-
-  shutdown(): Promise<void> {
-    return this.process.shutdown();
-  }
-
-  private assertStarted(): void {
-    if (!this.process.isStarted()) {
-      throw new Error('Pi subprocess is not started');
-    }
-  }
-
-  private notifyClose(error?: Error): void {
-    if (this.notifiedClose) return;
-    this.notifiedClose = true;
-    for (const listener of [...this.closeListeners]) {
-      try {
-        listener(error);
-      } catch {
-        // Close observers cannot interrupt provider cleanup.
-      }
-    }
-    this.closeListeners.clear();
-  }
-}
-
-function formatExit(code: number | null, signal: string | null): string {
-  if (signal) return `signal ${signal}`;
-  if (code === null) return 'unknown';
-  return `code ${code}`;
 }

--- a/tests/unit/core/process/ManagedCommandRunner.test.ts
+++ b/tests/unit/core/process/ManagedCommandRunner.test.ts
@@ -63,6 +63,7 @@ describe('ManagedCommandRunner', () => {
 
   it('returns an error termination for non-zero exits', async () => {
     const pending = runCommand();
+    proc.emit('exit', 1, null);
     proc.emit('close', 1, null);
 
     await expect(pending).resolves.toEqual({

--- a/tests/unit/core/process/ManagedCommandRunner.test.ts
+++ b/tests/unit/core/process/ManagedCommandRunner.test.ts
@@ -1,0 +1,97 @@
+import { EventEmitter } from 'node:events';
+import { Readable, Writable } from 'node:stream';
+
+jest.mock('node:child_process', () => ({
+  spawn: jest.fn(),
+}));
+
+import { spawn } from 'node:child_process';
+
+import { ManagedCommandRunner } from '@/core/process/ManagedCommandRunner';
+
+const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
+
+function createMockProcess(): any {
+  const proc = new EventEmitter() as any;
+  proc.exitCode = null;
+  proc.killed = false;
+  proc.pid = 12345;
+  proc.signalCode = null;
+  proc.stdin = new Writable({ write: (_chunk, _encoding, callback) => callback() });
+  proc.stdout = new Readable({ read() {} });
+  proc.stderr = new Readable({ read() {} });
+  proc.kill = jest.fn().mockReturnValue(true);
+  return proc;
+}
+
+function runCommand(overrides: Partial<Parameters<ManagedCommandRunner['run']>[0]> = {}) {
+  return new ManagedCommandRunner().run({
+    args: ['models'],
+    command: '/usr/bin/provider',
+    cwd: '/workspace',
+    env: { PATH: '/usr/bin' },
+    stdoutLimitBytes: 1024,
+    timeoutMs: 1_000,
+    ...overrides,
+  });
+}
+
+describe('ManagedCommandRunner', () => {
+  let proc: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('collects stdout and resolves from the final close state', async () => {
+    const pending = runCommand();
+    proc.stdout.emit('data', Buffer.from('{"models":['));
+    proc.stdout.emit('data', ']}');
+    proc.emit('close', 0, null);
+
+    await expect(pending).resolves.toEqual({
+      exitCode: 0,
+      stdout: '{"models":[]}',
+    });
+  });
+
+  it('returns an error termination for non-zero exits', async () => {
+    const pending = runCommand();
+    proc.emit('close', 1, null);
+
+    await expect(pending).resolves.toEqual({
+      exitCode: 1,
+      stdout: '',
+    });
+  });
+
+  it('aborts before spawning when the signal is already cancelled', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(runCommand({ signal: controller.signal })).resolves.toEqual({
+      exitCode: null,
+      stdout: '',
+      termination: 'abort',
+    });
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('stops collecting output after the configured limit', async () => {
+    const pending = runCommand({ stdoutLimitBytes: 4 });
+    proc.stdout.emit('data', '12345');
+
+    await expect(pending).resolves.toEqual({
+      exitCode: null,
+      stdout: '',
+      termination: 'output-limit',
+    });
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+});


### PR DESCRIPTION
## Summary

- Share long-lived stdio subprocess lifecycle across ACP and Pi adapters
- Add a common bounded command runner for abort, timeout, output limits, and exit states
- Migrate Grok and OMP metadata discovery commands
- Migrate OpenCode and Cursor SQLite history queries
- Preserve provider-specific launch policy and Claude SDK custom spawning
- Add core regression coverage for command lifecycle and exit-code handling

## Design notes

Claude's `customSpawn` remains provider-owned because it adapts the Claude SDK `SpawnedProcess` contract, cross-realm abort behavior, Node path resolution, and Windows process-tree termination.

## Validation

- 393 test suites passed
- 6912 tests passed
- Typecheck passed
- Lint passed
- Production build passed
