### PR TITLE
chore: release 2.2.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "packageManager": "pnpm@10.34.5",
   "description": "Oh My Claudian - provider-backed coding agents embedded in the Obsidian sidebar",
   "main": "main.js",


### PR DESCRIPTION
## Release 2.2.1

This release contains the fixes from PR #74:

- Restore Claude runtime context windows.
- Restore conversation Rename menu flow.

Validation completed locally:

- Typecheck passed
- Lint passed with existing warnings only
- 398 test suites and 6944 tests passed
- Production build passed

After this PR is merged, pushing the `2.2.1` tag will trigger the automated Release workflow.