### PR TITLE
feat: improve dual-pane controls and session hover

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.1.20",
+  "version": "2.2.0",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "2.1.20",
+  "version": "2.2.0",
   "packageManager": "pnpm@10.34.5",
   "description": "Oh My Claudian - provider-backed coding agents embedded in the Obsidian sidebar",
   "main": "main.js",

--- a/src/core/providers/commands/ProviderCommandDiscoveryStore.ts
+++ b/src/core/providers/commands/ProviderCommandDiscoveryStore.ts
@@ -20,6 +20,7 @@ export interface ProviderCommandDiscoveryController<T>
 export interface ProviderCommandDiscoveryStoreOptions {
   /** Evicts upstream discovery state before retry observers can start a new load. */
   onBeforeRetry?: () => void;
+  /** Set to 0 or a negative value when the upstream provider owns cancellation. */
   timeoutMs?: number;
 }
 
@@ -133,6 +134,10 @@ implements ProviderCommandDiscoveryController<T> {
   private async loadWithTimeout(
     abortController: AbortController,
   ): Promise<ProviderCommandDiscoveryResult<T>> {
+    if (this.timeoutMs <= 0) {
+      return await this.loader(abortController.signal);
+    }
+
     let timeoutId: number | null = null;
     const timeout = new Promise<ProviderCommandDiscoveryResult<T>>(resolve => {
       timeoutId = window.setTimeout(() => {

--- a/src/features/FeatureHost.ts
+++ b/src/features/FeatureHost.ts
@@ -54,6 +54,9 @@ export interface FeatureHost {
   mutateSettings(
     mutation: (settings: ClaudianSettings) => void | Promise<void>,
   ): Promise<void>;
+  toggleDualPaneMode(): Promise<void>;
+  isDualPaneModeEnabled(): boolean;
+  setDualPaneModeEnabled(enabled: boolean): void;
   getActiveEnvironmentVariables(providerId?: ProviderId): string;
   getAgentSkillResourceGeneration(): number;
   notifyAgentSkillsChanged(): Promise<void>;

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -78,6 +78,7 @@ export class ClaudianView extends ItemView {
   // DOM Elements
   private viewContainerEl: HTMLElement | null = null;
   private newTabButtonEl: HTMLElement | null = null;
+  private dualPaneToggleButtonEl: HTMLElement | null = null;
   private sessionNewButtonEl: HTMLElement | null = null;
   private sessionSearchFieldEl: HTMLElement | null = null;
   private sessionSearchInputEl: HTMLInputElement | null = null;
@@ -90,6 +91,7 @@ export class ClaudianView extends ItemView {
   private historyRenderAbortController: AbortController | null = null;
   private sessionSidebarEl: HTMLElement | null = null;
   private sidebarSurfaceSwitcherEl: HTMLElement | null = null;
+  private sidebarDualPaneToggleButtonEl: HTMLButtonElement | null = null;
   private sessionsSurfaceButtonEl: HTMLButtonElement | null = null;
   private filesSurfaceButtonEl: HTMLButtonElement | null = null;
   private sessionSurfaceEl: HTMLElement | null = null;
@@ -434,6 +436,15 @@ export class ClaudianView extends ItemView {
     setIcon(this.filesSurfaceButtonEl, 'folder-tree');
     this.filesSurfaceButtonEl.createSpan({ text: 'Files' });
     this.filesSurfaceButtonEl.addEventListener('click', () => this.showVaultFiles());
+    this.sidebarDualPaneToggleButtonEl = this.sidebarSurfaceSwitcherEl.createEl('button', {
+      cls: 'claudian-sidebar-surface-button claudian-sidebar-dual-pane-toggle-btn',
+      attr: { type: 'button' },
+    });
+    setIcon(this.sidebarDualPaneToggleButtonEl, 'columns-2');
+    this.sidebarDualPaneToggleButtonEl.addEventListener('click', () => {
+      void this.toggleDualPaneMode();
+    });
+    this.updateDualPaneToggleButton();
     if (this.activeSidebarSurface !== 'files') {
       this.activeSidebarSurface = 'sessions';
     }
@@ -469,6 +480,19 @@ export class ClaudianView extends ItemView {
     setIcon(newBtn, 'square-pen');
     newBtn.setAttribute('aria-label', 'New conversation');
     newBtn.addEventListener('click', () => this.requestNewConversation());
+
+    this.dualPaneToggleButtonEl = navActionsEl.createEl('button', {
+      cls: 'claudian-input-nav-btn claudian-dual-pane-toggle-btn',
+      attr: { type: 'button' },
+    });
+    setIcon(this.dualPaneToggleButtonEl, 'columns-2');
+    const toggleDualPane = (): void => {
+      void this.plugin.toggleDualPaneMode().catch(() => {
+        new Notice('Failed to toggle dual-pane mode');
+      });
+    };
+    this.dualPaneToggleButtonEl.addEventListener('click', toggleDualPane);
+    this.updateDualPaneToggleButton();
 
     // History dropdown
     const historyContainer = navActionsEl.createDiv({ cls: 'claudian-history-container' });
@@ -545,8 +569,48 @@ export class ClaudianView extends ItemView {
 
   refreshDualPaneLayout(): void {
     if (!this.viewContainerEl) return;
+    this.updateDualPaneToggleButton();
     this.updateSidebarSurfaceVisibility();
     this.updateSessionSidebarLayout(this.viewContainerEl.getBoundingClientRect().width);
+  }
+
+  private updateDualPaneToggleButton(): void {
+    const enabled = this.plugin?.settings?.enableDualPane ?? true;
+    this.dualPaneToggleButtonEl?.toggleClass('is-active', enabled);
+    const configured = this.plugin?.settings?.enableDualPane ?? true;
+    this.dualPaneToggleButtonEl?.toggleClass('claudian-hidden', !configured);
+    this.dualPaneToggleButtonEl?.setAttribute('aria-pressed', String(enabled));
+    this.dualPaneToggleButtonEl?.setAttribute(
+      'aria-label',
+      enabled ? 'Disable dual-pane mode' : 'Enable dual-pane mode',
+    );
+    this.dualPaneToggleButtonEl?.setAttribute(
+      'title',
+      enabled ? 'Disable dual-pane mode' : 'Enable dual-pane mode',
+    );
+    this.dualPaneToggleButtonEl?.setAttribute(
+      'data-tooltip-position',
+      'bottom',
+    );
+    this.sidebarDualPaneToggleButtonEl?.toggleClass('is-active', enabled);
+    this.sidebarDualPaneToggleButtonEl?.toggleClass('claudian-hidden', !configured);
+    this.sidebarDualPaneToggleButtonEl?.setAttribute('aria-pressed', String(enabled));
+    this.sidebarDualPaneToggleButtonEl?.setAttribute(
+      'aria-label',
+      enabled ? 'Disable dual-pane mode' : 'Enable dual-pane mode',
+    );
+    this.sidebarDualPaneToggleButtonEl?.setAttribute(
+      'title',
+      enabled ? 'Disable dual-pane mode' : 'Enable dual-pane mode',
+    );
+    this.sidebarDualPaneToggleButtonEl?.setAttribute(
+      'data-tooltip-position',
+      'bottom',
+    );
+  }
+
+  private toggleDualPaneMode(): Promise<void> {
+    return this.plugin.toggleDualPaneMode();
   }
 
   private findMostRecentUnboundTab(): TabData | null {
@@ -765,6 +829,7 @@ export class ClaudianView extends ItemView {
       }
     }
   }
+
 
   private renderSessionSidebar(): void {
     const sessionSurfaceEl = this.sessionSurfaceEl ?? this.sessionSidebarEl;
@@ -1754,7 +1819,8 @@ export class ClaudianView extends ItemView {
     const isLeft = this.plugin?.settings?.dualPaneSide === 'left';
     this.viewContainerEl.toggleClass('claudian-session-sidebar-left', isLeft);
 
-    const isDualPaneEnabled = this.plugin?.settings?.enableDualPane ?? true;
+    const isDualPaneEnabled = (this.plugin?.settings?.enableDualPane ?? true)
+      && (this.plugin?.isDualPaneModeEnabled?.() ?? true);
     const shouldUseWideLayout = isDualPaneEnabled && width >= WIDE_SESSION_LAYOUT_MIN_WIDTH;
     if (!shouldUseWideLayout) {
       this.sidebarSurfaceWheelGesture?.reset();

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -1443,6 +1443,15 @@ export class ConversationController {
       event.stopPropagation();
       this.closeSessionMetadataPopover();
     });
+
+    // A layout switch can replace the hovered item without dispatching a new
+    // mouseenter event. Synchronize once after insertion so the metadata card
+    // remains available when the pointer is already over the new item.
+    queueMicrotask(() => {
+      if (typeof item.matches === 'function' && item.matches(':hover')) {
+        this.showSessionMetadataPopover(item, focusTarget, conversation, options);
+      }
+    });
   }
 
   private showSessionMetadataPopover(

--- a/src/features/chat/tabs/ConversationNavigationQueue.ts
+++ b/src/features/chat/tabs/ConversationNavigationQueue.ts
@@ -1,0 +1,30 @@
+export type ConversationNavigationTask = () => Promise<void>;
+
+/**
+ * Serializes conversation navigation and drops stale requests before they
+ * start. Failed navigation is isolated so a later request can still run.
+ */
+export class ConversationNavigationQueue {
+  private requestRevision = 0;
+  private tail: Promise<void> = Promise.resolve();
+
+  async enqueue(task: ConversationNavigationTask): Promise<void> {
+    const requestRevision = ++this.requestRevision;
+    const pending = this.tail
+      .catch(() => undefined)
+      .then(async () => {
+        if (requestRevision !== this.requestRevision) return;
+        await task();
+      });
+    this.tail = pending.then(
+      () => undefined,
+      () => undefined,
+    );
+    await pending;
+  }
+
+  async invalidateAndDrain(): Promise<void> {
+    this.requestRevision += 1;
+    await this.tail;
+  }
+}

--- a/src/features/chat/tabs/ProvisionalTabCleanupCoordinator.ts
+++ b/src/features/chat/tabs/ProvisionalTabCleanupCoordinator.ts
@@ -1,0 +1,29 @@
+export type ProvisionalCleanupTask = () => Promise<void>;
+
+/** Ensures concurrent provisional-tab cleanup requests share one teardown. */
+export class ProvisionalTabCleanupCoordinator {
+  private activeCleanup: Promise<void> | null = null;
+
+  isRunning(): boolean {
+    return this.activeCleanup !== null;
+  }
+
+  async run(task: ProvisionalCleanupTask): Promise<void> {
+    if (this.activeCleanup) {
+      await this.activeCleanup;
+      return;
+    }
+
+    const cleanup = Promise.resolve()
+      .then(task)
+      .finally(() => {
+        if (this.activeCleanup === cleanup) this.activeCleanup = null;
+      });
+    this.activeCleanup = cleanup;
+    await cleanup;
+  }
+
+  async waitForIdle(): Promise<void> {
+    await this.activeCleanup;
+  }
+}

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -311,6 +311,7 @@ function getRegistryProviderCatalogInfo(providerId: ProviderId): ProviderCatalog
       normalizeProviderCommandDiscoveryItems(
         await catalog.listDropdownEntries({ includeBuiltIns: false, signal }),
       ),
+      { timeoutMs: 0 },
     ),
   };
 }

--- a/src/features/chat/tabs/TabActivationCoordinator.ts
+++ b/src/features/chat/tabs/TabActivationCoordinator.ts
@@ -1,0 +1,73 @@
+import type { TabData } from './types';
+
+export type TabActivationResult =
+  | { status: 'activated' }
+  | { status: 'aborted' }
+  | { status: 'failed'; error: unknown };
+
+export type TabActivationCoordinatorOptions = {
+  tab: TabData;
+  ensureWorkspaceServices: () => Promise<boolean>;
+  isTabAlive: () => boolean;
+  renderHydrationState: (error?: unknown) => void;
+  waitForPaint: () => Promise<void>;
+  startHydrationProfile: () => { finish: () => void } | null;
+};
+
+/**
+ * Coordinates the work that follows selecting a tab: provider workspace
+ * readiness, conversation hydration, and the empty-tab welcome state.
+ *
+ * Tab collection membership and active-tab selection remain owned by
+ * TabManager. Keeping this flow behind a narrow boundary makes activation
+ * ordering testable without giving the coordinator authority over tabs.
+ */
+export async function activateTabContent(
+  options: TabActivationCoordinatorOptions,
+): Promise<TabActivationResult> {
+  const {
+    tab,
+    ensureWorkspaceServices,
+    isTabAlive,
+    renderHydrationState,
+    waitForPaint,
+    startHydrationProfile,
+  } = options;
+  const needsHydration = !!tab.conversationId && tab.hydrationState !== 'ready';
+
+  if (needsHydration) {
+    tab.hydrationState = 'loading';
+    renderHydrationState();
+    await waitForPaint();
+    if (!isTabAlive()) return { status: 'aborted' };
+  }
+
+  try {
+    if (!await ensureWorkspaceServices()) {
+      return { status: 'aborted' };
+    }
+
+    if (needsHydration && tab.conversationId) {
+      const profile = startHydrationProfile();
+      try {
+        await tab.controllers.conversationController?.switchTo(tab.conversationId);
+      } finally {
+        profile?.finish();
+      }
+      if (!isTabAlive()) return { status: 'aborted' };
+      tab.hydrationState = 'ready';
+    } else if (tab.conversationId && tab.state.messages.length > 0) {
+      tab.hydrationState = 'ready';
+    } else if (!tab.conversationId && tab.state.messages.length === 0) {
+      tab.controllers.conversationController?.initializeWelcome();
+      tab.hydrationState = 'ready';
+    }
+  } catch (error) {
+    if (!isTabAlive()) return { status: 'aborted' };
+    tab.hydrationState = 'failed';
+    renderHydrationState(error);
+    return { status: 'failed', error };
+  }
+
+  return isTabAlive() ? { status: 'activated' } : { status: 'aborted' };
+}

--- a/src/features/chat/tabs/TabCloseCoordinator.ts
+++ b/src/features/chat/tabs/TabCloseCoordinator.ts
@@ -1,0 +1,46 @@
+import type { TabId } from './types';
+
+export type TabCloseFollowUp =
+  | { kind: 'none' }
+  | { kind: 'switch'; tabId: TabId }
+  | { kind: 'create' };
+
+export type TabCloseFollowUpOptions = {
+  activeTabId: TabId | null;
+  closedTabId: TabId;
+  tabIdsBeforeClose: readonly TabId[];
+  remainingTabIds: ReadonlySet<TabId>;
+};
+
+/**
+ * Resolves the navigation consequence of closing a tab.
+ *
+ * The caller retains ownership of tab storage and performs the follow-up.
+ * This policy only encodes the user-visible rule: closing an active tab
+ * selects the previous tab, except when closing the first tab, where it
+ * selects the next one; closing the final tab creates a blank replacement.
+ */
+export function resolveTabCloseFollowUp(
+  options: TabCloseFollowUpOptions,
+): TabCloseFollowUp {
+  const {
+    activeTabId,
+    closedTabId,
+    tabIdsBeforeClose,
+    remainingTabIds,
+  } = options;
+
+  if (activeTabId !== closedTabId) return { kind: 'none' };
+  if (remainingTabIds.size === 0) return { kind: 'create' };
+
+  const closingIndex = tabIdsBeforeClose.indexOf(closedTabId);
+  if (closingIndex < 0) return { kind: 'none' };
+
+  const candidateTabId = closingIndex === 0
+    ? tabIdsBeforeClose[1]
+    : tabIdsBeforeClose[closingIndex - 1];
+
+  return candidateTabId && remainingTabIds.has(candidateTabId)
+    ? { kind: 'switch', tabId: candidateTabId }
+    : { kind: 'none' };
+}

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -1247,6 +1247,7 @@ export class TabManager implements TabManagerInterface {
       signal => this.getProviderCommandDiscovery(tabId, signal),
       {
         onBeforeRetry: () => this.advanceTabCommandContextRevision(tabId),
+        timeoutMs: 0,
       },
     );
     this.providerCommandDiscoveryStores.set(tabId, discovery);

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -19,7 +19,9 @@ import { scheduleAnimationFrame } from '../../../utils/animationFrame';
 import { revealWorkspaceLeaf } from '../../../utils/obsidianCompat';
 import { getVaultPath } from '../../../utils/path';
 import type { FeatureHost } from '../../FeatureHost';
+import { ConversationNavigationQueue } from './ConversationNavigationQueue';
 import { getTabProviderId } from './providerResolution';
+import { ProvisionalTabCleanupCoordinator } from './ProvisionalTabCleanupCoordinator';
 import {
   activateTab,
   createTab,
@@ -33,6 +35,9 @@ import {
   refreshTabWorkspaceServices,
   wireTabInputEvents,
 } from './Tab';
+import { activateTabContent } from './TabActivationCoordinator';
+import { resolveTabCloseFollowUp } from './TabCloseCoordinator';
+import { TabSwitchCoordinator } from './TabSwitchCoordinator';
 import {
   type TabBarItem,
   type TabData,
@@ -119,14 +124,9 @@ export class TabManager implements TabManagerInterface {
   private tabCommandContextRevisions = new Map<TabId, number>();
   private tabActivationRevisions = new Map<TabId, number>();
 
-  /** Guard to prevent concurrent tab switches. */
-  private isSwitchingTab = false;
-  private pendingSwitchTabId: TabId | null = null;
-  private readonly tabSwitchIdleWaiters = new Set<() => void>();
-  private tabSwitchRequestRevision = 0;
-  private conversationNavigationRequestRevision = 0;
-  private conversationNavigationTail: Promise<void> = Promise.resolve();
-  private provisionalCleanupPromise: Promise<void> | null = null;
+  private readonly tabSwitchCoordinator: TabSwitchCoordinator;
+  private readonly conversationNavigationQueue = new ConversationNavigationQueue();
+  private readonly provisionalCleanupCoordinator = new ProvisionalTabCleanupCoordinator();
   private profiledFirstHydration = false;
   private destroyed = false;
 
@@ -151,6 +151,7 @@ export class TabManager implements TabManagerInterface {
     arg5: TabManagerCallbacks = {},
   ) {
     this.plugin = plugin;
+    this.tabSwitchCoordinator = new TabSwitchCoordinator(tabId => this.activeTabId === tabId);
 
     if (isTabManagerViewHost(arg3)) {
       this.containerEl = arg2 as HTMLElement;
@@ -279,20 +280,13 @@ export class TabManager implements TabManagerInterface {
     if (!tab) {
       return;
     }
-    this.tabSwitchRequestRevision += 1;
+    await this.tabSwitchCoordinator.request(tabId, async requestedTabId => {
+      const requestedTab = this.tabs.get(requestedTabId);
+      if (!requestedTab) return;
+      const previousTabId = this.activeTabId;
 
-    // Guard against concurrent tab switches
-    if (this.isSwitchingTab) {
-      this.pendingSwitchTabId = tabId;
-      return;
-    }
-
-    this.isSwitchingTab = true;
-    const previousTabId = this.activeTabId;
-
-    try {
       // Deactivate current tab
-      if (previousTabId && previousTabId !== tabId) {
+      if (previousTabId && previousTabId !== requestedTabId) {
         const currentTab = this.tabs.get(previousTabId);
         if (currentTab) {
           deactivateTab(currentTab);
@@ -300,89 +294,44 @@ export class TabManager implements TabManagerInterface {
       }
 
       // Activate new tab
-      this.activeTabId = tabId;
+      this.activeTabId = requestedTabId;
       this.tabActivationRevisions.set(
-        tabId,
-        (this.tabActivationRevisions.get(tabId) ?? 0) + 1,
+        requestedTabId,
+        (this.tabActivationRevisions.get(requestedTabId) ?? 0) + 1,
       );
-      activateTab(tab);
-      tab.state.acknowledgeReview();
-      this.callbacks.onActiveTabChanged?.(previousTabId, tabId);
+      activateTab(requestedTab);
+      requestedTab.state.acknowledgeReview();
+      this.callbacks.onActiveTabChanged?.(previousTabId, requestedTabId);
 
-      const providerId = tab.providerId;
-      const needsHydration = !!tab.conversationId && tab.hydrationState !== 'ready';
-      if (needsHydration) {
-        tab.hydrationState = 'loading';
-        this.renderTabHydrationState(tab);
-        await this.waitForTabPaint(tab);
-        if (!this.isTabAlive(tab)) return;
-      }
-
-      try {
-        if (!await this.ensureTabWorkspaceServices(tab, providerId, 'tab-activation')) {
-          return;
-        }
-
-        // Load conversation if not already loaded
-        if (needsHydration && tab.conversationId) {
-          const span = this.profiledFirstHydration ? null : StartupProfiler.start('active-hydration');
+      const activationResult = await activateTabContent({
+        tab: requestedTab,
+        ensureWorkspaceServices: () => this.ensureTabWorkspaceServices(
+          requestedTab,
+          requestedTab.providerId,
+          'tab-activation',
+        ),
+        isTabAlive: () => this.isTabAlive(requestedTab),
+        renderHydrationState: (error) => this.renderTabHydrationState(requestedTab, error),
+        waitForPaint: () => this.waitForTabPaint(requestedTab),
+        startHydrationProfile: () => {
+          const span = this.profiledFirstHydration
+            ? null
+            : StartupProfiler.start('active-hydration');
           this.profiledFirstHydration = true;
-          try {
-            await tab.controllers.conversationController?.switchTo(tab.conversationId);
-          } finally {
-            if (span) {
-              StartupProfiler.finish(span);
-            }
-          }
-          if (!this.isTabAlive(tab)) return;
-          tab.hydrationState = 'ready';
-        } else if (tab.conversationId && tab.state.messages.length > 0) {
-          tab.hydrationState = 'ready';
-        } else if (!tab.conversationId && tab.state.messages.length === 0) {
-          // New tab with no conversation - initialize welcome greeting
-          tab.controllers.conversationController?.initializeWelcome();
-          tab.hydrationState = 'ready';
-        }
-      } catch (error) {
-        if (!this.isTabAlive(tab)) return;
-        tab.hydrationState = 'failed';
-        this.renderTabHydrationState(tab, error);
-        return;
-      }
-
-      if (!this.isTabAlive(tab)) return;
-      this.callbacks.onTabSwitched?.(previousTabId, tabId);
-    } finally {
-      this.isSwitchingTab = false;
-      const pendingTabId = this.pendingSwitchTabId;
-      this.pendingSwitchTabId = null;
-      if (pendingTabId && pendingTabId !== this.activeTabId) {
-        await this.switchToTab(pendingTabId);
-      }
-      this.resolveTabSwitchIdleWaitersIfIdle();
-    }
+          return span ? { finish: () => StartupProfiler.finish(span) } : null;
+        },
+      });
+      if (activationResult.status !== 'activated') return;
+      this.callbacks.onTabSwitched?.(previousTabId, requestedTabId);
+    });
   }
 
   getTabSwitchRequestRevision(): number {
-    return this.tabSwitchRequestRevision;
+    return this.tabSwitchCoordinator.getRequestRevision();
   }
 
   async waitForTabSwitchIdle(): Promise<void> {
-    while (this.isSwitchingTab) {
-      await new Promise<void>((resolve) => {
-        this.tabSwitchIdleWaiters.add(resolve);
-      });
-    }
-  }
-
-  private resolveTabSwitchIdleWaitersIfIdle(): void {
-    if (this.isSwitchingTab || this.pendingSwitchTabId) return;
-
-    const waiters = [...this.tabSwitchIdleWaiters];
-    this.tabSwitchIdleWaiters.clear();
-    for (const resolve of waiters) {
-      resolve();
-    }
+    await this.tabSwitchCoordinator.waitForIdle();
   }
 
   /**
@@ -430,7 +379,6 @@ export class TabManager implements TabManagerInterface {
 
     // Capture tab order BEFORE deletion for fallback calculation
     const tabIdsBefore = Array.from(this.tabs.keys());
-    const closingIndex = tabIdsBefore.indexOf(tabId);
 
     // Destroy tab resources (async for proper cleanup)
     await destroyTab(tab);
@@ -445,21 +393,16 @@ export class TabManager implements TabManagerInterface {
     }
     this.callbacks.onTabClosed?.(tabId);
 
-    // If we closed the active tab, switch to another
-    if (wasActiveTab) {
-      if (this.tabs.size > 0) {
-        // Fallback strategy: prefer previous tab, except for first tab (go to next)
-        const fallbackTabId = closingIndex === 0
-          ? tabIdsBefore[1]  // First tab: go to next
-          : tabIdsBefore[closingIndex - 1];  // Others: go to previous
-
-        if (fallbackTabId && this.tabs.has(fallbackTabId)) {
-          await this.switchToTab(fallbackTabId);
-        }
-      } else {
-        // Create a replacement blank tab.
-        await this.createTab();
-      }
+    const closeFollowUp = resolveTabCloseFollowUp({
+      activeTabId: wasActiveTab ? tabId : this.activeTabId,
+      closedTabId: tabId,
+      tabIdsBeforeClose: tabIdsBefore,
+      remainingTabIds: new Set(this.tabs.keys()),
+    });
+    if (closeFollowUp.kind === 'switch') {
+      await this.switchToTab(closeFollowUp.tabId);
+    } else if (closeFollowUp.kind === 'create') {
+      await this.createTab();
     }
 
     if (didSaveFail) {
@@ -551,20 +494,9 @@ export class TabManager implements TabManagerInterface {
   /** Removes replaceable dual-mode previews while retaining cold and warm work. */
   async discardProvisionalTabs(): Promise<void> {
     if (this.destroyed) return;
-    if (this.provisionalCleanupPromise) {
-      await this.provisionalCleanupPromise;
-      return;
-    }
-
-    const cleanup = this.discardProvisionalTabsProtected();
-    this.provisionalCleanupPromise = cleanup;
-    try {
-      await cleanup;
-    } finally {
-      if (this.provisionalCleanupPromise === cleanup) {
-        this.provisionalCleanupPromise = null;
-      }
-    }
+    await this.provisionalCleanupCoordinator.run(
+      () => this.discardProvisionalTabsProtected(),
+    );
   }
 
   private async discardProvisionalTabsProtected(): Promise<void> {
@@ -649,32 +581,20 @@ export class TabManager implements TabManagerInterface {
     activate: boolean,
     provisional: boolean,
   ): Promise<void> {
-    if (this.destroyed || this.provisionalCleanupPromise) return;
-    const requestRevision = ++this.conversationNavigationRequestRevision;
-    const pending = this.conversationNavigationTail
-      .catch(() => undefined)
-      .then(async () => {
-        if (
-          this.destroyed
-          || requestRevision !== this.conversationNavigationRequestRevision
-        ) return;
-        await this.openConversationImmediately(
+    if (this.destroyed || this.provisionalCleanupCoordinator.isRunning()) return;
+    await this.conversationNavigationQueue.enqueue(async () => {
+      if (this.destroyed || this.provisionalCleanupCoordinator.isRunning()) return;
+      await this.openConversationImmediately(
           conversationId,
           preferNewTab,
           activate,
           provisional,
         );
-      });
-    this.conversationNavigationTail = pending.then(
-      () => undefined,
-      () => undefined,
-    );
-    await pending;
+    });
   }
 
   private async invalidateAndDrainConversationNavigation(): Promise<void> {
-    this.conversationNavigationRequestRevision += 1;
-    await this.conversationNavigationTail;
+    await this.conversationNavigationQueue.invalidateAndDrain();
   }
 
   private async openConversationImmediately(
@@ -1355,7 +1275,7 @@ export class TabManager implements TabManagerInterface {
     let provisionalCleanupError: unknown;
     let didProvisionalCleanupFail = false;
     try {
-      await this.provisionalCleanupPromise;
+      await this.provisionalCleanupCoordinator.waitForIdle();
     } catch (error) {
       didProvisionalCleanupFail = true;
       provisionalCleanupError = error;

--- a/src/features/chat/tabs/TabSwitchCoordinator.ts
+++ b/src/features/chat/tabs/TabSwitchCoordinator.ts
@@ -1,0 +1,62 @@
+import type { TabId } from './types';
+
+export type TabSwitchExecutor = (tabId: TabId) => Promise<void>;
+
+/**
+ * Serializes tab activation requests while coalescing them to the latest
+ * requested tab. It owns queue mechanics only; tab state and activation
+ * semantics remain with the caller.
+ */
+export class TabSwitchCoordinator {
+  private pendingTabId: TabId | null = null;
+  private running = false;
+  private requestRevision = 0;
+  private readonly idleWaiters = new Set<() => void>();
+
+  constructor(private readonly isCurrentTab: (tabId: TabId) => boolean) {}
+
+  async request(tabId: TabId, execute: TabSwitchExecutor): Promise<void> {
+    this.requestRevision += 1;
+    if (this.running) {
+      this.pendingTabId = tabId;
+      return;
+    }
+
+    this.running = true;
+    let requestedTabId: TabId | null = tabId;
+    try {
+      while (requestedTabId) {
+        this.pendingTabId = null;
+        await execute(requestedTabId);
+        const pendingTabId = this.pendingTabId;
+        this.pendingTabId = null;
+        requestedTabId = pendingTabId && !this.isCurrentTab(pendingTabId)
+          ? pendingTabId
+          : null;
+      }
+    } finally {
+      this.running = false;
+      this.resolveIdleWaiters();
+    }
+  }
+
+  getRequestRevision(): number {
+    return this.requestRevision;
+  }
+
+  async waitForIdle(): Promise<void> {
+    while (this.running) {
+      await new Promise<void>(resolve => {
+        this.idleWaiters.add(resolve);
+      });
+    }
+  }
+
+  private resolveIdleWaiters(): void {
+    if (this.running || this.pendingTabId) return;
+
+    const waiters = [...this.idleWaiters];
+    this.idleWaiters.clear();
+    for (const resolve of waiters) resolve();
+  }
+}

--- a/src/features/inline-edit/ui/InlineEditModal.ts
+++ b/src/features/inline-edit/ui/InlineEditModal.ts
@@ -556,14 +556,15 @@ export class InlineEditSession {
         hiddenCommands: getHiddenProviderCommandSet(this.plugin.settings, this.resolvedProviderId),
         ...(inlineCatalog ? {
           providerConfig: inlineCatalog.getDropdownConfig(),
-          providerDiscovery: new ProviderCommandDiscoveryStore(async signal =>
-            normalizeProviderCommandDiscoveryItems(
-              await inlineCatalog.listDropdownEntries({
-                includeBuiltIns: false,
-                signal,
-              }),
+            providerDiscovery: new ProviderCommandDiscoveryStore(async signal =>
+              normalizeProviderCommandDiscoveryItems(
+                await inlineCatalog.listDropdownEntries({
+                  includeBuiltIns: false,
+                  signal,
+                }),
+              ),
+              { timeoutMs: 0 },
             ),
-          ),
         } : {}),
       }
     );

--- a/src/features/settings/ClaudianSettings.ts
+++ b/src/features/settings/ClaudianSettings.ts
@@ -368,6 +368,7 @@ export class ClaudianSettingTab extends PluginSettingTab {
             await this.plugin.mutateSettings((settings) => {
               settings.enableDualPane = value;
             });
+            this.plugin.setDualPaneModeEnabled?.(value);
             this.refreshDualPaneLayouts();
             this.display();
           })

--- a/src/main.ts
+++ b/src/main.ts
@@ -118,6 +118,7 @@ export default class ClaudianPlugin extends Plugin {
   private hasLoadedAllSessionMetadata = false;
   private sessionMetadataLoadTimer: number | null = null;
   private remainingSessionMetadataLoad: Promise<void> | null = null;
+  private dualPaneModeEnabled = true;
   private providerChatOptionsChangeTail: Promise<void> = Promise.resolve();
   private isUnloading = false;
 
@@ -280,6 +281,16 @@ export default class ClaudianPlugin extends Plugin {
               void tabManager.closeTab(activeTabId);
             }
           }
+          return true;
+        },
+      });
+
+      this.addCommand({
+        id: 'toggle-dual-pane',
+        name: 'Toggle dual-pane mode',
+        checkCallback: (checking: boolean) => {
+          if (!(this.settings.enableDualPane ?? true)) return false;
+          if (!checking) void this.toggleDualPaneMode();
           return true;
         },
       });
@@ -629,6 +640,35 @@ export default class ClaudianPlugin extends Plugin {
     onCommitted?: SettingsCommit<ClaudianSettings>,
   ): Promise<void> {
     await this.settingsCoordinator.mutate(mutation, onCommitted);
+  }
+
+  async toggleDualPaneMode(): Promise<void> {
+    if (!(this.settings.enableDualPane ?? true)) return;
+    const enabled = !this.dualPaneModeEnabled;
+    this.dualPaneModeEnabled = enabled;
+
+    const views = this.getAllViews();
+    for (const view of views) {
+      view.refreshDualPaneLayout();
+    }
+
+    if (!enabled) {
+      new Notice('Claudian: dual-pane mode off');
+      return;
+    }
+
+    const tooNarrow = enabled && views.length > 0 && !views.some(view => view.isDualPaneMode());
+    new Notice(tooNarrow
+      ? 'Claudian: dual-pane mode on (view is too narrow to show the second pane)'
+      : 'Claudian: dual-pane mode on');
+  }
+
+  isDualPaneModeEnabled(): boolean {
+    return this.dualPaneModeEnabled;
+  }
+
+  setDualPaneModeEnabled(enabled: boolean): void {
+    this.dualPaneModeEnabled = enabled;
   }
 
   getAgentSkillResourceGeneration(): number {

--- a/src/style/accessibility.css
+++ b/src/style/accessibility.css
@@ -6,6 +6,7 @@
 .claudian-citations-header:focus-visible,
 .claudian-subagent-header:focus-visible,
 .claudian-input-nav-btn:focus-visible,
+.claudian-dual-pane-toggle-btn:focus-visible,
 .claudian-model-btn:focus-visible,
 .claudian-thinking-current:focus-visible {
   outline: 2px solid var(--interactive-accent);

--- a/src/style/components/history.css
+++ b/src/style/components/history.css
@@ -110,6 +110,23 @@
   outline-offset: 2px;
 }
 
+.claudian-session-sidebar .claudian-sidebar-dual-pane-toggle-btn {
+  margin-inline-start: auto;
+  width: 28px;
+  padding: 4px;
+}
+
+.claudian-session-sidebar .claudian-sidebar-dual-pane-toggle-btn.is-active {
+  color: var(--text-normal);
+  border-color: var(--background-modifier-border);
+  background: transparent;
+}
+
+.claudian-session-sidebar .claudian-sidebar-dual-pane-toggle-btn svg {
+  width: 16px;
+  height: 16px;
+}
+
 .claudian-session-new-control,
 .claudian-session-search-control,
 .claudian-session-archive-control {
@@ -456,84 +473,6 @@
   flex-shrink: 0;
   gap: 6px;
   margin-inline-start: 0;
-}
-
-.claudian-session-metadata-popover {
-  position: fixed;
-  z-index: 1000;
-  box-sizing: border-box;
-  width: min(280px, calc(100vw - 24px));
-  padding: 8px;
-  border: 1px solid var(--background-modifier-border);
-  border-radius: 10px;
-  background-color: #ffffff;
-  background-image: linear-gradient(var(--background-primary), var(--background-primary));
-  box-shadow: var(--shadow-s);
-}
-
-body.theme-dark .claudian-session-metadata-popover {
-  background-color: #1e1e1e;
-}
-
-.claudian-session-metadata-row {
-  display: grid;
-  grid-template-columns: 16px max-content minmax(0, 1fr);
-  align-items: center;
-  gap: 8px;
-  min-height: 28px;
-  color: var(--text-normal);
-  font-size: var(--font-ui-small);
-}
-
-.claudian-session-metadata-row--provider {
-  grid-template-columns: 16px minmax(0, 1fr);
-}
-
-.claudian-session-metadata-row--unlabeled {
-  grid-template-columns: 16px minmax(0, 1fr);
-}
-
-.claudian-session-metadata-row--provider-no-icon {
-  grid-template-columns: minmax(0, 1fr);
-}
-
-.claudian-session-metadata-provider-icon {
-  color: var(--text-muted);
-}
-
-.claudian-session-metadata-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-muted);
-}
-
-.claudian-session-metadata-icon svg {
-  width: 14px;
-  height: 14px;
-}
-
-.claudian-session-metadata-label {
-  color: var(--text-muted);
-  white-space: nowrap;
-}
-
-.claudian-session-metadata-value {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.claudian-session-metadata-value--note {
-  overflow-x: auto;
-  overflow-y: hidden;
-  text-overflow: clip;
-  scrollbar-width: none;
-}
-
-.claudian-session-metadata-value--note::-webkit-scrollbar {
-  display: none;
 }
 
 .claudian-session-sidebar .claudian-history-item:hover .claudian-history-item-actions,

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -83,6 +83,11 @@
   background: var(--background-modifier-hover);
 }
 
+.claudian-dual-pane-toggle-btn.is-active {
+  color: var(--text-faint);
+  background: transparent;
+}
+
 .claudian-input-nav-btn svg {
   width: 16px;
   height: 16px;

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -5,6 +5,7 @@
 @import "./base/variables.css";
 @import "./base/container.css";
 @import "./base/animations.css";
+@import "./session-metadata-popover.css";
 
 /* Components */
 @import "./components/tabs.css";

--- a/src/style/session-metadata-popover.css
+++ b/src/style/session-metadata-popover.css
@@ -1,0 +1,74 @@
+.claudian-session-metadata-popover {
+  position: fixed;
+  z-index: 1000;
+  box-sizing: border-box;
+  width: min(280px, calc(100vw - 24px));
+  padding: 8px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 10px;
+  background-color: #ffffff;
+  background-image: linear-gradient(var(--background-primary), var(--background-primary));
+  box-shadow: var(--shadow-s);
+}
+
+body.theme-dark .claudian-session-metadata-popover {
+  background-color: #1e1e1e;
+}
+
+.claudian-session-metadata-row {
+  display: grid;
+  grid-template-columns: 16px max-content minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  color: var(--text-normal);
+  font-size: var(--font-ui-small);
+}
+
+.claudian-session-metadata-row--provider,
+.claudian-session-metadata-row--unlabeled {
+  grid-template-columns: 16px minmax(0, 1fr);
+}
+
+.claudian-session-metadata-row--provider-no-icon {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.claudian-session-metadata-provider-icon,
+.claudian-session-metadata-icon {
+  color: var(--text-muted);
+}
+
+.claudian-session-metadata-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.claudian-session-metadata-icon svg {
+  width: 14px;
+  height: 14px;
+}
+
+.claudian-session-metadata-label {
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.claudian-session-metadata-value {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.claudian-session-metadata-value--note {
+  overflow-x: auto;
+  overflow-y: hidden;
+  text-overflow: clip;
+  scrollbar-width: none;
+}
+
+.claudian-session-metadata-value--note::-webkit-scrollbar {
+  display: none;
+}

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -1,5 +1,5 @@
 
-import { TFile, TFolder } from 'obsidian';
+import { Notice, TFile, TFolder } from 'obsidian';
 
 import { createConversationMetadataShell } from '@/app/conversations/SessionMetadataCoordinator';
 import { ConversationPersistenceStore } from '@/core/bootstrap/ConversationPersistenceStore';
@@ -2476,6 +2476,52 @@ describe('ClaudianPlugin', () => {
       expect(replaceCommand.name).toBe('Replace current conversation');
       expect(replaceCommand.checkCallback(true)).toBe(false);
       expect(closeCommand.checkCallback(true)).toBe(false);
+    });
+
+    it('toggles dual-pane mode and refreshes every open view', async () => {
+      await plugin.onload();
+
+      const firstView = {
+        isDualPaneMode: jest.fn().mockReturnValue(true),
+        refreshDualPaneLayout: jest.fn(),
+      };
+      const secondView = {
+        isDualPaneMode: jest.fn().mockReturnValue(true),
+        refreshDualPaneLayout: jest.fn(),
+      };
+      jest.spyOn(plugin, 'getAllViews').mockReturnValue([firstView, secondView] as any);
+
+      const command = getRegisteredCommand('toggle-dual-pane');
+
+      expect(command.name).toBe('Toggle dual-pane mode');
+      expect(command.checkCallback(true)).toBe(true);
+      command.checkCallback(false);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(plugin.settings.enableDualPane).toBe(true);
+      expect(plugin.isDualPaneModeEnabled()).toBe(false);
+      expect(firstView.refreshDualPaneLayout).toHaveBeenCalledTimes(1);
+      expect(secondView.refreshDualPaneLayout).toHaveBeenCalledTimes(1);
+    });
+
+    it('explains when dual-pane mode is enabled in a narrow view', async () => {
+      await plugin.onload();
+      plugin.setDualPaneModeEnabled(false);
+
+      const view = {
+        isDualPaneMode: jest.fn().mockReturnValue(false),
+        refreshDualPaneLayout: jest.fn(),
+      };
+      jest.spyOn(plugin, 'getAllViews').mockReturnValue([view] as any);
+      const command = getRegisteredCommand('toggle-dual-pane');
+      expect(command.checkCallback(true)).toBe(true);
+      command.checkCallback(false);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(plugin.settings.enableDualPane).toBe(true);
+      expect(Notice).toHaveBeenCalledWith(
+        'Claudian: dual-pane mode on (view is too narrow to show the second pane)',
+      );
     });
 
     it('opens the view without creating a duplicate tab when no tab layout is persisted', async () => {

--- a/tests/unit/core/providers/commands/ProviderCommandDiscoveryStore.test.ts
+++ b/tests/unit/core/providers/commands/ProviderCommandDiscoveryStore.test.ts
@@ -151,4 +151,24 @@ describe('ProviderCommandDiscoveryStore', () => {
       jest.useRealTimers();
     }
   });
+
+  it('allows callers to wait for slow provider initialization without a timeout', async () => {
+    jest.useFakeTimers();
+    try {
+      const response = deferred<ProviderCommandDiscoveryResult<string>>();
+      const store = new ProviderCommandDiscoveryStore(
+        () => response.promise,
+        { timeoutMs: 0 },
+      );
+
+      const load = store.load();
+      await jest.advanceTimersByTimeAsync(8_000);
+      expect(store.getSnapshot()).toEqual({ status: 'loading' });
+
+      response.resolve({ status: 'ready', items: ['review'] });
+      await expect(load).resolves.toEqual({ status: 'ready', items: ['review'] });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -1107,10 +1107,36 @@ describe('ClaudianView tab controls', () => {
     ))).toBe(true);
     expect(view.filesSurfaceButtonEl.getAttribute('aria-label')).toBe('Files');
     expect(view.filesSurfaceButtonEl.getAttribute('aria-pressed')).toBe('false');
+    expect(view.sidebarDualPaneToggleButtonEl.getAttribute('aria-label'))
+      .toBe('Disable dual-pane mode');
+    expect(view.sidebarDualPaneToggleButtonEl.getAttribute('aria-pressed')).toBe('true');
     expect(viewContainerEl.children[2].getAttribute('aria-label')).toBeNull();
     expect(viewContainerEl.children[1].getAttribute('role')).toBe('separator');
     expect(viewContainerEl.children[0].children).toContain(view.tabContentEl);
     expect(viewContainerEl.children[0].children).toContain(view.inputFooterEl);
+  });
+
+  it('adds an accessible dual-pane toggle to the chat navigation actions', () => {
+    const view = Object.create(ClaudianView.prototype) as any;
+    const viewContainerEl = createMockEl();
+    const toggleDualPaneMode = jest.fn().mockResolvedValue(undefined);
+    Object.assign(view, {
+      containerEl: createMockEl(),
+      plugin: {
+        settings: { enableDualPane: false },
+        toggleDualPaneMode,
+      },
+      viewContainerEl,
+    });
+
+    const nav = view.buildNavRowContent();
+    const button = nav.querySelector('.claudian-dual-pane-toggle-btn')!;
+
+    expect(button.getAttribute('type')).toBe('button');
+    expect(button.getAttribute('aria-label')).toBe('Enable dual-pane mode');
+    expect(button.getAttribute('aria-pressed')).toBe('false');
+    button.dispatchEvent({ type: 'click' });
+    expect(toggleDualPaneMode).toHaveBeenCalledTimes(1);
   });
 
   it('switches the persistent sidebar to Files without remounting the tree', () => {

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -1210,6 +1210,35 @@ describe('ConversationController', () => {
           .toHaveLength(2);
       });
 
+      it('shows metadata when a layout switch inserts an item under the pointer', async () => {
+        const container = createMockEl();
+        (deps.plugin.getConversationList as jest.Mock).mockReturnValue([{
+          id: 'session-1',
+          providerId: 'codex',
+          selectedModel: 'gpt-5.1-codex',
+          title: 'Review architecture',
+          createdAt: 1_000,
+          lastActivityAt: 2_000,
+        }]);
+        const body = createMockEl();
+
+        controller.renderHistoryDropdown(container, {
+          onSelectConversation: jest.fn(),
+          showMetadataPopover: true,
+          getModelLabel: () => 'GPT-5.1 Codex',
+        });
+        const item = container.querySelector('.claudian-history-item')!;
+        Object.defineProperty(item.ownerDocument, 'body', {
+          configurable: true,
+          value: body,
+        });
+        item.matches = jest.fn().mockReturnValue(true);
+        await Promise.resolve();
+
+        expect(body.querySelector('.claudian-session-metadata-popover'))
+          .not.toBeNull();
+      });
+
       it.each(['Enter', ' '])('opens a focusable dual-mode session with %s', async (key) => {
         const container = createMockEl();
         const onSelectConversation = jest.fn().mockResolvedValue(undefined);

--- a/tests/unit/features/chat/tabs/ConversationNavigationQueue.test.ts
+++ b/tests/unit/features/chat/tabs/ConversationNavigationQueue.test.ts
@@ -1,0 +1,60 @@
+import { ConversationNavigationQueue } from '@/features/chat/tabs/ConversationNavigationQueue';
+
+describe('ConversationNavigationQueue', () => {
+  it('drops an earlier request before it starts when a newer one is queued', async () => {
+    const queue = new ConversationNavigationQueue();
+    const gate = deferred<void>();
+    const events: string[] = [];
+
+    const first = queue.enqueue(async () => {
+      events.push('first');
+      await gate.promise;
+    });
+    await Promise.resolve();
+    const second = queue.enqueue(async () => {
+      events.push('second');
+    });
+
+    gate.resolve();
+    await Promise.all([first, second]);
+
+    expect(events).toEqual(['second']);
+  });
+
+  it('allows a later request after a failed task', async () => {
+    const queue = new ConversationNavigationQueue();
+    const later = jest.fn().mockResolvedValue(undefined);
+
+    await expect(queue.enqueue(async () => {
+      throw new Error('navigation failed');
+    })).rejects.toThrow('navigation failed');
+    await queue.enqueue(later);
+
+    expect(later).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates queued navigation before draining it', async () => {
+    const queue = new ConversationNavigationQueue();
+    const gate = deferred<void>();
+    const stale = jest.fn().mockResolvedValue(undefined);
+
+    const active = queue.enqueue(() => gate.promise);
+    const pending = queue.enqueue(stale);
+    const drain = queue.invalidateAndDrain();
+    gate.resolve();
+
+    await Promise.all([active, pending, drain]);
+    expect(stale).not.toHaveBeenCalled();
+  });
+});
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolver => {
+    resolve = resolver;
+  });
+  return { promise, resolve };
+}

--- a/tests/unit/features/chat/tabs/ProvisionalTabCleanupCoordinator.test.ts
+++ b/tests/unit/features/chat/tabs/ProvisionalTabCleanupCoordinator.test.ts
@@ -1,0 +1,40 @@
+import { ProvisionalTabCleanupCoordinator } from '@/features/chat/tabs/ProvisionalTabCleanupCoordinator';
+
+describe('ProvisionalTabCleanupCoordinator', () => {
+  it('shares one active cleanup with concurrent callers', async () => {
+    const coordinator = new ProvisionalTabCleanupCoordinator();
+    const gate = deferred<void>();
+    const task = jest.fn(() => gate.promise);
+
+    const first = coordinator.run(task);
+    await Promise.resolve();
+    const second = coordinator.run(task);
+
+    expect(task).toHaveBeenCalledTimes(1);
+    expect(coordinator.isRunning()).toBe(true);
+    gate.resolve();
+    await Promise.all([first, second]);
+    expect(coordinator.isRunning()).toBe(false);
+  });
+
+  it('releases the coordinator when cleanup fails', async () => {
+    const coordinator = new ProvisionalTabCleanupCoordinator();
+    const error = new Error('cleanup failed');
+
+    await expect(coordinator.run(async () => {
+      throw error;
+    })).rejects.toBe(error);
+    expect(coordinator.isRunning()).toBe(false);
+  });
+});
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolver => {
+    resolve = resolver;
+  });
+  return { promise, resolve };
+}

--- a/tests/unit/features/chat/tabs/TabActivationCoordinator.test.ts
+++ b/tests/unit/features/chat/tabs/TabActivationCoordinator.test.ts
@@ -1,0 +1,80 @@
+import { activateTabContent } from '@/features/chat/tabs/TabActivationCoordinator';
+
+function createTab(overrides: Record<string, unknown> = {}): any {
+  return {
+    conversationId: null,
+    hydrationState: 'idle',
+    state: { messages: [] },
+    controllers: {
+      conversationController: {
+        initializeWelcome: jest.fn(),
+        switchTo: jest.fn().mockResolvedValue(undefined),
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('activateTabContent', () => {
+  it('initializes an empty tab after workspace services are ready', async () => {
+    const tab = createTab();
+    const ensureWorkspaceServices = jest.fn().mockResolvedValue(true);
+
+    const result = await activateTabContent({
+      tab,
+      ensureWorkspaceServices,
+      isTabAlive: () => true,
+      renderHydrationState: jest.fn(),
+      waitForPaint: jest.fn().mockResolvedValue(undefined),
+      startHydrationProfile: () => null,
+    });
+
+    expect(result).toEqual({ status: 'activated' });
+    expect(ensureWorkspaceServices).toHaveBeenCalledTimes(1);
+    expect(tab.controllers.conversationController.initializeWelcome).toHaveBeenCalledTimes(1);
+    expect(tab.hydrationState).toBe('ready');
+  });
+
+  it('hydrates a conversation only after the paint boundary', async () => {
+    const tab = createTab({ conversationId: 'conversation-1' });
+    const events: string[] = [];
+    tab.controllers.conversationController.switchTo.mockImplementation(async () => {
+      events.push('switch');
+    });
+
+    const result = await activateTabContent({
+      tab,
+      ensureWorkspaceServices: jest.fn().mockResolvedValue(true),
+      isTabAlive: () => true,
+      renderHydrationState: () => events.push('render-loading'),
+      waitForPaint: async () => {
+        events.push('paint');
+      },
+      startHydrationProfile: () => ({ finish: () => events.push('profile-finished') }),
+    });
+
+    expect(result).toEqual({ status: 'activated' });
+    expect(events).toEqual(['render-loading', 'paint', 'switch', 'profile-finished']);
+    expect(tab.hydrationState).toBe('ready');
+  });
+
+  it('reports hydration errors and leaves the tab retryable', async () => {
+    const tab = createTab({ conversationId: 'conversation-1' });
+    const error = new Error('load failed');
+    tab.controllers.conversationController.switchTo.mockRejectedValue(error);
+    const renderHydrationState = jest.fn();
+
+    const result = await activateTabContent({
+      tab,
+      ensureWorkspaceServices: jest.fn().mockResolvedValue(true),
+      isTabAlive: () => true,
+      renderHydrationState,
+      waitForPaint: jest.fn().mockResolvedValue(undefined),
+      startHydrationProfile: () => null,
+    });
+
+    expect(result).toEqual({ status: 'failed', error });
+    expect(tab.hydrationState).toBe('failed');
+    expect(renderHydrationState).toHaveBeenLastCalledWith(error);
+  });
+});

--- a/tests/unit/features/chat/tabs/TabCloseCoordinator.test.ts
+++ b/tests/unit/features/chat/tabs/TabCloseCoordinator.test.ts
@@ -1,0 +1,42 @@
+import { resolveTabCloseFollowUp } from '@/features/chat/tabs/TabCloseCoordinator';
+
+describe('resolveTabCloseFollowUp', () => {
+  const base = {
+    activeTabId: 'tab-2',
+    closedTabId: 'tab-2',
+    tabIdsBeforeClose: ['tab-1', 'tab-2', 'tab-3'],
+  } as const;
+
+  it('selects the previous tab when closing a non-first active tab', () => {
+    expect(resolveTabCloseFollowUp({
+      ...base,
+      remainingTabIds: new Set(['tab-1', 'tab-3']),
+    })).toEqual({ kind: 'switch', tabId: 'tab-1' });
+  });
+
+  it('selects the next tab when closing the first active tab', () => {
+    expect(resolveTabCloseFollowUp({
+      activeTabId: 'tab-1',
+      closedTabId: 'tab-1',
+      tabIdsBeforeClose: ['tab-1', 'tab-2'],
+      remainingTabIds: new Set(['tab-2']),
+    })).toEqual({ kind: 'switch', tabId: 'tab-2' });
+  });
+
+  it('requests a replacement when the final active tab is closed', () => {
+    expect(resolveTabCloseFollowUp({
+      activeTabId: 'tab-1',
+      closedTabId: 'tab-1',
+      tabIdsBeforeClose: ['tab-1'],
+      remainingTabIds: new Set(),
+    })).toEqual({ kind: 'create' });
+  });
+
+  it('does not navigate when closing an inactive tab', () => {
+    expect(resolveTabCloseFollowUp({
+      ...base,
+      closedTabId: 'tab-1',
+      remainingTabIds: new Set(['tab-2', 'tab-3']),
+    })).toEqual({ kind: 'none' });
+  });
+});

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -221,15 +221,15 @@ describe('TabManager provider execution orchestration', () => {
     const { manager } = createManager();
     const initial = await manager.createTab();
     const managerInternals = manager as any;
-    managerInternals.isSwitchingTab = true;
+    const switching = deferred<void>();
+    void managerInternals.tabSwitchCoordinator.request('pending-tab', () => switching.promise);
 
-    const switchingIdle = managerInternals.waitForTabSwitchIdle();
+    const switchingIdle = manager.waitForTabSwitchIdle();
     await Promise.resolve();
 
     expect(manager.getActiveTabId()).toBe(initial!.id);
 
-    managerInternals.isSwitchingTab = false;
-    managerInternals.resolveTabSwitchIdleWaitersIfIdle();
+    switching.resolve();
 
     await expect(switchingIdle).resolves.toBeUndefined();
     expect(manager.getActiveTabId()).toBe(initial!.id);

--- a/tests/unit/features/chat/tabs/TabSwitchCoordinator.test.ts
+++ b/tests/unit/features/chat/tabs/TabSwitchCoordinator.test.ts
@@ -1,0 +1,55 @@
+import { TabSwitchCoordinator } from '@/features/chat/tabs/TabSwitchCoordinator';
+
+describe('TabSwitchCoordinator', () => {
+  it('coalesces overlapping requests to the latest non-current tab', async () => {
+    let currentTabId = 'tab-1';
+    let releaseFirst!: () => void;
+    const firstStarted = new Promise<void>(resolve => {
+      releaseFirst = resolve;
+    });
+    const events: string[] = [];
+    const coordinator = new TabSwitchCoordinator(tabId => tabId === currentTabId);
+    const execute = jest.fn(async (tabId: string) => {
+      events.push(`start:${tabId}`);
+      if (tabId === 'tab-2') await firstStarted;
+      currentTabId = tabId;
+      events.push(`finish:${tabId}`);
+    });
+
+    const firstRequest = coordinator.request('tab-2', execute);
+    await Promise.resolve();
+    await coordinator.request('tab-3', execute);
+    releaseFirst();
+    await firstRequest;
+
+    expect(events).toEqual([
+      'start:tab-2',
+      'finish:tab-2',
+      'start:tab-3',
+      'finish:tab-3',
+    ]);
+    expect(coordinator.getRequestRevision()).toBe(2);
+  });
+
+  it('resolves idle waiters after the queued request finishes', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    const coordinator = new TabSwitchCoordinator(() => false);
+    const request = coordinator.request('tab-1', async () => gate);
+    const idle = coordinator.waitForIdle();
+
+    let idleResolved = false;
+    void idle.then(() => {
+      idleResolved = true;
+    });
+    await Promise.resolve();
+    expect(idleResolved).toBe(false);
+
+    release();
+    await request;
+    await idle;
+    expect(idleResolved).toBe(true);
+  });
+});

--- a/tests/unit/style/components/history.test.ts
+++ b/tests/unit/style/components/history.test.ts
@@ -13,10 +13,16 @@ describe('Session history styles', () => {
     );
   });
 
-  it('keeps session and history rules inside the Oh My Claudian root', () => {
+  it('keeps history rules scoped and session metadata overlay rules global', () => {
     const css = readFileSync(path.resolve('src/style/components/history.css'), 'utf8');
+    const metadataCss = readFileSync(
+      path.resolve('src/style/session-metadata-popover.css'),
+      'utf8',
+    );
 
     expect(css).toContain('.claudian-history-container');
-    expect(css).toContain('body.theme-dark .claudian-session-metadata-popover');
+    expect(css).not.toContain('.claudian-session-metadata-popover');
+    expect(metadataCss).toContain('.claudian-session-metadata-popover');
+    expect(metadataCss).toContain('body.theme-dark .claudian-session-metadata-popover');
   });
 });


### PR DESCRIPTION
## Summary

- add a persistent dual-pane capability setting with a separate runtime toggle
- add a command and visible UI controls for switching dual-pane layout
- preserve session metadata hover cards across dual-pane rendering and restore their scoped styles
- disable the fixed command-discovery timeout when the provider owns cancellation
- prepare the plugin for version 2.2.0

## Validation

- typecheck passed
- lint passed with 5 existing sentence-case warnings
- architecture checks passed
- targeted integration/unit tests passed (219 tests)
- production build passed

The full suite has 10 pre-existing sandbox failures in `createNodeFetch.test.ts` because the environment cannot listen on `127.0.0.1` (`EPERM`).