### PR TITLE
fix: sync upstream context and rename fixes

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -898,6 +898,31 @@ export class ClaudianView extends ItemView {
       showOpenStateLabels: navigationMode === 'history',
       showOpenStateActions: navigationMode === 'history' && !isArchiveView,
       preserveListState: true,
+      showInlinePinAction: navigationMode === 'sessions',
+      onRequestInlineRename: ({ beginRename, conversationId }) => {
+        if (navigationMode === 'sessions' && this.isSessionSearchActive) {
+          this.closeSessionSearch();
+        }
+        const restoreAndRename = () => {
+          if (
+            navigationMode === 'history'
+            && (signal.aborted || this.historyDropdown !== container)
+          ) return;
+          const targetItem = Array.from(
+            container.querySelectorAll<HTMLElement>('.claudian-history-item'),
+          ).find(item => item.getAttribute('data-conversation-id') === conversationId);
+          if (!targetItem) return;
+
+          if (navigationMode === 'history') {
+            container.addClass('visible');
+          }
+          beginRename(targetItem);
+        };
+        scheduleAnimationFrame(
+          restoreAndRename,
+          container.ownerDocument.defaultView,
+        );
+      },
       sessionScope: isArchiveView ? 'archived' : 'active',
       sessionActionMode: isArchiveView ? 'archived' : 'active',
       historyHeaderLabel: isArchiveView ? 'Archived' : 'Sessions',
@@ -1961,6 +1986,7 @@ export class ClaudianView extends ItemView {
   private cancelHistoryRendering(): void {
     this.historyRenderAbortController?.abort();
     this.historyRenderAbortController = null;
+    this.historyDropdownDirty = true;
   }
 
   private cancelSessionSidebarRendering(): void {
@@ -2084,13 +2110,14 @@ export class ClaudianView extends ItemView {
         || this.isSessionSearchComposing
         || this.vaultFileTree?.isComposingSearch()
       ) return;
+      const activeTab = this.tabManager?.getActiveTab();
+      if (activeTab?.controllers.conversationController?.cancelInlineRename()) return false;
       if (this.vaultFileTree?.handleEscape(e)) return false;
       if (this.isSessionSearchActive) {
         this.closeSessionSearch();
         return false;
       }
       if (!e.defaultPrevented) {
-        const activeTab = this.tabManager?.getActiveTab();
         if (activeTab?.state.isStreaming) {
           activeTab.controllers.inputController?.cancelStreaming();
         }

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -150,6 +150,11 @@ type HistoryRenderOptions = {
   onSetConversationPinned?: (id: string, isPinned: boolean) => Promise<void>;
   onSetConversationArchived?: (id: string, isArchived: boolean) => Promise<void>;
   onBeforeRestoreListState?: (container: HTMLElement) => void;
+  onRequestInlineRename?: (request: {
+    beginRename: (item: HTMLElement) => void;
+    conversationId: string;
+  }) => void;
+  showInlinePinAction?: boolean;
 };
 
 type HistorySurfaceRenderOptions = Omit<HistoryRenderOptions, 'onRerender'> & {
@@ -157,6 +162,10 @@ type HistorySurfaceRenderOptions = Omit<HistoryRenderOptions, 'onRerender'> & {
 };
 
 export class ConversationController {
+  private activeInlineRename: {
+    cancel: () => void;
+    input: HTMLInputElement;
+  } | null = null;
   private deps: ConversationControllerDeps;
   private callbacks: ConversationCallbacks;
   private readonly historyViewport = new HistoryViewport();
@@ -727,6 +736,19 @@ export class ConversationController {
     }
   }
 
+  cancelInlineRename(): boolean {
+    const activeInlineRename = this.activeInlineRename;
+    if (!activeInlineRename) return false;
+    if (activeInlineRename.input.isConnected === false) {
+      this.activeInlineRename = null;
+      return false;
+    }
+
+    this.activeInlineRename = null;
+    activeInlineRename.cancel();
+    return true;
+  }
+
   updateHistoryDropdown(): void {
     const dropdown = this.deps.getHistoryDropdown();
     if (!dropdown) return;
@@ -749,6 +771,13 @@ export class ConversationController {
     if (options.signal?.aborted) return;
     if (options.showMetadataPopover) {
       this.closeSessionMetadataPopover();
+    }
+
+    if (
+      this.activeInlineRename
+      && container.contains(this.activeInlineRename.input)
+    ) {
+      this.activeInlineRename = null;
     }
 
     const viewportSnapshot = this.historyViewport.capture(
@@ -1324,21 +1353,23 @@ export class ConversationController {
     if (options.sessionActionMode === 'active') {
       if (!showAttentionState) {
         const isPinned = conversation.isPinned === true;
-        const pinBtn = actions.createEl('button', {
-          cls: 'claudian-action-btn claudian-pin-btn',
-        });
-        setIcon(pinBtn, isPinned ? 'pin-off' : 'pin');
-        pinBtn.setAttribute('aria-label', isPinned ? 'Unpin' : 'Pin');
-        pinBtn.addEventListener('click', (event) => {
-          event.stopPropagation();
-          runConversationAction(
-            () => this.runHistoryAction(
-              () => options.onSetConversationPinned?.(conversation.id, !isPinned),
+        if (options.showInlinePinAction !== false) {
+          const pinBtn = actions.createEl('button', {
+            cls: 'claudian-action-btn claudian-pin-btn',
+          });
+          setIcon(pinBtn, isPinned ? 'pin-off' : 'pin');
+          pinBtn.setAttribute('aria-label', isPinned ? 'Unpin' : 'Pin');
+          pinBtn.addEventListener('click', (event) => {
+            event.stopPropagation();
+            runConversationAction(
+              () => this.runHistoryAction(
+                () => options.onSetConversationPinned?.(conversation.id, !isPinned),
+                isPinned ? 'Failed to unpin session' : 'Failed to pin session',
+              ),
               isPinned ? 'Failed to unpin session' : 'Failed to pin session',
-            ),
-            isPinned ? 'Failed to unpin session' : 'Failed to pin session',
-          );
-        });
+            );
+          });
+        }
 
         const archiveBtn = actions.createEl('button', {
           cls: 'claudian-action-btn claudian-archive-btn',
@@ -1386,7 +1417,7 @@ export class ConversationController {
       renameBtn.setAttribute('aria-label', 'Rename');
       renameBtn.addEventListener('click', (event) => {
         event.stopPropagation();
-        this.showRenameInput(item, conversation.id, conversation.title, options);
+        this.showRenameEditor(item, conversation.id, conversation.title, options);
       });
       createDeleteButton();
     }
@@ -1835,6 +1866,11 @@ export class ConversationController {
     }
 
     if (options.sessionActionMode === 'active') {
+      menu.addItem((menuItem) => menuItem
+        .setTitle('Rename')
+        .onClick(() => {
+          this.showRenameEditor(item, conversationId, title, options);
+        }));
       menu.addItem((menuItem) => {
         menuItem
           .setTitle('Archive')
@@ -1848,11 +1884,6 @@ export class ConversationController {
           });
         }
       });
-      menu.addItem((menuItem) => menuItem
-        .setTitle('Rename')
-        .onClick(() => {
-          this.showRenameInput(item, conversationId, title, options);
-        }));
       menu.showAtMouseEvent(event);
       return;
     }
@@ -1860,7 +1891,7 @@ export class ConversationController {
     menu.addItem((menuItem) => menuItem
       .setTitle('Rename')
       .onClick(() => {
-        this.showRenameInput(item, conversationId, title, options);
+        this.showRenameEditor(item, conversationId, title, options);
       }));
     menu.addItem((menuItem) => menuItem
       .setTitle('Delete')
@@ -1889,6 +1920,26 @@ export class ConversationController {
     }
   }
 
+  private showRenameEditor(
+    item: HTMLElement,
+    convId: string,
+    currentTitle: string,
+    options: HistoryRenderOptions,
+  ): void {
+    const beginRename = (targetItem: HTMLElement) => {
+      this.showRenameInput(targetItem, convId, currentTitle, options);
+    };
+    if (options.onRequestInlineRename) {
+      options.onRequestInlineRename({
+        beginRename,
+        conversationId: convId,
+      });
+      return;
+    }
+
+    beginRename(item);
+  }
+
   /** Shows inline rename input for a conversation. */
   private showRenameInput(
     item: HTMLElement,
@@ -1908,17 +1959,36 @@ export class ConversationController {
     input.focus();
     input.select();
 
+    let isFinishing = false;
+    const cancelRename = () => {
+      input.value = currentTitle;
+      input.blur();
+    };
+    this.activeInlineRename = { cancel: cancelRename, input };
     const finishRename = async () => {
+      if (isFinishing) return;
+      isFinishing = true;
+      const newTitle = input.value.trim();
+      if (!newTitle || newTitle === currentTitle) {
+        isFinishing = false;
+        options.onRerender();
+        return;
+      }
+
       try {
-        const newTitle = input.value.trim() || currentTitle;
         await this.deps.plugin.renameConversation(convId, newTitle);
         options.onRerender();
       } catch {
         new Notice('Failed to rename conversation');
+      } finally {
+        isFinishing = false;
       }
     };
 
     input.addEventListener('blur', () => {
+      if (this.activeInlineRename?.input === input) {
+        this.activeInlineRename = null;
+      }
       runConversationAction(finishRename, 'Failed to rename conversation');
     });
     input.addEventListener('keydown', (e) => {
@@ -1926,8 +1996,9 @@ export class ConversationController {
       if (e.key === 'Enter' && !e.isComposing) {
         input.blur();
       } else if (e.key === 'Escape' && !e.isComposing) {
-        input.value = currentTitle;
-        input.blur();
+        e.preventDefault();
+        e.stopPropagation();
+        cancelRename();
       }
     });
   }

--- a/src/providers/claude/execution/ClaudeExecutionEventNormalizer.ts
+++ b/src/providers/claude/execution/ClaudeExecutionEventNormalizer.ts
@@ -14,7 +14,7 @@ import type {
   ProviderUserMessageStartedEvent,
   ToolExecutionScope,
 } from '../../../core/execution';
-import type { StreamChunk } from '../../../core/types';
+import type { StreamChunk, UsageInfo } from '../../../core/types';
 import { ClaudeTaskToolNormalizer } from '../normalization/ClaudeTaskToolNormalizer';
 import {
   isAsyncSubagentCompletion,
@@ -29,6 +29,7 @@ import type {
 import {
   createTransformStreamState,
   createTransformUsageState,
+  recalculateClaudeUsageContextWindow,
   transformSDKMessage,
 } from '../stream/transformClaudeMessage';
 
@@ -79,6 +80,11 @@ export type ClaudeNormalizedExecutionEvent =
     readonly providerSessionId?: string;
   }
   | {
+    readonly type: 'context_window';
+    readonly model: string;
+    readonly contextWindow: number;
+  }
+  | {
     readonly type: 'result';
   };
 
@@ -95,6 +101,7 @@ interface NormalizationState {
   readonly usageState: ReturnType<typeof createTransformUsageState>;
   readonly toolScopes: Map<string, ToolIdentity>;
   readonly blockedToolIds: Set<string>;
+  lastUsage: UsageInfo | null;
   assistantStarted: boolean;
   sawStreamText: boolean;
   sawStreamThinking: boolean;
@@ -115,6 +122,7 @@ export class ClaudeExecutionEventNormalizer {
     options: {
       readonly intendedModel?: string;
       readonly customContextLimits?: Record<string, number>;
+      readonly authoritativeContextWindow?: number;
     } = {},
   ): ClaudeNormalizedExecutionEvent[] {
     const state = this.states[channel];
@@ -139,6 +147,34 @@ export class ClaudeExecutionEventNormalizer {
         continue;
       }
       if (isContextWindowEvent(event)) {
+        const model = options.intendedModel ?? state.lastUsage?.model ?? 'sonnet';
+        const authoritativeContextWindow = isFinitePositiveNumber(
+          options.authoritativeContextWindow,
+        )
+          ? options.authoritativeContextWindow
+          : undefined;
+        if (authoritativeContextWindow === undefined) {
+          normalized.push({
+            type: 'context_window',
+            model,
+            contextWindow: event.contextWindow,
+          });
+        }
+        const correctedUsage = this.updateContextWindow(
+          channel,
+          model,
+          options.customContextLimits,
+          authoritativeContextWindow ?? event.contextWindow,
+        );
+        if (correctedUsage) {
+          normalized.push({
+            type: 'output',
+            event: {
+              type: 'usage_updated',
+              usage: correctedUsage,
+            },
+          });
+        }
         continue;
       }
       if (isStreamChunk(event)) {
@@ -160,6 +196,28 @@ export class ClaudeExecutionEventNormalizer {
     return normalized;
   }
 
+  updateContextWindow(
+    channel: ClaudeExecutionEventChannel,
+    model: string,
+    customContextLimits: Record<string, number> | undefined,
+    runtimeContextWindow: number,
+  ): UsageInfo | null {
+    const state = this.states[channel];
+    if (!state.lastUsage || state.lastUsage.model !== model) {
+      return null;
+    }
+    const correctedUsage = recalculateClaudeUsageContextWindow(
+      state.lastUsage,
+      customContextLimits,
+      runtimeContextWindow,
+    );
+    if (sameUsageWindow(state.lastUsage, correctedUsage)) {
+      return null;
+    }
+    state.lastUsage = correctedUsage;
+    return correctedUsage;
+  }
+
   markToolBlocked(
     toolUseId: string,
     channel: ClaudeExecutionEventChannel,
@@ -174,6 +232,7 @@ export class ClaudeExecutionEventNormalizer {
     state.usageState.clear();
     state.toolScopes.clear();
     state.blockedToolIds.clear();
+    state.lastUsage = null;
     state.assistantStarted = false;
     state.sawStreamText = false;
     state.sawStreamThinking = false;
@@ -258,6 +317,7 @@ function createNormalizationState(): NormalizationState {
     usageState: createTransformUsageState(),
     toolScopes: new Map(),
     blockedToolIds: new Set(),
+    lastUsage: null,
     assistantStarted: false,
     sawStreamText: false,
     sawStreamThinking: false,
@@ -353,6 +413,7 @@ function toOutputEvent(
       };
     }
     case 'usage':
+      state.lastUsage = chunk.usage;
       return {
         type: 'usage_updated',
         usage: chunk.usage,
@@ -368,6 +429,16 @@ function toOutputEvent(
         level: chunk.level,
       };
   }
+}
+
+function sameUsageWindow(current: UsageInfo, next: UsageInfo): boolean {
+  return current.contextWindow === next.contextWindow
+    && current.contextWindowIsAuthoritative === next.contextWindowIsAuthoritative
+    && current.percentage === next.percentage;
+}
+
+function isFinitePositiveNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
 }
 
 function normalizeToolStarted(

--- a/src/providers/claude/execution/ClaudeExecutionSession.ts
+++ b/src/providers/claude/execution/ClaudeExecutionSession.ts
@@ -114,6 +114,11 @@ ClaudeExecutionStrategySink {
   private lastAllowedTools: ReadonlySet<string> | null = null;
   private currentPermissionMode: PermissionMode;
   private readonly eventNormalizer = new ClaudeExecutionEventNormalizer();
+  private nativeQuery: Query | null = null;
+  private authoritativeContextWindow: {
+    readonly model: string;
+    readonly contextWindow: number;
+  } | null = null;
 
   constructor(
     private readonly host: ProviderHost,
@@ -455,12 +460,18 @@ ClaudeExecutionStrategySink {
     }
 
     const active = this.activeRun;
+    const intendedModel = this.lastEncodedRequest?.model;
+    const authoritativeContextWindow = intendedModel
+      && this.authoritativeContextWindow?.model === intendedModel
+      ? this.authoritativeContextWindow.contextWindow
+      : undefined;
     const normalizedEvents = this.eventNormalizer.normalize(
       message,
       active ? 'requested' : 'background',
       {
         intendedModel: this.lastEncodedRequest?.model,
         customContextLimits: this.host.settings.customContextLimits,
+        authoritativeContextWindow,
       },
     );
     if (
@@ -556,6 +567,13 @@ ClaudeExecutionStrategySink {
           this.finishBackgroundTurn('provider-ended');
         }
         return;
+      }
+      if (normalized.type === 'context_window') {
+        this.authoritativeContextWindow = {
+          model: normalized.model,
+          contextWindow: normalized.contextWindow,
+        };
+        continue;
       }
       if (normalized.type === 'result') {
         if (this.activeRun) {
@@ -671,6 +689,52 @@ ClaudeExecutionStrategySink {
 
   releaseNativeTurnFence(queryToken: number): void {
     this.suppressedEphemeralQueryTokens.delete(queryToken);
+  }
+
+  handleNativeQueryOpened(query: Query): void {
+    if (this.nativeQuery === query) return;
+    this.nativeQuery = query;
+    this.authoritativeContextWindow = null;
+  }
+
+  handleNativeQueryClosed(query: Query): void {
+    if (this.nativeQuery !== query) return;
+    this.nativeQuery = null;
+    this.authoritativeContextWindow = null;
+  }
+
+  handleAuthoritativeContextWindow(
+    query: Query,
+    model: string,
+    contextWindow: number,
+  ): void {
+    if (
+      this.nativeQuery !== query
+      || !Number.isFinite(contextWindow)
+      || contextWindow <= 0
+    ) {
+      return;
+    }
+    this.authoritativeContextWindow = { model, contextWindow };
+    const channel = this.activeRun
+      ? 'requested'
+      : this.backgroundTurn
+        ? 'background'
+        : null;
+    if (!channel) return;
+    const correctedUsage = this.eventNormalizer.updateContextWindow(
+      channel,
+      model,
+      this.host.settings.customContextLimits,
+      contextWindow,
+    );
+    const target = this.activeRun ?? this.backgroundTurn;
+    if (correctedUsage && target) {
+      this.emitTurnOutput(target, {
+        type: 'usage_updated',
+        usage: correctedUsage,
+      });
+    }
   }
 
   private async startExecution(

--- a/src/providers/claude/execution/ClaudeExecutionStrategies.ts
+++ b/src/providers/claude/execution/ClaudeExecutionStrategies.ts
@@ -23,6 +23,13 @@ export interface ClaudeExecutionStrategySink {
   handleNativeFailure(error: unknown, queryToken: number): void;
   handleNativeEnd(queryToken: number): void;
   releaseNativeTurnFence(queryToken: number): void;
+  handleNativeQueryOpened(query: Query): void;
+  handleNativeQueryClosed(query: Query): void;
+  handleAuthoritativeContextWindow(
+    query: Query,
+    model: string,
+    contextWindow: number,
+  ): void;
   publishCommands(query: Query, queryToken: number): void;
 }
 
@@ -60,6 +67,16 @@ implements ClaudeExecutionStrategy {
   private consumerPromise: Promise<void> | null = null;
   private currentConfig: ClaudeEncodedExecutionRequest | null = null;
   private activeNativeTurn: PersistentNativeTurn | null = null;
+  private authoritativeContextWindow: {
+    readonly query: Query;
+    readonly model: string;
+    readonly contextWindow: number;
+  } | null = null;
+  private contextWindowDiscovery: {
+    readonly query: Query;
+    readonly model: string;
+    readonly promise: Promise<void>;
+  } | null = null;
   private preparingTurnToken: number | null = null;
   private disposed = false;
 
@@ -90,6 +107,7 @@ implements ClaudeExecutionStrategy {
 
       await this.applyDynamicUpdates(request);
       requestSignal?.throwIfAborted();
+      void this.refreshAuthoritativeContextWindow(request.model);
       const message = buildClaudeSDKUserMessage(
         request.prompt,
         this.sink.getProviderSessionId() ?? '',
@@ -162,7 +180,10 @@ implements ClaudeExecutionStrategy {
     this.query = null;
     this.messageChannel = null;
     this.abortController = null;
+    this.authoritativeContextWindow = null;
+    this.contextWindowDiscovery = null;
     if (query) {
+      this.sink.handleNativeQueryClosed(query);
       this.finishNativeTurn(query, {
         type: 'failed',
         error: new Error('Claude persistent query was disposed.'),
@@ -217,6 +238,9 @@ implements ClaudeExecutionStrategy {
     this.messageChannel = messageChannel;
     this.query = query;
     this.currentConfig = request;
+    this.authoritativeContextWindow = null;
+    this.contextWindowDiscovery = null;
+    this.sink.handleNativeQueryOpened(query);
     this.consumerPromise = this.consume(query, queryToken);
   }
 
@@ -246,6 +270,62 @@ implements ClaudeExecutionStrategy {
       if (this.query !== query || this.disposed) return;
     }
     this.currentConfig = request;
+  }
+
+  private refreshAuthoritativeContextWindow(model: string): Promise<void> {
+    const query = this.query;
+    if (!query || typeof query.getContextUsage !== 'function') {
+      return Promise.resolve();
+    }
+    if (
+      this.authoritativeContextWindow?.query === query
+      && this.authoritativeContextWindow.model === model
+    ) {
+      return Promise.resolve();
+    }
+    if (
+      this.contextWindowDiscovery?.query === query
+      && this.contextWindowDiscovery.model === model
+    ) {
+      return this.contextWindowDiscovery.promise;
+    }
+
+    let request: ReturnType<Query['getContextUsage']>;
+    try {
+      request = query.getContextUsage();
+    } catch {
+      return Promise.resolve();
+    }
+    const promise = request
+      .then((contextUsage) => {
+        if (
+          this.query !== query
+          || this.currentConfig?.model !== model
+          || this.disposed
+        ) {
+          return;
+        }
+        const contextWindow = contextUsage.rawMaxTokens;
+        if (!isFinitePositiveNumber(contextWindow)) {
+          return;
+        }
+        this.authoritativeContextWindow = { query, model, contextWindow };
+        this.sink.handleAuthoritativeContextWindow(
+          query,
+          model,
+          contextWindow,
+        );
+      })
+      .catch(() => {
+        // Result model metadata remains the fallback when control discovery fails.
+      })
+      .finally(() => {
+        if (this.contextWindowDiscovery?.promise === promise) {
+          this.contextWindowDiscovery = null;
+        }
+      });
+    this.contextWindowDiscovery = { query, model, promise };
+    return promise;
   }
 
   private async consume(query: Query, queryToken: number): Promise<void> {
@@ -331,6 +411,9 @@ implements ClaudeExecutionStrategy {
     this.messageChannel = null;
     this.abortController = null;
     this.currentConfig = null;
+    this.authoritativeContextWindow = null;
+    this.contextWindowDiscovery = null;
+    this.sink.handleNativeQueryClosed(query);
   }
 }
 
@@ -386,6 +469,7 @@ implements ClaudeExecutionStrategy {
         onQuery: (openedQuery) => {
           query = openedQuery;
           this.activeQuery = openedQuery;
+          this.sink.handleNativeQueryOpened(openedQuery);
           this.sink.markNativeTurnHandedOff(queryToken);
         },
         onMessage: async (message) => {
@@ -414,6 +498,9 @@ implements ClaudeExecutionStrategy {
       }
     } finally {
       if (!query || this.activeQuery === query) {
+        if (query) {
+          this.sink.handleNativeQueryClosed(query);
+        }
         this.activeQuery = null;
         this.activeAbortController = null;
       }
@@ -449,10 +536,15 @@ implements ClaudeExecutionStrategy {
     this.activeAbortController = null;
     this.activeQuery = null;
     if (query) {
+      this.sink.handleNativeQueryClosed(query);
       await query.interrupt().catch(() => undefined);
     }
     await this.turnBarrier.catch(() => undefined);
   }
+}
+
+function isFinitePositiveNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
 }
 
 async function* toSingleMessagePrompt(

--- a/src/providers/claude/stream/transformClaudeMessage.ts
+++ b/src/providers/claude/stream/transformClaudeMessage.ts
@@ -327,24 +327,39 @@ function samePromptUsage(a: PromptUsageSnapshot, b: PromptUsageSnapshot): boolea
 
 function buildUsageInfo(promptUsage: PromptUsageSnapshot, options?: TransformOptions): UsageInfo {
   const model = options?.intendedModel ?? 'sonnet';
-  const contextWindowResolution = resolveContextWindowSize(
-    model,
-    options?.customContextLimits,
-    options?.authoritativeContextWindow,
-  );
-  const { contextWindow } = contextWindowResolution;
-  const percentage = Math.min(100, Math.max(0, Math.round((promptUsage.contextTokens / contextWindow) * 100)));
-
-  return {
+  return recalculateClaudeUsageContextWindow({
     model,
     inputTokens: promptUsage.inputTokens,
     cacheCreationInputTokens: promptUsage.cacheCreationInputTokens,
     cacheReadInputTokens: promptUsage.cacheReadInputTokens,
-    contextWindow,
-    ...(contextWindowResolution.source === 'runtime' ? { contextWindowIsAuthoritative: true } : {}),
+    contextWindow: 0,
     contextTokens: promptUsage.contextTokens,
-    percentage,
+    percentage: 0,
+  }, options?.customContextLimits, options?.authoritativeContextWindow);
+}
+
+export function recalculateClaudeUsageContextWindow(
+  usage: UsageInfo,
+  customContextLimits?: Record<string, number>,
+  runtimeContextWindow?: number,
+): UsageInfo {
+  const contextWindowResolution = resolveContextWindowSize(
+    usage.model ?? 'sonnet',
+    customContextLimits,
+    runtimeContextWindow,
+  );
+  const { contextWindow } = contextWindowResolution;
+  const nextUsage: UsageInfo = {
+    ...usage,
+    contextWindow,
+    percentage: Math.min(100, Math.max(0, Math.round((usage.contextTokens / contextWindow) * 100))),
   };
+  if (contextWindowResolution.source === 'runtime') {
+    nextUsage.contextWindowIsAuthoritative = true;
+  } else {
+    delete nextUsage.contextWindowIsAuthoritative;
+  }
+  return nextUsage;
 }
 
 export function createTransformUsageState(): TransformUsageState {
@@ -597,14 +612,6 @@ export function* transformSDKMessage(
         }
         options.usageState.clear();
       }
-      if (isResultError(message)) {
-        const content = message.errors.filter((e) => e.trim().length > 0).join('\n');
-        yield {
-          type: 'error',
-          content: content || `Result error: ${message.subtype}`,
-        };
-      }
-
       // Usage is now extracted from assistant messages for accuracy (excludes subagent tokens)
       // Result message usage is aggregated across main + subagents, causing inaccurate spikes
 
@@ -614,6 +621,13 @@ export function* transformSDKMessage(
         if (selectedEntry) {
           yield { type: 'context_window', contextWindow: selectedEntry.contextWindow };
         }
+      }
+      if (isResultError(message)) {
+        const content = message.errors.filter((e) => e.trim().length > 0).join('\n');
+        yield {
+          type: 'error',
+          content: content || `Result error: ${message.subtype}`,
+        };
       }
       break;
 

--- a/src/style/AGENTS.md
+++ b/src/style/AGENTS.md
@@ -38,6 +38,27 @@ Choose a folder by UI ownership, not by the screen where a selector happens to a
 - Use Obsidian CSS variables such as `--background-*`, `--text-*`, and `--interactive-*`.
 - Use `var(--font-monospace)` for code blocks.
 
+## Specific Element Rules
+
+Every Claudian-owned instance of an element listed below must use its required base pattern. A departure is allowed only through an explicit semantic or surface modifier; selector order, nesting, and inherited Obsidian styles are not exceptions.
+
+### Buttons
+
+- All buttons use `border: 0`, `background: transparent`, `box-shadow: none`, and `color: var(--text-muted)` at rest.
+- Hover and `focus-visible` use `color: var(--text-normal)` while retaining no border, transparent background, and no box shadow. Filled hover or focus surfaces require an explicit modifier.
+- Disabled buttons use `color: var(--text-faint)` and `cursor: default`, and must not retain hover, focus, or active emphasis.
+- Button SVGs inherit `currentColor`; their width and height are declared by the button's base selector. Different icon sizing requires an explicit modifier.
+- Apply the complete base pattern to the Claudian button class and its hover, focus, active, and disabled selectors so Obsidian cannot restore native button chrome in any state.
+
+### Inputs and Textareas
+
+- All standalone inputs and textareas use `min-width: 0`, `border: 1px solid var(--background-modifier-border)`, `background: var(--background-modifier-form-field)`, `box-shadow: none`, `color: var(--text-normal)`, and the inherited UI font.
+- Hover retains the base border, background, and box shadow. Focus uses `outline: none` and `border-color: var(--interactive-accent)` without introducing a browser or Obsidian box shadow.
+- Placeholders use `color: var(--text-muted)`. Disabled controls use `color: var(--text-faint)` and `cursor: default`.
+- An input or textarea embedded in a wrapper uses `border: 0`, `background: transparent`, and `box-shadow: none` in every interaction state; the wrapper alone owns the border, background, radius, and focus treatment.
+- Textareas use `resize: none` and `overflow-y: auto` by default. A resizable textarea requires an explicit modifier and bounded sizing.
+- Error, warning, read-only, and semantic-mode treatments require explicit modifiers or scoped custom properties; they must override every affected interaction state.
+
 ## Gotchas
 
 - Obsidian uses `body.theme-dark` and `body.theme-light` for theme detection.

--- a/src/style/components/history.css
+++ b/src/style/components/history.css
@@ -736,6 +736,22 @@
   color: var(--interactive-accent);
 }
 
+.claudian-history-menu .claudian-history-item-actions .claudian-action-btn {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  color: var(--text-muted);
+  transition: color 0.15s ease;
+}
+
+.claudian-history-menu .claudian-history-item-actions .claudian-action-btn:hover,
+.claudian-history-menu .claudian-history-item-actions .claudian-action-btn:focus-visible {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  color: var(--text-normal);
+}
+
 .claudian-rename-input {
   width: 100%;
   padding: 2px 4px;

--- a/tests/__mocks__/claude-agent-sdk.ts
+++ b/tests/__mocks__/claude-agent-sdk.ts
@@ -124,6 +124,8 @@ let mockSupportedCommandsImplementation: (() => Promise<Array<{
   description: string;
   argumentHint?: string;
 }>>) | null = null;
+let mockContextUsage: { rawMaxTokens: number } | null = null;
+let mockContextUsageImplementation: (() => Promise<{ rawMaxTokens: number }>) | null = null;
 let lastResponse: (AsyncGenerator<any> & {
   interrupt: jest.Mock;
   setModel: jest.Mock;
@@ -132,6 +134,7 @@ let lastResponse: (AsyncGenerator<any> & {
   applyFlagSettings: jest.Mock;
   setMcpServers: jest.Mock;
   supportedCommands: jest.Mock;
+  getContextUsage: jest.Mock;
 }) | null = null;
 
 // Crash simulation control
@@ -151,6 +154,8 @@ export function resetMockMessages() {
   lastOptions = undefined;
   mockSupportedCommands = [];
   mockSupportedCommandsImplementation = null;
+  mockContextUsage = null;
+  mockContextUsageImplementation = null;
   lastResponse = null;
   shouldThrowOnIteration = false;
   throwAfterChunks = 0;
@@ -171,6 +176,16 @@ export function setMockSupportedCommandsImplementation(
   }>>,
 ) {
   mockSupportedCommandsImplementation = implementation;
+}
+
+export function setMockContextUsage(contextUsage: { rawMaxTokens: number } | null) {
+  mockContextUsage = contextUsage;
+}
+
+export function setMockContextUsageImplementation(
+  implementation: (() => Promise<{ rawMaxTokens: number }>) | null,
+) {
+  mockContextUsageImplementation = implementation;
 }
 
 /**
@@ -243,7 +258,8 @@ function getMessagesForPrompt(): any[] {
 async function* emitMessages(messages: any[], options: Options) {
   let chunksEmitted = 0;
 
-  for (const msg of messages) {
+  for (const pendingMessage of messages) {
+    const msg = await pendingMessage;
     // Check if we should throw (crash simulation)
     if (shouldThrowOnIteration && chunksEmitted >= throwAfterChunks) {
       // Reset for next query (allows recovery to work)
@@ -318,6 +334,7 @@ export function query({ prompt, options }: { prompt: any; options: Options }): A
     applyFlagSettings: jest.Mock;
     setMcpServers: jest.Mock;
     supportedCommands: jest.Mock;
+    getContextUsage: jest.Mock;
   };
   gen.interrupt = jest.fn().mockResolvedValue(undefined);
   // Dynamic update methods for persistent queries
@@ -330,6 +347,13 @@ export function query({ prompt, options }: { prompt: any; options: Options }): A
     mockSupportedCommandsImplementation
       ? mockSupportedCommandsImplementation()
       : Promise.resolve(mockSupportedCommands)
+  ));
+  gen.getContextUsage = jest.fn().mockImplementation(() => (
+    mockContextUsageImplementation
+      ? mockContextUsageImplementation()
+      : mockContextUsage
+      ? Promise.resolve(mockContextUsage)
+      : Promise.reject(new Error('Context usage unavailable'))
   ));
   lastResponse = gen;
 

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -658,10 +658,17 @@ describe('ClaudianView tab controls', () => {
 
   it('keeps tab-aware navigation on the single-mode history surface', () => {
     const container = createMockEl();
+    const ownerRequestAnimationFrame = jest.fn((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    container.ownerDocument.defaultView.requestAnimationFrame = ownerRequestAnimationFrame;
+    const globalRequestAnimationFrame = jest.spyOn(window, 'requestAnimationFrame');
     const renderHistoryDropdown = jest.fn();
     const view = Object.create(ClaudianView.prototype) as any;
     Object.assign(view, {
       isArchiveSessionView: false,
+      historyDropdown: container,
       openHistoryConversation: jest.fn(),
       openHistoryConversationInNewTab: jest.fn(),
       getHistoryConversationStatus: jest.fn(),
@@ -681,10 +688,25 @@ describe('ClaudianView tab controls', () => {
     const options = renderHistoryDropdown.mock.calls[0]?.[1];
     expect(options.showOpenStateLabels).toBe(true);
     expect(options.showOpenStateActions).toBe(true);
+    expect(options.showInlinePinAction).toBe(false);
+    expect(options.onRequestInlineRename).toEqual(expect.any(Function));
     expect(options.onOpenConversationInNewTab).toEqual(expect.any(Function));
     expect(options.onBeforeRestoreListState).toEqual(expect.any(Function));
     expect(options).not.toHaveProperty('organization');
     expect(options).not.toHaveProperty('showMetadataPopover');
+
+    const beginRename = jest.fn();
+    const targetItem = container.createDiv({ cls: 'claudian-history-item' });
+    targetItem.setAttribute('data-conversation-id', 'conversation-1');
+    options.onRequestInlineRename({
+      beginRename,
+      conversationId: 'conversation-1',
+    });
+    expect(container.hasClass('visible')).toBe(true);
+    expect(beginRename).toHaveBeenCalledWith(targetItem);
+    expect(ownerRequestAnimationFrame).toHaveBeenCalledTimes(1);
+    expect(globalRequestAnimationFrame).not.toHaveBeenCalled();
+    globalRequestAnimationFrame.mockRestore();
   });
 
   it('collapses and expands every linked-note group from the session header', () => {
@@ -1070,12 +1092,20 @@ describe('ClaudianView tab controls', () => {
     view.updateHistoryDropdown();
 
     expect(renderHistoryDropdown).toHaveBeenCalledTimes(2);
+    const secondRenderSignal = renderHistoryDropdown.mock.calls[1][1].signal as AbortSignal;
 
     view.toggleHistoryDropdown();
     expect(firstRenderSignal.aborted).toBe(true);
+    expect(secondRenderSignal.aborted).toBe(true);
     view.updateHistoryDropdown();
 
     expect(renderHistoryDropdown).toHaveBeenCalledTimes(2);
+
+    view.toggleHistoryDropdown();
+
+    expect(renderHistoryDropdown).toHaveBeenCalledTimes(3);
+    const reopenedSignal = renderHistoryDropdown.mock.calls[2][1].signal as AbortSignal;
+    expect(reopenedSignal.aborted).toBe(false);
   });
 
   it('builds the persistent session column to the right of the chat panel', () => {
@@ -1842,10 +1872,12 @@ describe('ClaudianView tab controls', () => {
         getProviderIcon: expect.any(Function),
         getModelLabel: expect.any(Function),
         onRerender: expect.any(Function),
+        onRequestInlineRename: expect.any(Function),
         onSelectConversation: expect.any(Function),
         preserveListState: true,
         searchQuery: 'roadmap',
         showAttentionState: true,
+        showInlinePinAction: true,
         showOpenStateActions: false,
         showOpenStateLabels: false,
         showMetadataPopover: true,
@@ -1897,6 +1929,31 @@ describe('ClaudianView tab controls', () => {
         collapsedGroupKeys: expect.any(Set),
       }),
     );
+
+    const ownerRequestAnimationFrame = jest.fn((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    sessionSidebarEl.ownerDocument.defaultView.requestAnimationFrame = ownerRequestAnimationFrame;
+    let replacementItem: ReturnType<typeof createMockEl> | null = null;
+    view.isArchiveSessionView = false;
+    view.isSessionSearchActive = true;
+    view.closeSessionSearch = jest.fn(() => {
+      view.isSessionSearchActive = false;
+      sessionSidebarEl.empty();
+      replacementItem = sessionSidebarEl.createDiv({ cls: 'claudian-history-item' });
+      replacementItem.setAttribute('data-conversation-id', 'conversation-1');
+    });
+    const beginRename = jest.fn();
+
+    sessionOptions.onRequestInlineRename({
+      beginRename,
+      conversationId: 'conversation-1',
+    });
+
+    expect(view.closeSessionSearch).toHaveBeenCalledTimes(1);
+    expect(ownerRequestAnimationFrame).toHaveBeenCalledTimes(1);
+    expect(beginRename).toHaveBeenCalledWith(replacementItem);
   });
 
   it('projects local and cross-view runtime attention into session status', () => {
@@ -2489,10 +2546,12 @@ describe('ClaudianView Escape handling', () => {
   function createEscapeHarness(options: {
     isStreaming: boolean;
   }): {
+    cancelInlineRename: jest.Mock;
     cancelStreaming: jest.Mock;
     eventRefs: unknown[];
     view: any;
   } {
+    const cancelInlineRename = jest.fn().mockReturnValue(false);
     const cancelStreaming = jest.fn();
     const eventRefs: unknown[] = [];
     const parentScope = new Scope();
@@ -2526,6 +2585,7 @@ describe('ClaudianView Escape handling', () => {
       getActiveTab: jest.fn().mockReturnValue({
         state: { isStreaming: options.isStreaming },
         controllers: {
+          conversationController: { cancelInlineRename },
           inputController: { cancelStreaming },
         },
         ui: {
@@ -2539,7 +2599,7 @@ describe('ClaudianView Escape handling', () => {
       }),
     };
 
-    return { cancelStreaming, eventRefs, view };
+    return { cancelInlineRename, cancelStreaming, eventRefs, view };
   }
 
   function createScopedSendHarness(options: {
@@ -2638,6 +2698,24 @@ describe('ClaudianView Escape handling', () => {
     const escapeHandler = view.scope.handlers.find((handler: any) => handler.key === 'Escape');
     const result = escapeHandler.func({ key: 'Escape', isComposing: false } as KeyboardEvent);
 
+    expect(cancelStreaming).not.toHaveBeenCalled();
+    expect(result).toBe(false);
+  });
+
+  it('exits inline rename before handling other scoped Escape actions', () => {
+    const { cancelInlineRename, cancelStreaming, view } = createEscapeHarness({
+      isStreaming: true,
+    });
+    cancelInlineRename.mockReturnValue(true);
+    view.closeSessionSearch = jest.fn();
+    view.isSessionSearchActive = true;
+
+    view.wireEventHandlers();
+    const escapeHandler = view.scope.handlers.find((handler: any) => handler.key === 'Escape');
+    const result = escapeHandler.func({ key: 'Escape', isComposing: false } as KeyboardEvent);
+
+    expect(cancelInlineRename).toHaveBeenCalledTimes(1);
+    expect(view.closeSessionSearch).not.toHaveBeenCalled();
     expect(cancelStreaming).not.toHaveBeenCalled();
     expect(result).toBe(false);
   });

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -2619,6 +2619,40 @@ describe('ConversationController', () => {
         expect(onSetConversationPinned).toHaveBeenCalledWith('pinned', false);
       });
 
+      it('hides the inline pin action without removing the context-menu action', () => {
+        const container = createMockEl();
+        (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+          { id: 'active', title: 'Active', createdAt: 2 },
+        ]);
+
+        controller.renderHistoryDropdown(container, {
+          onSelectConversation: jest.fn(),
+          onSetConversationArchived: jest.fn().mockResolvedValue(undefined),
+          onSetConversationPinned: jest.fn().mockResolvedValue(undefined),
+          sessionActionMode: 'active',
+          showInlinePinAction: false,
+          showOpenStateActions: false,
+        });
+
+        const item = container.querySelector('.claudian-history-item')!;
+        expect(item.querySelector('.claudian-pin-btn')).toBeNull();
+        expect(item.querySelector('.claudian-archive-btn')).not.toBeNull();
+
+        item.dispatchEvent({
+          type: 'contextmenu',
+          stopPropagation: jest.fn(),
+          preventDefault: jest.fn(),
+        });
+        const menu = (Menu as typeof Menu & {
+          instances: Array<{ items: Array<{ title: string }> }>;
+        }).instances.at(-1)!;
+        expect(menu.items.map(menuItem => menuItem.title)).toEqual([
+          'Pin',
+          'Rename',
+          'Archive',
+        ]);
+      });
+
       it('keeps rename in the active context menu and delete in Archived only', () => {
         const activeContainer = createMockEl();
         (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
@@ -2645,7 +2679,7 @@ describe('ConversationController', () => {
           }>;
         }).instances.at(-1)!;
         expect(menu.useNativeMenu).toBe(false);
-        expect(menu.items.map(item => item.title)).toEqual(['Pin', 'Archive', 'Rename']);
+        expect(menu.items.map(item => item.title)).toEqual(['Pin', 'Rename', 'Archive']);
 
         const archivedContainer = createMockEl();
         (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
@@ -2672,6 +2706,60 @@ describe('ConversationController', () => {
         }).instances.at(-1)!;
         expect(menu.useNativeMenu).toBe(false);
         expect(menu.items.map(item => item.title)).toEqual(['Restore', 'Delete']);
+      });
+
+      it('defers inline rename until the transient history surface is restored', async () => {
+        const container = createMockEl();
+        const onRerender = jest.fn();
+        const onRequestInlineRename = jest.fn();
+        (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+          { id: 'active', title: 'Original title', createdAt: 2 },
+        ]);
+
+        controller.renderHistoryDropdown(container, {
+          onSelectConversation: jest.fn(),
+          onRerender,
+          onRequestInlineRename,
+          sessionActionMode: 'active',
+          showOpenStateActions: true,
+        });
+
+        const item = container.querySelector('.claudian-history-item')!;
+        const title = item.querySelector('.claudian-history-item-title')!;
+        title.replaceWith = jest.fn();
+        item.dispatchEvent({
+          type: 'contextmenu',
+          stopPropagation: jest.fn(),
+          preventDefault: jest.fn(),
+        });
+
+        const menu = (Menu as typeof Menu & {
+          instances: Array<{
+            items: Array<{ title: string; clickHandler: (() => void) | null }>;
+          }>;
+        }).instances.at(-1)!;
+        menu.items.find(menuItem => menuItem.title === 'Rename')?.clickHandler?.();
+
+        expect(title.replaceWith).not.toHaveBeenCalled();
+        expect(item.querySelector('.claudian-rename-input')).toBeNull();
+        expect(onRequestInlineRename).toHaveBeenCalledWith({
+          beginRename: expect.any(Function),
+          conversationId: 'active',
+        });
+
+        onRequestInlineRename.mock.calls[0][0].beginRename(item);
+        const input = item.querySelector('.claudian-rename-input')!;
+        expect(title.replaceWith).toHaveBeenCalledWith(input);
+        input.value = 'Renamed title';
+        input.blur();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(deps.plugin.renameConversation).toHaveBeenCalledWith(
+          'active',
+          'Renamed title',
+        );
+        expect(onRerender).toHaveBeenCalledTimes(1);
       });
     });
   });
@@ -2811,6 +2899,83 @@ describe('ConversationController', () => {
 
       expect(deps.plugin.renameConversation).toHaveBeenCalledWith('conv-1', 'New title');
       expect(onRerender).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not persist an unchanged inline rename', async () => {
+      const container = createMockEl();
+      const onRerender = jest.fn();
+      (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+        { id: 'conv-1', title: 'Original title', createdAt: 1000 },
+      ]);
+
+      controller.renderHistoryDropdown(container, {
+        onSelectConversation: jest.fn(),
+        onRerender,
+      });
+
+      const item = container.querySelector('.claudian-history-item')!;
+      const title = item.querySelector('.claudian-history-item-title')!;
+      title.replaceWith = jest.fn();
+      item.querySelector('.claudian-history-item-actions')!.children[0].click();
+      const input = item.querySelector('.claudian-rename-input')!;
+      input.value = '  Original title  ';
+      input.blur();
+      await Promise.resolve();
+
+      expect(deps.plugin.renameConversation).not.toHaveBeenCalled();
+      expect(onRerender).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancels the active inline rename without persisting the draft', async () => {
+      const container = createMockEl();
+      const onRerender = jest.fn();
+      (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+        { id: 'conv-1', title: 'Original title', createdAt: 1000 },
+      ]);
+
+      controller.renderHistoryDropdown(container, {
+        onSelectConversation: jest.fn(),
+        onRerender,
+      });
+
+      const item = container.querySelector('.claudian-history-item')!;
+      const title = item.querySelector('.claudian-history-item-title')!;
+      title.replaceWith = jest.fn();
+      item.querySelector('.claudian-history-item-actions')!.children[0].click();
+      const input = item.querySelector('.claudian-rename-input')!;
+      input.value = 'Unsaved title';
+
+      expect(controller.cancelInlineRename()).toBe(true);
+      await Promise.resolve();
+
+      expect(input.value).toBe('Original title');
+      expect(deps.plugin.renameConversation).not.toHaveBeenCalled();
+      expect(onRerender).toHaveBeenCalledTimes(1);
+      expect(controller.cancelInlineRename()).toBe(false);
+    });
+
+    it('releases inline rename ownership when its surface rerenders without blur', () => {
+      const container = createMockEl();
+      const options = {
+        onSelectConversation: jest.fn(),
+        onRerender: jest.fn(),
+      };
+      (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+        { id: 'conv-1', title: 'Original title', createdAt: 1000 },
+      ]);
+
+      controller.renderHistoryDropdown(container, options);
+      const item = container.querySelector('.claudian-history-item')!;
+      const title = item.querySelector('.claudian-history-item-title')!;
+      title.replaceWith = jest.fn();
+      item.querySelector('.claudian-history-item-actions')!.children[0].click();
+      const input = item.querySelector('.claudian-rename-input')!;
+      input.value = 'Detached draft';
+
+      controller.renderHistoryDropdown(container, options);
+
+      expect(controller.cancelInlineRename()).toBe(false);
+      expect(deps.plugin.renameConversation).not.toHaveBeenCalled();
     });
 
     it('should delete conversation and reload active when deleting current conversation', async () => {

--- a/tests/unit/providers/claude/execution/ClaudeExecutionBackend.test.ts
+++ b/tests/unit/providers/claude/execution/ClaudeExecutionBackend.test.ts
@@ -27,6 +27,7 @@ const sdkMock = sdkModule as unknown as {
     setPermissionMode: jest.Mock;
     setMcpServers: jest.Mock;
     supportedCommands: jest.Mock;
+    getContextUsage: jest.Mock;
   } | null;
   getQueryCallCount: () => number;
   resetMockMessages: () => void;
@@ -40,6 +41,12 @@ const sdkMock = sdkModule as unknown as {
       description: string;
       argumentHint?: string;
     }>,
+  ) => void;
+  setMockContextUsage: (
+    contextUsage: { rawMaxTokens: number } | null,
+  ) => void;
+  setMockContextUsageImplementation: (
+    implementation: (() => Promise<{ rawMaxTokens: number }>) | null,
   ) => void;
 };
 
@@ -505,6 +512,379 @@ describe('ClaudeExecutionBackend', () => {
     }));
     expect(events).toContainEqual(expect.objectContaining({
       type: 'context_compacted',
+    }));
+  });
+
+  it('keeps the persistent runtime context window when result metadata disagrees', async () => {
+    sdkMock.setMockContextUsage({ rawMaxTokens: 1_000_000 });
+    sdkMock.setMockMessages([
+      { type: 'system', subtype: 'init', session_id: 'session-1' },
+      {
+        type: 'assistant',
+        parent_tool_use_id: null,
+        message: {
+          content: [{ type: 'text', text: 'Hello' }],
+          usage: { input_tokens: 250_000 },
+        },
+      },
+      {
+        type: 'result',
+        subtype: 'success',
+        modelUsage: {
+          'custom-model': { contextWindow: 200_000 },
+        },
+      },
+    ], { appendResult: false });
+    const { services } = createServices();
+    const session = new ClaudeExecutionBackend(createHost(), services)
+      .createSession(createConfig());
+
+    const events = await collectEvents(session.execute(createRequest({
+      configuration: {
+        systemInstructions: { kind: 'provider-default' },
+        model: 'custom-model',
+        reasoning: 'medium',
+        permissionMode: 'ask',
+      },
+    })).events);
+
+    expect(sdkMock.getLastResponse()?.getContextUsage).toHaveBeenCalledTimes(1);
+    const usageEvents = events.filter((event) => event.type === 'usage_updated');
+    expect(usageEvents.at(-1)).toEqual(expect.objectContaining({
+      type: 'usage_updated',
+      usage: expect.objectContaining({
+        model: 'custom-model',
+        contextTokens: 250_000,
+        contextWindow: 1_000_000,
+        contextWindowIsAuthoritative: true,
+        percentage: 25,
+      }),
+    }));
+  });
+
+  it('corrects live usage when runtime context discovery resolves after usage', async () => {
+    const contextUsage = createDeferred<{ rawMaxTokens: number }>();
+    const resultBarrier = createDeferred<null>();
+    sdkMock.setMockContextUsageImplementation(() => contextUsage.promise);
+    sdkMock.setMockMessages([
+      {
+        type: 'assistant',
+        parent_tool_use_id: null,
+        message: {
+          content: [{ type: 'text', text: 'Hello' }],
+          usage: { input_tokens: 250_000 },
+        },
+      },
+      resultBarrier.promise,
+      { type: 'result', subtype: 'success' },
+    ], { appendResult: false });
+    const { services } = createServices();
+    const session = new ClaudeExecutionBackend(createHost(), services)
+      .createSession(createConfig());
+    const collected: ProviderExecutionEvent[] = [];
+    const run = session.execute(createRequest({
+      configuration: {
+        systemInstructions: { kind: 'provider-default' },
+        model: 'custom-model',
+        reasoning: 'medium',
+        permissionMode: 'ask',
+      },
+    }));
+    const collection = (async () => {
+      for await (const event of run.events) {
+        collected.push(event);
+      }
+    })();
+
+    await waitFor(() => collected.some((event) => (
+      event.type === 'usage_updated'
+      && event.usage.contextWindow === 200_000
+    )));
+    contextUsage.resolve({ rawMaxTokens: 1_000_000 });
+    await waitFor(() => collected.some((event) => (
+      event.type === 'usage_updated'
+      && event.usage.contextWindow === 1_000_000
+      && event.usage.contextWindowIsAuthoritative === true
+    )));
+    resultBarrier.resolve(null);
+    await collection;
+
+    expect(collected.filter((event) => event.type === 'usage_updated').at(-1))
+      .toEqual(expect.objectContaining({
+        usage: expect.objectContaining({
+          contextWindow: 1_000_000,
+          percentage: 25,
+        }),
+      }));
+  });
+
+  it('ignores a delayed context window after the persistent model changes', async () => {
+    const staleContextUsage = createDeferred<{ rawMaxTokens: number }>();
+    const secondResultBarrier = createDeferred<null>();
+    const getContextUsage = jest.fn()
+      .mockReturnValueOnce(staleContextUsage.promise)
+      .mockResolvedValueOnce({ rawMaxTokens: 500_000 });
+    const queryFactory = jest.fn((request: {
+      prompt: AsyncIterable<sdkModule.SDKUserMessage>;
+    }) => {
+      const query = attachContextUsage(
+        createPromptDrivenPersistentQuery(request.prompt, (prompt) => (
+          prompt.includes('First model')
+            ? [
+              { type: 'system', subtype: 'init', session_id: 'session-1' },
+              {
+                type: 'assistant',
+                message: {
+                  content: [{ type: 'text', text: 'First response' }],
+                  usage: { input_tokens: 250_000 },
+                },
+              },
+              { type: 'result', subtype: 'success' },
+            ]
+            : [
+              {
+                type: 'assistant',
+                message: {
+                  content: [{ type: 'text', text: 'Second response' }],
+                  usage: { input_tokens: 250_000 },
+                },
+              },
+              secondResultBarrier.promise,
+              { type: 'result', subtype: 'success' },
+            ]
+        )),
+        getContextUsage,
+      );
+      return query;
+    });
+    jest.spyOn(
+      await import('@/providers/claude/loadClaudeAgentSdk'),
+      'loadClaudeAgentQuery',
+    ).mockResolvedValueOnce(queryFactory as never);
+    const { services } = createServices();
+    const session = new ClaudeExecutionBackend(createHost(), services)
+      .createSession(createConfig());
+
+    await collectEvents(session.execute(createRequest({
+      input: [{ type: 'text', text: 'First model' }],
+      configuration: {
+        systemInstructions: { kind: 'provider-default' },
+        model: 'custom-model-a',
+        reasoning: 'medium',
+        permissionMode: 'ask',
+      },
+    })).events);
+    const secondEvents: ProviderExecutionEvent[] = [];
+    const secondRun = session.execute(createRequest({
+      input: [{ type: 'text', text: 'Second model' }],
+      configuration: {
+        systemInstructions: { kind: 'provider-default' },
+        model: 'custom-model-b',
+        reasoning: 'medium',
+        permissionMode: 'ask',
+      },
+    }));
+    const secondCollection = (async () => {
+      for await (const event of secondRun.events) {
+        secondEvents.push(event);
+      }
+    })();
+
+    await waitFor(() => secondEvents.some((event) => (
+      event.type === 'usage_updated'
+      && event.usage.contextWindow === 500_000
+    )));
+    staleContextUsage.resolve({ rawMaxTokens: 1_000_000 });
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(secondEvents).not.toContainEqual(expect.objectContaining({
+      type: 'usage_updated',
+      usage: expect.objectContaining({ contextWindow: 1_000_000 }),
+    }));
+    secondResultBarrier.resolve(null);
+    await secondCollection;
+    expect(getContextUsage).toHaveBeenCalledTimes(2);
+    await session.dispose();
+  });
+
+  it('ignores context discovery from a replaced persistent query', async () => {
+    const staleContextUsage = createDeferred<{ rawMaxTokens: number }>();
+    const replacementResultBarrier = createDeferred<null>();
+    const getStaleContextUsage = jest.fn().mockReturnValue(staleContextUsage.promise);
+    const getReplacementContextUsage = jest.fn().mockResolvedValue({ rawMaxTokens: 500_000 });
+    const staleFactory = jest.fn((request: {
+      prompt: AsyncIterable<sdkModule.SDKUserMessage>;
+    }) => {
+      const staleQuery = attachContextUsage(
+        createPromptDrivenPersistentQuery(request.prompt, () => [
+          { type: 'system', subtype: 'init', session_id: 'session-1' },
+          { type: 'result', subtype: 'success' },
+        ]),
+        getStaleContextUsage,
+      );
+      return staleQuery;
+    });
+    const replacementFactory = jest.fn((request: {
+      prompt: AsyncIterable<sdkModule.SDKUserMessage>;
+    }) => {
+      const replacementQuery = attachContextUsage(
+        createPromptDrivenPersistentQuery(request.prompt, () => [
+          { type: 'system', subtype: 'init', session_id: 'session-2' },
+          {
+            type: 'assistant',
+            message: {
+              content: [{ type: 'text', text: 'Replacement response' }],
+              usage: { input_tokens: 250_000 },
+            },
+          },
+          replacementResultBarrier.promise,
+          { type: 'result', subtype: 'success' },
+        ]),
+        getReplacementContextUsage,
+      );
+      return replacementQuery;
+    });
+    jest.spyOn(
+      await import('@/providers/claude/loadClaudeAgentSdk'),
+      'loadClaudeAgentQuery',
+    )
+      .mockResolvedValueOnce(staleFactory as never)
+      .mockResolvedValueOnce(replacementFactory as never);
+    const { services } = createServices();
+    const session = new ClaudeExecutionBackend(createHost(), services)
+      .createSession(createConfig());
+
+    await collectEvents(session.execute(createRequest({
+      configuration: {
+        systemInstructions: { kind: 'provider-default' },
+        model: 'custom-model',
+        reasoning: 'medium',
+        permissionMode: 'ask',
+      },
+    })).events);
+    const replacementEvents: ProviderExecutionEvent[] = [];
+    const replacementRun = session.execute(createRequest({
+      configuration: {
+        systemInstructions: {
+          kind: 'explicit',
+          instructions: 'Use replacement instructions.',
+        },
+        model: 'custom-model',
+        reasoning: 'medium',
+        permissionMode: 'ask',
+      },
+    }));
+    const replacementCollection = (async () => {
+      for await (const event of replacementRun.events) {
+        replacementEvents.push(event);
+      }
+    })();
+
+    await waitFor(() => replacementEvents.some((event) => (
+      event.type === 'usage_updated'
+      && event.usage.contextWindow === 500_000
+    )));
+    staleContextUsage.resolve({ rawMaxTokens: 1_000_000 });
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(replacementEvents).not.toContainEqual(expect.objectContaining({
+      type: 'usage_updated',
+      usage: expect.objectContaining({ contextWindow: 1_000_000 }),
+    }));
+    replacementResultBarrier.resolve(null);
+    await replacementCollection;
+    expect(getStaleContextUsage).toHaveBeenCalledTimes(1);
+    expect(getReplacementContextUsage).toHaveBeenCalledTimes(1);
+    await session.dispose();
+  });
+
+  it('corrects custom-model usage from result model metadata', async () => {
+    sdkMock.setMockMessages([
+      {
+        type: 'assistant',
+        parent_tool_use_id: null,
+        message: {
+          content: [{ type: 'text', text: 'Hello' }],
+          usage: { input_tokens: 250_000 },
+        },
+      },
+      {
+        type: 'result',
+        subtype: 'success',
+        modelUsage: {
+          'custom-model': { contextWindow: 1_000_000 },
+        },
+      },
+    ], { appendResult: false });
+    const { services } = createServices();
+    const session = new ClaudeExecutionBackend(createHost(), services)
+      .createSession(createConfig());
+
+    const events = await collectEvents(session.execute(createRequest({
+      configuration: {
+        systemInstructions: { kind: 'provider-default' },
+        model: 'custom-model',
+        reasoning: 'medium',
+        permissionMode: 'ask',
+      },
+    })).events);
+    const usageEvents = events.filter((event) => event.type === 'usage_updated');
+
+    expect(usageEvents.at(-1)).toEqual(expect.objectContaining({
+      type: 'usage_updated',
+      usage: expect.objectContaining({
+        model: 'custom-model',
+        contextTokens: 250_000,
+        contextWindow: 1_000_000,
+        contextWindowIsAuthoritative: true,
+        percentage: 25,
+      }),
+    }));
+  });
+
+  it('applies result context metadata before terminating an errored turn', async () => {
+    sdkMock.setMockMessages([
+      {
+        type: 'assistant',
+        parent_tool_use_id: null,
+        message: {
+          content: [{ type: 'text', text: 'Partial output' }],
+          usage: { input_tokens: 250_000 },
+        },
+      },
+      {
+        type: 'result',
+        subtype: 'error_max_turns',
+        errors: ['Hit maximum turn limit'],
+        modelUsage: {
+          'custom-model': { contextWindow: 1_000_000 },
+        },
+      },
+    ], { appendResult: false });
+    const { services } = createServices();
+    const session = new ClaudeExecutionBackend(createHost(), services)
+      .createSession(createConfig());
+
+    const events = await collectEvents(session.execute(createRequest({
+      configuration: {
+        systemInstructions: { kind: 'provider-default' },
+        model: 'custom-model',
+        reasoning: 'medium',
+        permissionMode: 'ask',
+      },
+    })).events);
+
+    expect(events.filter((event) => event.type === 'usage_updated').at(-1))
+      .toEqual(expect.objectContaining({
+        usage: expect.objectContaining({
+          contextWindow: 1_000_000,
+          contextWindowIsAuthoritative: true,
+          percentage: 25,
+        }),
+      }));
+    expect(events.at(-1)).toEqual(expect.objectContaining({
+      type: 'execution_error',
+      message: 'Hit maximum turn limit',
     }));
   });
 
@@ -1923,6 +2303,17 @@ type ScriptedQuery = AsyncGenerator<unknown> & {
   rewindFiles: jest.Mock;
   finished: Promise<void>;
 };
+
+type ContextAwareScriptedQuery = ScriptedQuery & {
+  getContextUsage: jest.Mock;
+};
+
+function attachContextUsage(
+  query: ScriptedQuery,
+  getContextUsage: jest.Mock,
+): ContextAwareScriptedQuery {
+  return Object.assign(query, { getContextUsage });
+}
 
 function attachQueryMethods(
   query: AsyncGenerator<unknown>,

--- a/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
+++ b/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
@@ -1258,8 +1258,8 @@ describe('transformSDKMessage', () => {
       const results = [...transformSDKMessage(message)];
 
       expect(results).toEqual([
-        { type: 'error', content: 'Hit maximum turn limit' },
         { type: 'context_window', contextWindow: 200000 },
+        { type: 'error', content: 'Hit maximum turn limit' },
       ]);
     });
 

--- a/tests/unit/style/components/history.test.ts
+++ b/tests/unit/style/components/history.test.ts
@@ -26,3 +26,16 @@ describe('Session history styles', () => {
     expect(metadataCss).toContain('body.theme-dark .claudian-session-metadata-popover');
   });
 });
+
+describe('Single-pane history action styles', () => {
+  it('keeps row actions borderless and transparent while using color for interaction', () => {
+    const css = readFileSync(path.resolve('src/style/components/history.css'), 'utf8');
+
+    expect(css).toMatch(
+      /\.claudian-history-menu \.claudian-history-item-actions \.claudian-action-btn\s*{[^}]*background:\s*transparent;[^}]*border:\s*none;[^}]*box-shadow:\s*none;[^}]*color:\s*var\(--text-muted\);/,
+    );
+    expect(css).toMatch(
+      /\.claudian-history-menu \.claudian-history-item-actions \.claudian-action-btn:hover,[\s\S]*?\.claudian-history-menu \.claudian-history-item-actions \.claudian-action-btn:focus-visible\s*{[^}]*background:\s*transparent;[^}]*box-shadow:\s*none;[^}]*color:\s*var\(--text-normal\);/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Restore Claude runtime context windows from `query.getContextUsage()` and `rawMaxTokens`.
- Restore conversation Rename menu flow across Sessions, history, search, and dual-pane surfaces.
- Preserve the fork's existing `HistoryViewport`, session hover, and dual-pane behavior.

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test` — 398 suites, 6944 tests passed
- `pnpm run build`

Upstream fixes: #1091 and #1095.