### PR TITLE
refactor: deepen chat orchestration

### DIFF
--- a/src/features/chat/tabs/ConversationNavigationQueue.ts
+++ b/src/features/chat/tabs/ConversationNavigationQueue.ts
@@ -1,0 +1,30 @@
+export type ConversationNavigationTask = () => Promise<void>;
+
+/**
+ * Serializes conversation navigation and drops stale requests before they
+ * start. Failed navigation is isolated so a later request can still run.
+ */
+export class ConversationNavigationQueue {
+  private requestRevision = 0;
+  private tail: Promise<void> = Promise.resolve();
+
+  async enqueue(task: ConversationNavigationTask): Promise<void> {
+    const requestRevision = ++this.requestRevision;
+    const pending = this.tail
+      .catch(() => undefined)
+      .then(async () => {
+        if (requestRevision !== this.requestRevision) return;
+        await task();
+      });
+    this.tail = pending.then(
+      () => undefined,
+      () => undefined,
+    );
+    await pending;
+  }
+
+  async invalidateAndDrain(): Promise<void> {
+    this.requestRevision += 1;
+    await this.tail;
+  }
+}

--- a/src/features/chat/tabs/ProvisionalTabCleanupCoordinator.ts
+++ b/src/features/chat/tabs/ProvisionalTabCleanupCoordinator.ts
@@ -1,0 +1,29 @@
+export type ProvisionalCleanupTask = () => Promise<void>;
+
+/** Ensures concurrent provisional-tab cleanup requests share one teardown. */
+export class ProvisionalTabCleanupCoordinator {
+  private activeCleanup: Promise<void> | null = null;
+
+  isRunning(): boolean {
+    return this.activeCleanup !== null;
+  }
+
+  async run(task: ProvisionalCleanupTask): Promise<void> {
+    if (this.activeCleanup) {
+      await this.activeCleanup;
+      return;
+    }
+
+    const cleanup = Promise.resolve()
+      .then(task)
+      .finally(() => {
+        if (this.activeCleanup === cleanup) this.activeCleanup = null;
+      });
+    this.activeCleanup = cleanup;
+    await cleanup;
+  }
+
+  async waitForIdle(): Promise<void> {
+    await this.activeCleanup;
+  }
+}

--- a/src/features/chat/tabs/TabActivationCoordinator.ts
+++ b/src/features/chat/tabs/TabActivationCoordinator.ts
@@ -1,0 +1,73 @@
+import type { TabData } from './types';
+
+export type TabActivationResult =
+  | { status: 'activated' }
+  | { status: 'aborted' }
+  | { status: 'failed'; error: unknown };
+
+export type TabActivationCoordinatorOptions = {
+  tab: TabData;
+  ensureWorkspaceServices: () => Promise<boolean>;
+  isTabAlive: () => boolean;
+  renderHydrationState: (error?: unknown) => void;
+  waitForPaint: () => Promise<void>;
+  startHydrationProfile: () => { finish: () => void } | null;
+};
+
+/**
+ * Coordinates the work that follows selecting a tab: provider workspace
+ * readiness, conversation hydration, and the empty-tab welcome state.
+ *
+ * Tab collection membership and active-tab selection remain owned by
+ * TabManager. Keeping this flow behind a narrow boundary makes activation
+ * ordering testable without giving the coordinator authority over tabs.
+ */
+export async function activateTabContent(
+  options: TabActivationCoordinatorOptions,
+): Promise<TabActivationResult> {
+  const {
+    tab,
+    ensureWorkspaceServices,
+    isTabAlive,
+    renderHydrationState,
+    waitForPaint,
+    startHydrationProfile,
+  } = options;
+  const needsHydration = !!tab.conversationId && tab.hydrationState !== 'ready';
+
+  if (needsHydration) {
+    tab.hydrationState = 'loading';
+    renderHydrationState();
+    await waitForPaint();
+    if (!isTabAlive()) return { status: 'aborted' };
+  }
+
+  try {
+    if (!await ensureWorkspaceServices()) {
+      return { status: 'aborted' };
+    }
+
+    if (needsHydration && tab.conversationId) {
+      const profile = startHydrationProfile();
+      try {
+        await tab.controllers.conversationController?.switchTo(tab.conversationId);
+      } finally {
+        profile?.finish();
+      }
+      if (!isTabAlive()) return { status: 'aborted' };
+      tab.hydrationState = 'ready';
+    } else if (tab.conversationId && tab.state.messages.length > 0) {
+      tab.hydrationState = 'ready';
+    } else if (!tab.conversationId && tab.state.messages.length === 0) {
+      tab.controllers.conversationController?.initializeWelcome();
+      tab.hydrationState = 'ready';
+    }
+  } catch (error) {
+    if (!isTabAlive()) return { status: 'aborted' };
+    tab.hydrationState = 'failed';
+    renderHydrationState(error);
+    return { status: 'failed', error };
+  }
+
+  return isTabAlive() ? { status: 'activated' } : { status: 'aborted' };
+}

--- a/src/features/chat/tabs/TabCloseCoordinator.ts
+++ b/src/features/chat/tabs/TabCloseCoordinator.ts
@@ -1,0 +1,46 @@
+import type { TabId } from './types';
+
+export type TabCloseFollowUp =
+  | { kind: 'none' }
+  | { kind: 'switch'; tabId: TabId }
+  | { kind: 'create' };
+
+export type TabCloseFollowUpOptions = {
+  activeTabId: TabId | null;
+  closedTabId: TabId;
+  tabIdsBeforeClose: readonly TabId[];
+  remainingTabIds: ReadonlySet<TabId>;
+};
+
+/**
+ * Resolves the navigation consequence of closing a tab.
+ *
+ * The caller retains ownership of tab storage and performs the follow-up.
+ * This policy only encodes the user-visible rule: closing an active tab
+ * selects the previous tab, except when closing the first tab, where it
+ * selects the next one; closing the final tab creates a blank replacement.
+ */
+export function resolveTabCloseFollowUp(
+  options: TabCloseFollowUpOptions,
+): TabCloseFollowUp {
+  const {
+    activeTabId,
+    closedTabId,
+    tabIdsBeforeClose,
+    remainingTabIds,
+  } = options;
+
+  if (activeTabId !== closedTabId) return { kind: 'none' };
+  if (remainingTabIds.size === 0) return { kind: 'create' };
+
+  const closingIndex = tabIdsBeforeClose.indexOf(closedTabId);
+  if (closingIndex < 0) return { kind: 'none' };
+
+  const candidateTabId = closingIndex === 0
+    ? tabIdsBeforeClose[1]
+    : tabIdsBeforeClose[closingIndex - 1];
+
+  return candidateTabId && remainingTabIds.has(candidateTabId)
+    ? { kind: 'switch', tabId: candidateTabId }
+    : { kind: 'none' };
+}

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -19,7 +19,9 @@ import { scheduleAnimationFrame } from '../../../utils/animationFrame';
 import { revealWorkspaceLeaf } from '../../../utils/obsidianCompat';
 import { getVaultPath } from '../../../utils/path';
 import type { FeatureHost } from '../../FeatureHost';
+import { ConversationNavigationQueue } from './ConversationNavigationQueue';
 import { getTabProviderId } from './providerResolution';
+import { ProvisionalTabCleanupCoordinator } from './ProvisionalTabCleanupCoordinator';
 import {
   activateTab,
   createTab,
@@ -33,6 +35,9 @@ import {
   refreshTabWorkspaceServices,
   wireTabInputEvents,
 } from './Tab';
+import { activateTabContent } from './TabActivationCoordinator';
+import { resolveTabCloseFollowUp } from './TabCloseCoordinator';
+import { TabSwitchCoordinator } from './TabSwitchCoordinator';
 import {
   type TabBarItem,
   type TabData,
@@ -119,14 +124,9 @@ export class TabManager implements TabManagerInterface {
   private tabCommandContextRevisions = new Map<TabId, number>();
   private tabActivationRevisions = new Map<TabId, number>();
 
-  /** Guard to prevent concurrent tab switches. */
-  private isSwitchingTab = false;
-  private pendingSwitchTabId: TabId | null = null;
-  private readonly tabSwitchIdleWaiters = new Set<() => void>();
-  private tabSwitchRequestRevision = 0;
-  private conversationNavigationRequestRevision = 0;
-  private conversationNavigationTail: Promise<void> = Promise.resolve();
-  private provisionalCleanupPromise: Promise<void> | null = null;
+  private readonly tabSwitchCoordinator: TabSwitchCoordinator;
+  private readonly conversationNavigationQueue = new ConversationNavigationQueue();
+  private readonly provisionalCleanupCoordinator = new ProvisionalTabCleanupCoordinator();
   private profiledFirstHydration = false;
   private destroyed = false;
 
@@ -151,6 +151,7 @@ export class TabManager implements TabManagerInterface {
     arg5: TabManagerCallbacks = {},
   ) {
     this.plugin = plugin;
+    this.tabSwitchCoordinator = new TabSwitchCoordinator(tabId => this.activeTabId === tabId);
 
     if (isTabManagerViewHost(arg3)) {
       this.containerEl = arg2 as HTMLElement;
@@ -279,20 +280,13 @@ export class TabManager implements TabManagerInterface {
     if (!tab) {
       return;
     }
-    this.tabSwitchRequestRevision += 1;
+    await this.tabSwitchCoordinator.request(tabId, async requestedTabId => {
+      const requestedTab = this.tabs.get(requestedTabId);
+      if (!requestedTab) return;
+      const previousTabId = this.activeTabId;
 
-    // Guard against concurrent tab switches
-    if (this.isSwitchingTab) {
-      this.pendingSwitchTabId = tabId;
-      return;
-    }
-
-    this.isSwitchingTab = true;
-    const previousTabId = this.activeTabId;
-
-    try {
       // Deactivate current tab
-      if (previousTabId && previousTabId !== tabId) {
+      if (previousTabId && previousTabId !== requestedTabId) {
         const currentTab = this.tabs.get(previousTabId);
         if (currentTab) {
           deactivateTab(currentTab);
@@ -300,89 +294,44 @@ export class TabManager implements TabManagerInterface {
       }
 
       // Activate new tab
-      this.activeTabId = tabId;
+      this.activeTabId = requestedTabId;
       this.tabActivationRevisions.set(
-        tabId,
-        (this.tabActivationRevisions.get(tabId) ?? 0) + 1,
+        requestedTabId,
+        (this.tabActivationRevisions.get(requestedTabId) ?? 0) + 1,
       );
-      activateTab(tab);
-      tab.state.acknowledgeReview();
-      this.callbacks.onActiveTabChanged?.(previousTabId, tabId);
+      activateTab(requestedTab);
+      requestedTab.state.acknowledgeReview();
+      this.callbacks.onActiveTabChanged?.(previousTabId, requestedTabId);
 
-      const providerId = tab.providerId;
-      const needsHydration = !!tab.conversationId && tab.hydrationState !== 'ready';
-      if (needsHydration) {
-        tab.hydrationState = 'loading';
-        this.renderTabHydrationState(tab);
-        await this.waitForTabPaint(tab);
-        if (!this.isTabAlive(tab)) return;
-      }
-
-      try {
-        if (!await this.ensureTabWorkspaceServices(tab, providerId, 'tab-activation')) {
-          return;
-        }
-
-        // Load conversation if not already loaded
-        if (needsHydration && tab.conversationId) {
-          const span = this.profiledFirstHydration ? null : StartupProfiler.start('active-hydration');
+      const activationResult = await activateTabContent({
+        tab: requestedTab,
+        ensureWorkspaceServices: () => this.ensureTabWorkspaceServices(
+          requestedTab,
+          requestedTab.providerId,
+          'tab-activation',
+        ),
+        isTabAlive: () => this.isTabAlive(requestedTab),
+        renderHydrationState: (error) => this.renderTabHydrationState(requestedTab, error),
+        waitForPaint: () => this.waitForTabPaint(requestedTab),
+        startHydrationProfile: () => {
+          const span = this.profiledFirstHydration
+            ? null
+            : StartupProfiler.start('active-hydration');
           this.profiledFirstHydration = true;
-          try {
-            await tab.controllers.conversationController?.switchTo(tab.conversationId);
-          } finally {
-            if (span) {
-              StartupProfiler.finish(span);
-            }
-          }
-          if (!this.isTabAlive(tab)) return;
-          tab.hydrationState = 'ready';
-        } else if (tab.conversationId && tab.state.messages.length > 0) {
-          tab.hydrationState = 'ready';
-        } else if (!tab.conversationId && tab.state.messages.length === 0) {
-          // New tab with no conversation - initialize welcome greeting
-          tab.controllers.conversationController?.initializeWelcome();
-          tab.hydrationState = 'ready';
-        }
-      } catch (error) {
-        if (!this.isTabAlive(tab)) return;
-        tab.hydrationState = 'failed';
-        this.renderTabHydrationState(tab, error);
-        return;
-      }
-
-      if (!this.isTabAlive(tab)) return;
-      this.callbacks.onTabSwitched?.(previousTabId, tabId);
-    } finally {
-      this.isSwitchingTab = false;
-      const pendingTabId = this.pendingSwitchTabId;
-      this.pendingSwitchTabId = null;
-      if (pendingTabId && pendingTabId !== this.activeTabId) {
-        await this.switchToTab(pendingTabId);
-      }
-      this.resolveTabSwitchIdleWaitersIfIdle();
-    }
+          return span ? { finish: () => StartupProfiler.finish(span) } : null;
+        },
+      });
+      if (activationResult.status !== 'activated') return;
+      this.callbacks.onTabSwitched?.(previousTabId, requestedTabId);
+    });
   }
 
   getTabSwitchRequestRevision(): number {
-    return this.tabSwitchRequestRevision;
+    return this.tabSwitchCoordinator.getRequestRevision();
   }
 
   async waitForTabSwitchIdle(): Promise<void> {
-    while (this.isSwitchingTab) {
-      await new Promise<void>((resolve) => {
-        this.tabSwitchIdleWaiters.add(resolve);
-      });
-    }
-  }
-
-  private resolveTabSwitchIdleWaitersIfIdle(): void {
-    if (this.isSwitchingTab || this.pendingSwitchTabId) return;
-
-    const waiters = [...this.tabSwitchIdleWaiters];
-    this.tabSwitchIdleWaiters.clear();
-    for (const resolve of waiters) {
-      resolve();
-    }
+    await this.tabSwitchCoordinator.waitForIdle();
   }
 
   /**
@@ -430,7 +379,6 @@ export class TabManager implements TabManagerInterface {
 
     // Capture tab order BEFORE deletion for fallback calculation
     const tabIdsBefore = Array.from(this.tabs.keys());
-    const closingIndex = tabIdsBefore.indexOf(tabId);
 
     // Destroy tab resources (async for proper cleanup)
     await destroyTab(tab);
@@ -445,21 +393,16 @@ export class TabManager implements TabManagerInterface {
     }
     this.callbacks.onTabClosed?.(tabId);
 
-    // If we closed the active tab, switch to another
-    if (wasActiveTab) {
-      if (this.tabs.size > 0) {
-        // Fallback strategy: prefer previous tab, except for first tab (go to next)
-        const fallbackTabId = closingIndex === 0
-          ? tabIdsBefore[1]  // First tab: go to next
-          : tabIdsBefore[closingIndex - 1];  // Others: go to previous
-
-        if (fallbackTabId && this.tabs.has(fallbackTabId)) {
-          await this.switchToTab(fallbackTabId);
-        }
-      } else {
-        // Create a replacement blank tab.
-        await this.createTab();
-      }
+    const closeFollowUp = resolveTabCloseFollowUp({
+      activeTabId: wasActiveTab ? tabId : this.activeTabId,
+      closedTabId: tabId,
+      tabIdsBeforeClose: tabIdsBefore,
+      remainingTabIds: new Set(this.tabs.keys()),
+    });
+    if (closeFollowUp.kind === 'switch') {
+      await this.switchToTab(closeFollowUp.tabId);
+    } else if (closeFollowUp.kind === 'create') {
+      await this.createTab();
     }
 
     if (didSaveFail) {
@@ -551,20 +494,9 @@ export class TabManager implements TabManagerInterface {
   /** Removes replaceable dual-mode previews while retaining cold and warm work. */
   async discardProvisionalTabs(): Promise<void> {
     if (this.destroyed) return;
-    if (this.provisionalCleanupPromise) {
-      await this.provisionalCleanupPromise;
-      return;
-    }
-
-    const cleanup = this.discardProvisionalTabsProtected();
-    this.provisionalCleanupPromise = cleanup;
-    try {
-      await cleanup;
-    } finally {
-      if (this.provisionalCleanupPromise === cleanup) {
-        this.provisionalCleanupPromise = null;
-      }
-    }
+    await this.provisionalCleanupCoordinator.run(
+      () => this.discardProvisionalTabsProtected(),
+    );
   }
 
   private async discardProvisionalTabsProtected(): Promise<void> {
@@ -649,32 +581,20 @@ export class TabManager implements TabManagerInterface {
     activate: boolean,
     provisional: boolean,
   ): Promise<void> {
-    if (this.destroyed || this.provisionalCleanupPromise) return;
-    const requestRevision = ++this.conversationNavigationRequestRevision;
-    const pending = this.conversationNavigationTail
-      .catch(() => undefined)
-      .then(async () => {
-        if (
-          this.destroyed
-          || requestRevision !== this.conversationNavigationRequestRevision
-        ) return;
-        await this.openConversationImmediately(
+    if (this.destroyed || this.provisionalCleanupCoordinator.isRunning()) return;
+    await this.conversationNavigationQueue.enqueue(async () => {
+      if (this.destroyed || this.provisionalCleanupCoordinator.isRunning()) return;
+      await this.openConversationImmediately(
           conversationId,
           preferNewTab,
           activate,
           provisional,
         );
-      });
-    this.conversationNavigationTail = pending.then(
-      () => undefined,
-      () => undefined,
-    );
-    await pending;
+    });
   }
 
   private async invalidateAndDrainConversationNavigation(): Promise<void> {
-    this.conversationNavigationRequestRevision += 1;
-    await this.conversationNavigationTail;
+    await this.conversationNavigationQueue.invalidateAndDrain();
   }
 
   private async openConversationImmediately(
@@ -1355,7 +1275,7 @@ export class TabManager implements TabManagerInterface {
     let provisionalCleanupError: unknown;
     let didProvisionalCleanupFail = false;
     try {
-      await this.provisionalCleanupPromise;
+      await this.provisionalCleanupCoordinator.waitForIdle();
     } catch (error) {
       didProvisionalCleanupFail = true;
       provisionalCleanupError = error;

--- a/src/features/chat/tabs/TabSwitchCoordinator.ts
+++ b/src/features/chat/tabs/TabSwitchCoordinator.ts
@@ -1,0 +1,62 @@
+import type { TabId } from './types';
+
+export type TabSwitchExecutor = (tabId: TabId) => Promise<void>;
+
+/**
+ * Serializes tab activation requests while coalescing them to the latest
+ * requested tab. It owns queue mechanics only; tab state and activation
+ * semantics remain with the caller.
+ */
+export class TabSwitchCoordinator {
+  private pendingTabId: TabId | null = null;
+  private running = false;
+  private requestRevision = 0;
+  private readonly idleWaiters = new Set<() => void>();
+
+  constructor(private readonly isCurrentTab: (tabId: TabId) => boolean) {}
+
+  async request(tabId: TabId, execute: TabSwitchExecutor): Promise<void> {
+    this.requestRevision += 1;
+    if (this.running) {
+      this.pendingTabId = tabId;
+      return;
+    }
+
+    this.running = true;
+    let requestedTabId: TabId | null = tabId;
+    try {
+      while (requestedTabId) {
+        this.pendingTabId = null;
+        await execute(requestedTabId);
+        const pendingTabId = this.pendingTabId;
+        this.pendingTabId = null;
+        requestedTabId = pendingTabId && !this.isCurrentTab(pendingTabId)
+          ? pendingTabId
+          : null;
+      }
+    } finally {
+      this.running = false;
+      this.resolveIdleWaiters();
+    }
+  }
+
+  getRequestRevision(): number {
+    return this.requestRevision;
+  }
+
+  async waitForIdle(): Promise<void> {
+    while (this.running) {
+      await new Promise<void>(resolve => {
+        this.idleWaiters.add(resolve);
+      });
+    }
+  }
+
+  private resolveIdleWaiters(): void {
+    if (this.running || this.pendingTabId) return;
+
+    const waiters = [...this.idleWaiters];
+    this.idleWaiters.clear();
+    for (const resolve of waiters) resolve();
+  }
+}

--- a/tests/unit/features/chat/tabs/ConversationNavigationQueue.test.ts
+++ b/tests/unit/features/chat/tabs/ConversationNavigationQueue.test.ts
@@ -1,0 +1,60 @@
+import { ConversationNavigationQueue } from '@/features/chat/tabs/ConversationNavigationQueue';
+
+describe('ConversationNavigationQueue', () => {
+  it('drops an earlier request before it starts when a newer one is queued', async () => {
+    const queue = new ConversationNavigationQueue();
+    const gate = deferred<void>();
+    const events: string[] = [];
+
+    const first = queue.enqueue(async () => {
+      events.push('first');
+      await gate.promise;
+    });
+    await Promise.resolve();
+    const second = queue.enqueue(async () => {
+      events.push('second');
+    });
+
+    gate.resolve();
+    await Promise.all([first, second]);
+
+    expect(events).toEqual(['second']);
+  });
+
+  it('allows a later request after a failed task', async () => {
+    const queue = new ConversationNavigationQueue();
+    const later = jest.fn().mockResolvedValue(undefined);
+
+    await expect(queue.enqueue(async () => {
+      throw new Error('navigation failed');
+    })).rejects.toThrow('navigation failed');
+    await queue.enqueue(later);
+
+    expect(later).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates queued navigation before draining it', async () => {
+    const queue = new ConversationNavigationQueue();
+    const gate = deferred<void>();
+    const stale = jest.fn().mockResolvedValue(undefined);
+
+    const active = queue.enqueue(() => gate.promise);
+    const pending = queue.enqueue(stale);
+    const drain = queue.invalidateAndDrain();
+    gate.resolve();
+
+    await Promise.all([active, pending, drain]);
+    expect(stale).not.toHaveBeenCalled();
+  });
+});
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolver => {
+    resolve = resolver;
+  });
+  return { promise, resolve };
+}

--- a/tests/unit/features/chat/tabs/ProvisionalTabCleanupCoordinator.test.ts
+++ b/tests/unit/features/chat/tabs/ProvisionalTabCleanupCoordinator.test.ts
@@ -1,0 +1,40 @@
+import { ProvisionalTabCleanupCoordinator } from '@/features/chat/tabs/ProvisionalTabCleanupCoordinator';
+
+describe('ProvisionalTabCleanupCoordinator', () => {
+  it('shares one active cleanup with concurrent callers', async () => {
+    const coordinator = new ProvisionalTabCleanupCoordinator();
+    const gate = deferred<void>();
+    const task = jest.fn(() => gate.promise);
+
+    const first = coordinator.run(task);
+    await Promise.resolve();
+    const second = coordinator.run(task);
+
+    expect(task).toHaveBeenCalledTimes(1);
+    expect(coordinator.isRunning()).toBe(true);
+    gate.resolve();
+    await Promise.all([first, second]);
+    expect(coordinator.isRunning()).toBe(false);
+  });
+
+  it('releases the coordinator when cleanup fails', async () => {
+    const coordinator = new ProvisionalTabCleanupCoordinator();
+    const error = new Error('cleanup failed');
+
+    await expect(coordinator.run(async () => {
+      throw error;
+    })).rejects.toBe(error);
+    expect(coordinator.isRunning()).toBe(false);
+  });
+});
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolver => {
+    resolve = resolver;
+  });
+  return { promise, resolve };
+}

--- a/tests/unit/features/chat/tabs/TabActivationCoordinator.test.ts
+++ b/tests/unit/features/chat/tabs/TabActivationCoordinator.test.ts
@@ -1,0 +1,80 @@
+import { activateTabContent } from '@/features/chat/tabs/TabActivationCoordinator';
+
+function createTab(overrides: Record<string, unknown> = {}): any {
+  return {
+    conversationId: null,
+    hydrationState: 'idle',
+    state: { messages: [] },
+    controllers: {
+      conversationController: {
+        initializeWelcome: jest.fn(),
+        switchTo: jest.fn().mockResolvedValue(undefined),
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('activateTabContent', () => {
+  it('initializes an empty tab after workspace services are ready', async () => {
+    const tab = createTab();
+    const ensureWorkspaceServices = jest.fn().mockResolvedValue(true);
+
+    const result = await activateTabContent({
+      tab,
+      ensureWorkspaceServices,
+      isTabAlive: () => true,
+      renderHydrationState: jest.fn(),
+      waitForPaint: jest.fn().mockResolvedValue(undefined),
+      startHydrationProfile: () => null,
+    });
+
+    expect(result).toEqual({ status: 'activated' });
+    expect(ensureWorkspaceServices).toHaveBeenCalledTimes(1);
+    expect(tab.controllers.conversationController.initializeWelcome).toHaveBeenCalledTimes(1);
+    expect(tab.hydrationState).toBe('ready');
+  });
+
+  it('hydrates a conversation only after the paint boundary', async () => {
+    const tab = createTab({ conversationId: 'conversation-1' });
+    const events: string[] = [];
+    tab.controllers.conversationController.switchTo.mockImplementation(async () => {
+      events.push('switch');
+    });
+
+    const result = await activateTabContent({
+      tab,
+      ensureWorkspaceServices: jest.fn().mockResolvedValue(true),
+      isTabAlive: () => true,
+      renderHydrationState: () => events.push('render-loading'),
+      waitForPaint: async () => {
+        events.push('paint');
+      },
+      startHydrationProfile: () => ({ finish: () => events.push('profile-finished') }),
+    });
+
+    expect(result).toEqual({ status: 'activated' });
+    expect(events).toEqual(['render-loading', 'paint', 'switch', 'profile-finished']);
+    expect(tab.hydrationState).toBe('ready');
+  });
+
+  it('reports hydration errors and leaves the tab retryable', async () => {
+    const tab = createTab({ conversationId: 'conversation-1' });
+    const error = new Error('load failed');
+    tab.controllers.conversationController.switchTo.mockRejectedValue(error);
+    const renderHydrationState = jest.fn();
+
+    const result = await activateTabContent({
+      tab,
+      ensureWorkspaceServices: jest.fn().mockResolvedValue(true),
+      isTabAlive: () => true,
+      renderHydrationState,
+      waitForPaint: jest.fn().mockResolvedValue(undefined),
+      startHydrationProfile: () => null,
+    });
+
+    expect(result).toEqual({ status: 'failed', error });
+    expect(tab.hydrationState).toBe('failed');
+    expect(renderHydrationState).toHaveBeenLastCalledWith(error);
+  });
+});

--- a/tests/unit/features/chat/tabs/TabCloseCoordinator.test.ts
+++ b/tests/unit/features/chat/tabs/TabCloseCoordinator.test.ts
@@ -1,0 +1,42 @@
+import { resolveTabCloseFollowUp } from '@/features/chat/tabs/TabCloseCoordinator';
+
+describe('resolveTabCloseFollowUp', () => {
+  const base = {
+    activeTabId: 'tab-2',
+    closedTabId: 'tab-2',
+    tabIdsBeforeClose: ['tab-1', 'tab-2', 'tab-3'],
+  } as const;
+
+  it('selects the previous tab when closing a non-first active tab', () => {
+    expect(resolveTabCloseFollowUp({
+      ...base,
+      remainingTabIds: new Set(['tab-1', 'tab-3']),
+    })).toEqual({ kind: 'switch', tabId: 'tab-1' });
+  });
+
+  it('selects the next tab when closing the first active tab', () => {
+    expect(resolveTabCloseFollowUp({
+      activeTabId: 'tab-1',
+      closedTabId: 'tab-1',
+      tabIdsBeforeClose: ['tab-1', 'tab-2'],
+      remainingTabIds: new Set(['tab-2']),
+    })).toEqual({ kind: 'switch', tabId: 'tab-2' });
+  });
+
+  it('requests a replacement when the final active tab is closed', () => {
+    expect(resolveTabCloseFollowUp({
+      activeTabId: 'tab-1',
+      closedTabId: 'tab-1',
+      tabIdsBeforeClose: ['tab-1'],
+      remainingTabIds: new Set(),
+    })).toEqual({ kind: 'create' });
+  });
+
+  it('does not navigate when closing an inactive tab', () => {
+    expect(resolveTabCloseFollowUp({
+      ...base,
+      closedTabId: 'tab-1',
+      remainingTabIds: new Set(['tab-2', 'tab-3']),
+    })).toEqual({ kind: 'none' });
+  });
+});

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -221,15 +221,15 @@ describe('TabManager provider execution orchestration', () => {
     const { manager } = createManager();
     const initial = await manager.createTab();
     const managerInternals = manager as any;
-    managerInternals.isSwitchingTab = true;
+    const switching = deferred<void>();
+    void managerInternals.tabSwitchCoordinator.request('pending-tab', () => switching.promise);
 
-    const switchingIdle = managerInternals.waitForTabSwitchIdle();
+    const switchingIdle = manager.waitForTabSwitchIdle();
     await Promise.resolve();
 
     expect(manager.getActiveTabId()).toBe(initial!.id);
 
-    managerInternals.isSwitchingTab = false;
-    managerInternals.resolveTabSwitchIdleWaitersIfIdle();
+    switching.resolve();
 
     await expect(switchingIdle).resolves.toBeUndefined();
     expect(manager.getActiveTabId()).toBe(initial!.id);

--- a/tests/unit/features/chat/tabs/TabSwitchCoordinator.test.ts
+++ b/tests/unit/features/chat/tabs/TabSwitchCoordinator.test.ts
@@ -1,0 +1,55 @@
+import { TabSwitchCoordinator } from '@/features/chat/tabs/TabSwitchCoordinator';
+
+describe('TabSwitchCoordinator', () => {
+  it('coalesces overlapping requests to the latest non-current tab', async () => {
+    let currentTabId = 'tab-1';
+    let releaseFirst!: () => void;
+    const firstStarted = new Promise<void>(resolve => {
+      releaseFirst = resolve;
+    });
+    const events: string[] = [];
+    const coordinator = new TabSwitchCoordinator(tabId => tabId === currentTabId);
+    const execute = jest.fn(async (tabId: string) => {
+      events.push(`start:${tabId}`);
+      if (tabId === 'tab-2') await firstStarted;
+      currentTabId = tabId;
+      events.push(`finish:${tabId}`);
+    });
+
+    const firstRequest = coordinator.request('tab-2', execute);
+    await Promise.resolve();
+    await coordinator.request('tab-3', execute);
+    releaseFirst();
+    await firstRequest;
+
+    expect(events).toEqual([
+      'start:tab-2',
+      'finish:tab-2',
+      'start:tab-3',
+      'finish:tab-3',
+    ]);
+    expect(coordinator.getRequestRevision()).toBe(2);
+  });
+
+  it('resolves idle waiters after the queued request finishes', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    const coordinator = new TabSwitchCoordinator(() => false);
+    const request = coordinator.request('tab-1', async () => gate);
+    const idle = coordinator.waitForIdle();
+
+    let idleResolved = false;
+    void idle.then(() => {
+      idleResolved = true;
+    });
+    await Promise.resolve();
+    expect(idleResolved).toBe(false);
+
+    release();
+    await request;
+    await idle;
+    expect(idleResolved).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- extract tab activation/hydration orchestration from `TabManager`
- isolate close-tab follow-up navigation policy
- centralize tab switching and conversation navigation queues
- coordinate provisional-tab cleanup with shared teardown ownership
- add focused regression coverage for each coordinator and `TabManager`

## Validation

- `pnpm run typecheck` ✅
- `pnpm run lint` ✅ (existing warnings only)
- `pnpm run test:architecture` ✅
- focused chat tests: 39 passed ✅
- full test suite: 6916 passed; 10 failures caused by sandbox `listen EPERM` on `127.0.0.1` in existing `createNodeFetch` tests
