### PR TITLE
feat: harden external file access boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Oh My Claudian is designed to make powerful local agents safer to operate withou
 - New installations start in **Safe** mode. Provider-native permission controls decide when an operation requires approval; **YOLO** remains an explicit user choice.
 - The optional `!` bash mode is disabled by default. When enabled, it runs commands directly as the current OS user and should be treated like a local terminal.
 - External files and folders enter the conversation as explicit context attachments instead of being silently added by Oh My Claudian.
+- An external file attachment is context only; mentioning or attaching a file does not grant write access. Direct edits outside the vault are routed through the provider approval flow when supported, and direct file APIs reject paths outside the vault.
+- Rejecting an external write prevents that write operation; it does not create a persistent allow rule. Review each approval request and use provider-native permission settings for any broader trust decision.
 - Provider-owned settings, transcripts, and permission rules remain provider-owned. Oh My Claudian does not rewrite native history or send telemetry.
 
 The vault is the agent's working directory, not an operating-system security boundary. A local provider CLI, shell command, MCP server, plugin, or other child process may be able to access files, network services, and credentials available to your OS account. Safe/approval mode reduces accidental actions but cannot guarantee that every indirect access path is confined to the vault.

--- a/src/core/storage/pathAccessPolicy.ts
+++ b/src/core/storage/pathAccessPolicy.ts
@@ -1,0 +1,125 @@
+import {
+  lstatSync,
+  readlinkSync,
+  realpathSync,
+} from 'node:fs';
+import * as path from 'node:path';
+
+export type FileOperation = 'read' | 'write';
+export type PathAccessOutcome = 'allow' | 'deny' | 'needsApproval';
+
+export interface PathAccessRequest {
+  readonly externalPathMode?: 'deny' | 'needsApproval';
+  readonly operation: FileOperation;
+  readonly requestedPath: string;
+  readonly workspaceRoot: string;
+}
+
+export interface PathAccessDecision {
+  readonly outcome: PathAccessOutcome;
+  readonly path: string;
+  readonly reason: string;
+}
+
+export class PathAccessError extends Error {
+  constructor(readonly decision: PathAccessDecision) {
+    super(decision.reason);
+    this.name = 'PathAccessError';
+  }
+}
+
+export function evaluatePathAccess(request: PathAccessRequest): PathAccessDecision {
+  const workspaceRoot = path.resolve(request.workspaceRoot);
+  const requestedPath = request.requestedPath.trim();
+  if (!requestedPath) {
+    return deny(workspaceRoot, 'File access requires a non-empty path.');
+  }
+
+  const lexicalPath = path.resolve(workspaceRoot, requestedPath);
+  const canonicalRoot = resolveCanonicalPath(workspaceRoot);
+  const canonicalPath = resolveCanonicalPath(lexicalPath);
+  const lexicalInside = isPathWithinRoot(lexicalPath, workspaceRoot);
+  const canonicalInside = isPathWithinRoot(canonicalPath, canonicalRoot);
+
+  if (lexicalInside && canonicalInside) {
+    return {
+      outcome: 'allow',
+      path: canonicalPath,
+      reason: `${request.operation} access is within the current workspace.`,
+    };
+  }
+
+  if (lexicalInside && !canonicalInside) {
+    return deny(canonicalPath, 'File access cannot follow a link outside the current workspace.');
+  }
+
+  if (request.externalPathMode === 'needsApproval') {
+    return {
+      outcome: 'needsApproval',
+      path: canonicalPath,
+      reason: 'File access is outside the current workspace and requires approval.',
+    };
+  }
+
+  return deny(canonicalPath, 'File access is limited to the current workspace.');
+}
+
+export function resolveAllowedFileOperationPath(request: PathAccessRequest): string {
+  const decision = evaluatePathAccess(request);
+  if (decision.outcome !== 'allow') throw new PathAccessError(decision);
+  return decision.path;
+}
+
+function deny(targetPath: string, reason: string): PathAccessDecision {
+  return { outcome: 'deny', path: targetPath, reason };
+}
+
+function resolveCanonicalPath(
+  targetPath: string,
+  resolvingLinks = new Set<string>(),
+): string {
+  let current = path.resolve(targetPath);
+  const missingSegments: string[] = [];
+
+  while (true) {
+    try {
+      return path.resolve(realpathSync.native(current), ...missingSegments);
+    } catch (error) {
+      if (!isMissingPathError(error)) throw error;
+      let linkTarget: string | null = null;
+      try {
+        if (lstatSync(current).isSymbolicLink()) linkTarget = readlinkSync(current);
+      } catch (linkError) {
+        if (!isMissingPathError(linkError)) throw linkError;
+      }
+      if (linkTarget !== null) {
+        if (resolvingLinks.has(current)) {
+          throw new Error(`Circular symbolic link: ${current}`, { cause: error });
+        }
+        const next = new Set(resolvingLinks);
+        next.add(current);
+        const resolvedTarget = path.isAbsolute(linkTarget)
+          ? linkTarget
+          : path.resolve(path.dirname(current), linkTarget);
+        return path.resolve(resolveCanonicalPath(resolvedTarget, next), ...missingSegments);
+      }
+      const parent = path.dirname(current);
+      if (parent === current) throw error;
+      missingSegments.unshift(path.basename(current));
+      current = parent;
+    }
+  }
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return Boolean(error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT');
+}
+
+function isPathWithinRoot(candidate: string, root: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (
+    relative !== '..'
+    && !relative.startsWith(`..${path.sep}`)
+    && !path.isAbsolute(relative)
+  );
+}

--- a/src/providers/claude/execution/ClaudeExecutionRequestEncoder.ts
+++ b/src/providers/claude/execution/ClaudeExecutionRequestEncoder.ts
@@ -14,6 +14,11 @@ import type { ProviderHost } from '../../../core/providers/ProviderHost';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type { AppPluginManager } from '../../../core/providers/types';
 import {
+  getActionPattern,
+} from '../../../core/security/approvalRules';
+import { evaluatePathAccess } from '../../../core/storage/pathAccessPolicy';
+import {
+  isEditTool,
   isReadOnlyTool,
   READ_ONLY_TOOLS,
 } from '../../../core/tools/toolNames';
@@ -143,6 +148,10 @@ export class ClaudeExecutionRequestEncoder {
     ]);
     const mcpServers = this.deps.mcpManager.getActiveServers(enabledMcpServers);
     const policy = resolveToolPolicy(request);
+    const hooks: HookCallbackMatcher[] = [
+      createVaultBoundaryHook(sessionConfig.vaultWorkingDirectory),
+      ...(policy.hooks?.PreToolUse ?? []),
+    ];
     const systemPrompt = request.configuration.systemInstructions.kind === 'explicit'
       ? [
         request.configuration.systemInstructions.instructions.trim(),
@@ -190,7 +199,7 @@ export class ClaudeExecutionRequestEncoder {
         ? { additionalDirectories: externalPaths }
         : {}),
       ...(policy.tools !== undefined ? { tools: policy.tools } : {}),
-      ...(policy.hooks ? { hooks: policy.hooks } : {}),
+      hooks: { PreToolUse: hooks },
       ...(resume.sessionId ? { resume: resume.sessionId } : {}),
       ...(resume.resumeAt ? { resumeSessionAt: resume.resumeAt } : {}),
       ...(resume.fork ? { forkSession: true } : {}),
@@ -376,6 +385,92 @@ function createReadOnlyHook(): HookCallbackMatcher {
       };
     }],
   };
+}
+
+export function createVaultBoundaryHook(workspaceRoot: string): HookCallbackMatcher {
+  return {
+    hooks: [async (hookInput) => {
+      const record = hookInput as unknown as Record<string, unknown>;
+      const toolName = typeof record.tool_name === 'string' ? record.tool_name : '';
+      if (toolName === 'Bash') {
+        const command = typeof record.tool_input === 'object'
+          && record.tool_input !== null
+          && typeof (record.tool_input as Record<string, unknown>).command === 'string'
+          ? (record.tool_input as Record<string, string>).command
+          : '';
+        const externalPath = findExternalCommandPath(command, workspaceRoot);
+        if (!externalPath) return { continue: true };
+        return {
+          continue: false,
+          hookSpecificOutput: {
+            hookEventName: 'PreToolUse' as const,
+            permissionDecision: 'ask' as const,
+            permissionDecisionReason:
+              `This command references a path outside the current vault: ${externalPath}`,
+          },
+        };
+      }
+      if (!isEditTool(toolName)) return { continue: true };
+
+      const toolInput = isRecord(record.tool_input)
+        ? record.tool_input
+        : {};
+      const requestedPath = getActionPattern(toolName, toolInput);
+      if (!requestedPath) {
+        return {
+          continue: false,
+          hookSpecificOutput: {
+            hookEventName: 'PreToolUse' as const,
+            permissionDecision: 'deny' as const,
+            permissionDecisionReason: 'Edit tool did not provide a file path.',
+          },
+        };
+      }
+
+      const decision = evaluatePathAccess({
+        operation: 'write',
+        requestedPath,
+        workspaceRoot,
+        externalPathMode: 'needsApproval',
+      });
+      if (decision.outcome === 'allow') return { continue: true };
+      if (decision.outcome === 'needsApproval') {
+        return {
+          continue: false,
+          hookSpecificOutput: {
+            hookEventName: 'PreToolUse' as const,
+            permissionDecision: 'ask' as const,
+            permissionDecisionReason:
+              'This edit is outside the current vault and requires approval.',
+          },
+        };
+      }
+      return {
+        continue: false,
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse' as const,
+          permissionDecision: 'deny' as const,
+          permissionDecisionReason:
+            'Direct edits outside the current vault are blocked.',
+        },
+      };
+    }],
+  };
+}
+
+function findExternalCommandPath(command: string, workspaceRoot: string): string | null {
+  const candidates = command.match(/(?:^|[\s"'=])((?:\/|\.\.\/|\.\/)[^\s"';&|`]*)/g) ?? [];
+  for (const candidate of candidates) {
+    const requestedPath = candidate.trim().replace(/^[\s"'=]+/u, '');
+    const decision = evaluatePathAccess({
+      operation: 'write',
+      requestedPath,
+      workspaceRoot,
+      externalPathMode: 'needsApproval',
+    });
+    if (decision.outcome !== 'allow') return requestedPath;
+  }
+  return null;
 }
 
 function isPermissionMode(value: unknown): value is PermissionMode {

--- a/src/providers/claude/execution/ClaudeExecutionSession.ts
+++ b/src/providers/claude/execution/ClaudeExecutionSession.ts
@@ -172,6 +172,7 @@ ClaudeExecutionStrategySink {
           this.activeRun ? 'requested' : 'background',
         );
       },
+      workspaceRoot: config.vaultWorkingDirectory,
     });
     this.strategy = config.lifecycle === 'persistent'
       ? new ClaudePersistentExecutionStrategy(this)

--- a/src/providers/claude/execution/ClaudeInteractionHandler.ts
+++ b/src/providers/claude/execution/ClaudeInteractionHandler.ts
@@ -8,8 +8,13 @@ import type {
   ProviderInteractionDismissReason,
   ProviderInteractionPort,
 } from '../../../core/execution';
-import { getActionDescription } from '../../../core/security/approvalRules';
 import {
+  getActionDescription,
+  getActionPattern,
+} from '../../../core/security/approvalRules';
+import { evaluatePathAccess } from '../../../core/storage/pathAccessPolicy';
+import {
+  isEditTool,
   TOOL_ASK_USER_QUESTION,
   TOOL_EXIT_PLAN_MODE,
 } from '../../../core/tools/toolNames';
@@ -26,6 +31,7 @@ export interface ClaudeExecutionInteractionDeps {
     mode: PermissionMode,
   ) => SDKPermissionMode;
   readonly onToolBlocked: (toolUseId: string) => void;
+  readonly workspaceRoot?: string;
 }
 
 export class ClaudeInteractionHandler {
@@ -43,6 +49,25 @@ export class ClaudeInteractionHandler {
         behavior: 'deny',
         message: `Tool "${toolName}" is not allowed by this execution policy.`,
       };
+    }
+
+    if (isEditTool(toolName) && this.deps.workspaceRoot) {
+      const requestedPath = getActionPattern(toolName, input);
+      if (requestedPath) {
+        const decision = evaluatePathAccess({
+          operation: 'write',
+          requestedPath,
+          workspaceRoot: this.deps.workspaceRoot,
+          externalPathMode: 'needsApproval',
+        });
+        if (decision.outcome === 'deny') {
+          return {
+            behavior: 'deny',
+            message: 'Direct edits outside the current vault are blocked.',
+            interrupt: false,
+          };
+        }
+      }
     }
 
     const turnId = this.deps.getTurnId();

--- a/src/providers/codex/execution/CodexExecutionSession.ts
+++ b/src/providers/codex/execution/CodexExecutionSession.ts
@@ -1748,11 +1748,9 @@ export class CodexExecutionSession
     policy: CodexPolicy,
   ): SandboxPolicy {
     if (policy.sandbox !== 'workspace-write') return policy.sandboxPolicy;
-    const externalPaths = [
-      ...(request.context?.externalContextPaths ?? []),
-      ...(request.configuration.externalWorkspaceRoots ?? []),
-    ];
-    return this.buildWorkspaceWriteSandboxPolicy(externalPaths);
+    // External context remains readable through the sandbox's read-only
+    // access. It must never be promoted to a writable root for a turn.
+    return this.buildWorkspaceWriteSandboxPolicy([]);
   }
 
   private buildWorkspaceWriteSandboxPolicy(

--- a/src/providers/cursor/execution/CursorAcpSessionKernel.ts
+++ b/src/providers/cursor/execution/CursorAcpSessionKernel.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 
 import type { ProviderSessionConfig } from '@/core/execution';
 import type { ProviderHost } from '@/core/providers/ProviderHost';
+import { resolveAllowedFileOperationPath } from '@/core/storage/pathAccessPolicy';
 import { t } from '@/i18n/i18n';
 import {
   AcpClientConnection,
@@ -192,7 +193,7 @@ export class DefaultCursorAcpSessionKernel implements CursorAcpSessionKernel {
   }
 
   private async readTextFile(request: AcpReadTextFileRequest): Promise<{ content: string }> {
-    const filePath = resolveWorkspacePath(this.options.config.vaultWorkingDirectory, request.path);
+    const filePath = resolveWorkspacePath(this.options.config.vaultWorkingDirectory, request.path, 'read');
     const content = await fs.readFile(filePath, 'utf8');
     if (request.line === undefined && request.limit === undefined) return { content };
     const lines = content.split(/\r?\n/u);
@@ -202,7 +203,7 @@ export class DefaultCursorAcpSessionKernel implements CursorAcpSessionKernel {
   }
 
   private async writeTextFile(request: AcpWriteTextFileRequest): Promise<Record<string, never>> {
-    const filePath = resolveWorkspacePath(this.options.config.vaultWorkingDirectory, request.path);
+    const filePath = resolveWorkspacePath(this.options.config.vaultWorkingDirectory, request.path, 'write');
     await fs.mkdir(path.dirname(filePath), { recursive: true });
     await fs.writeFile(filePath, request.content, 'utf8');
     return {};
@@ -214,14 +215,20 @@ export class DefaultCursorAcpSessionKernel implements CursorAcpSessionKernel {
   }
 }
 
-export function resolveWorkspacePath(workspaceRoot: string, requestedPath: string): string {
-  const root = path.resolve(workspaceRoot);
-  const resolved = path.resolve(root, requestedPath);
-  const relative = path.relative(root, resolved);
-  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+export function resolveWorkspacePath(
+  workspaceRoot: string,
+  requestedPath: string,
+  operation: 'read' | 'write' = 'read',
+): string {
+  try {
+    return resolveAllowedFileOperationPath({
+      operation,
+      requestedPath,
+      workspaceRoot,
+    });
+  } catch {
     throw new Error('Cursor file access is limited to the current workspace');
   }
-  return resolved;
 }
 
 function presentCursorPermission(

--- a/src/providers/omp/execution/OmpAcpSessionKernel.ts
+++ b/src/providers/omp/execution/OmpAcpSessionKernel.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import type { ProviderSessionConfig } from '@/core/execution';
 import { getRuntimeEnvironmentVariables } from '@/core/providers/providerEnvironment';
 import type { ProviderHost } from '@/core/providers/ProviderHost';
+import { resolveAllowedFileOperationPath } from '@/core/storage/pathAccessPolicy';
 import { t } from '@/i18n/i18n';
 import {
   AcpClientConnection,
@@ -182,7 +183,7 @@ export class DefaultOmpAcpSessionKernel implements OmpAcpSessionKernel {
   }
 
   private async readTextFile(request: AcpReadTextFileRequest): Promise<{ content: string }> {
-    const filePath = resolveWorkspacePath(this.options.config.vaultWorkingDirectory, request.path);
+    const filePath = resolveWorkspacePath(this.options.config.vaultWorkingDirectory, request.path, 'read');
     const content = await fs.readFile(filePath, 'utf8');
     if (request.line === undefined && request.limit === undefined) return { content };
     const lines = content.split(/\r?\n/u);
@@ -192,7 +193,7 @@ export class DefaultOmpAcpSessionKernel implements OmpAcpSessionKernel {
   }
 
   private async writeTextFile(request: AcpWriteTextFileRequest): Promise<Record<string, never>> {
-    const filePath = resolveWorkspacePath(this.options.config.vaultWorkingDirectory, request.path);
+    const filePath = resolveWorkspacePath(this.options.config.vaultWorkingDirectory, request.path, 'write');
     await fs.mkdir(path.dirname(filePath), { recursive: true });
     await fs.writeFile(filePath, request.content, 'utf8');
     return {};
@@ -204,14 +205,20 @@ export class DefaultOmpAcpSessionKernel implements OmpAcpSessionKernel {
   }
 }
 
-export function resolveWorkspacePath(workspaceRoot: string, requestedPath: string): string {
-  const root = path.resolve(workspaceRoot);
-  const resolved = path.resolve(root, requestedPath);
-  const relative = path.relative(root, resolved);
-  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+export function resolveWorkspacePath(
+  workspaceRoot: string,
+  requestedPath: string,
+  operation: 'read' | 'write' = 'read',
+): string {
+  try {
+    return resolveAllowedFileOperationPath({
+      operation,
+      requestedPath,
+      workspaceRoot,
+    });
+  } catch {
     throw new Error('OMP file access is limited to the current workspace');
   }
-  return resolved;
 }
 
 function presentOmpPermission(

--- a/src/shared/mention/MentionDropdownController.ts
+++ b/src/shared/mention/MentionDropdownController.ts
@@ -6,7 +6,6 @@ import { type ExternalContextFile, externalContextScanner } from '../../utils/ex
 import { extractMcpMentions } from '../../utils/mcp';
 import { SelectableDropdown } from '../components/SelectableDropdown';
 import { appendMcpIcon } from '../icons';
-import { formatVaultFileMention } from './formatMention';
 import {
   type AgentMentionProvider,
   type FolderMentionItem,
@@ -686,19 +685,21 @@ export class MentionDropdownController {
         return;
       }
       case 'context-file': {
-        // Display friendly name in input; absolute path resolution happens at send time.
-        const displayName = selectedItem.folderName
-          ? `@${selectedItem.folderName}/${selectedItem.name}`
-          : `@${selectedItem.name}`;
+        // External file references become context chips; keep the prompt text clean.
         if (selectedItem.absolutePath) {
           this.callbacks.onAttachFile(selectedItem.absolutePath);
         }
-        this.insertReplacement(beforeAt, `${displayName} `, afterCursor);
+        this.insertReplacement(beforeAt, '', afterCursor);
         break;
       }
       case 'folder': {
         const normalizedPath = this.callbacks.normalizePathForVault(selectedItem.path);
-        this.insertReplacement(beforeAt, `@${normalizedPath ?? selectedItem.path}/ `, afterCursor);
+        if (normalizedPath) {
+          this.callbacks.onAttachFile(
+            normalizedPath.endsWith('/') ? normalizedPath : `${normalizedPath}/`,
+          );
+        }
+        this.insertReplacement(beforeAt, '', afterCursor);
         break;
       }
       default: {
@@ -707,11 +708,7 @@ export class MentionDropdownController {
         if (normalizedPath) {
           this.callbacks.onAttachFile(normalizedPath);
         }
-        this.insertReplacement(
-          beforeAt,
-          formatVaultFileMention(normalizedPath ?? selectedItem.name),
-          afterCursor,
-        );
+        this.insertReplacement(beforeAt, '', afterCursor);
         break;
       }
     }

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -130,13 +130,16 @@
 }
 
 .claudian-input-send-button {
+  position: absolute;
+  right: 10px;
+  bottom: 8px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex: 0 0 36px;
   width: 36px;
   height: 36px;
-  margin-inline-start: 8px;
+  margin: 0;
   padding: 0;
   border: 1px solid var(--claudian-brand);
   border-radius: 50%;
@@ -144,6 +147,11 @@
   color: var(--background-primary);
   cursor: pointer;
   transition: background 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
+}
+
+/* Keep the provider mode switch and the primary action together on the right. */
+.claudian-input-toolbar > .claudian-mode-selector {
+  margin-inline-start: auto;
 }
 
 .claudian-input-send-button:hover:not(:disabled) {
@@ -178,8 +186,8 @@
   justify-content: flex-start;
   flex-wrap: wrap;
   flex-shrink: 0;
-  row-gap: 12px;
-  padding: 4px 6px 6px 6px;
+  row-gap: 8px;
+  padding: 4px 56px 8px 10px;
 }
 
 /* Keep the composer layout isolated when upstream Claudian is installed too. */

--- a/tests/unit/core/storage/pathAccessPolicy.test.ts
+++ b/tests/unit/core/storage/pathAccessPolicy.test.ts
@@ -1,0 +1,103 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import {
+  evaluatePathAccess,
+  resolveAllowedFileOperationPath,
+} from '@/core/storage/pathAccessPolicy';
+
+describe('path access policy', () => {
+  it('allows vault-relative and absolute paths inside the vault', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'claudian-path-policy-'));
+    mkdirSync(path.join(root, 'notes'));
+    writeFileSync(path.join(root, 'notes', 'today.md'), 'today');
+
+    try {
+      expect(evaluatePathAccess({
+        operation: 'read',
+        requestedPath: 'notes/today.md',
+        workspaceRoot: root,
+      })).toMatchObject({
+        outcome: 'allow',
+        path: path.join(realpathSync.native(root), 'notes', 'today.md'),
+      });
+      expect(resolveAllowedFileOperationPath({
+        operation: 'write',
+        requestedPath: path.join(root, 'notes', 'new.md'),
+        workspaceRoot: root,
+      })).toBe(path.join(realpathSync.native(root), 'notes', 'new.md'));
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('denies traversal and symlinks that resolve outside the vault', () => {
+    const testRoot = mkdtempSync(path.join(tmpdir(), 'claudian-path-policy-'));
+    const workspaceRoot = path.join(testRoot, 'vault');
+    const outsideRoot = path.join(testRoot, 'outside');
+    mkdirSync(workspaceRoot);
+    mkdirSync(outsideRoot);
+    writeFileSync(path.join(outsideRoot, 'secret.md'), 'secret');
+    symlinkSync(path.join(outsideRoot, 'secret.md'), path.join(workspaceRoot, 'linked.md'));
+
+    try {
+      expect(evaluatePathAccess({
+        operation: 'read',
+        requestedPath: '../outside/secret.md',
+        workspaceRoot,
+      })).toMatchObject({ outcome: 'deny' });
+      expect(evaluatePathAccess({
+        operation: 'read',
+        requestedPath: 'linked.md',
+        workspaceRoot,
+      })).toMatchObject({ outcome: 'deny' });
+    } finally {
+      rmSync(testRoot, { force: true, recursive: true });
+    }
+  });
+
+  it('returns needsApproval for an external path until it is authorized', () => {
+    const testRoot = mkdtempSync(path.join(tmpdir(), 'claudian-path-policy-'));
+    const workspaceRoot = path.join(testRoot, 'vault');
+    const outsideRoot = path.join(testRoot, 'external');
+    mkdirSync(workspaceRoot);
+    mkdirSync(outsideRoot);
+
+    try {
+      expect(evaluatePathAccess({
+        externalPathMode: 'needsApproval',
+        operation: 'read',
+        requestedPath: path.join(outsideRoot, 'context.md'),
+        workspaceRoot,
+      })).toMatchObject({
+        outcome: 'needsApproval',
+        path: path.join(realpathSync.native(outsideRoot), 'context.md'),
+      });
+    } finally {
+      rmSync(testRoot, { force: true, recursive: true });
+    }
+  });
+
+  it('allows missing files below an existing in-vault directory', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'claudian-path-policy-'));
+    mkdirSync(path.join(root, 'notes'));
+
+    try {
+      expect(resolveAllowedFileOperationPath({
+        operation: 'write',
+        requestedPath: 'notes/new/deep.md',
+        workspaceRoot: root,
+      })).toBe(path.join(realpathSync.native(root), 'notes', 'new', 'deep.md'));
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/tests/unit/features/chat/ui/FileContextManager.test.ts
+++ b/tests/unit/features/chat/ui/FileContextManager.test.ts
@@ -247,7 +247,7 @@ describe('FileContextManager', () => {
     manager.destroy();
   });
 
-  it('shows vault-relative path in @ dropdown and inserts full path on selection', () => {
+  it('shows vault-relative path in @ dropdown and turns selection into a context chip', () => {
     const app = createMockApp({
       files: ['clipping/file.md'],
     });
@@ -269,8 +269,8 @@ describe('FileContextManager', () => {
 
     manager.handleMentionKeydown({ key: 'Enter', preventDefault: jest.fn() } as any);
 
-    // Now inserts full vault-relative path (WYSIWYG)
-    expect(inputEl.value).toBe('@clipping/file.md ');
+    // File references are represented by a removable chip, not prompt text.
+    expect(inputEl.value).toBe('');
     const attached = manager.getAttachedFiles();
     expect(attached.has('clipping/file.md')).toBe(true);
 
@@ -335,8 +335,8 @@ describe('FileContextManager', () => {
 
     manager.handleMentionKeydown({ key: 'Enter', preventDefault: jest.fn() } as any);
 
-    // Display shows friendly name, but state stores mapping to absolute path
-    expect(inputEl.value).toBe('@external/src/app.md ');
+    // External file references are represented by a removable chip.
+    expect(inputEl.value).toBe('');
     const attached = manager.getAttachedFiles();
     expect(attached.has('/external/src/app.md')).toBe(true);
     // Check transformation works

--- a/tests/unit/providers/claude/execution/ClaudeInteractionHandler.test.ts
+++ b/tests/unit/providers/claude/execution/ClaudeInteractionHandler.test.ts
@@ -24,6 +24,7 @@ function createPort(): jest.Mocked<ProviderInteractionPort> {
 function createHandler(
   port: jest.Mocked<ProviderInteractionPort>,
   onToolBlocked: jest.Mock = jest.fn(),
+  workspaceRoot?: string,
 ): CanUseTool {
   return createClaudeExecutionCanUseTool({
     interactionPort: port,
@@ -33,6 +34,7 @@ function createHandler(
     getPermissionMode: () => 'normal',
     resolveSdkPermissionMode: () => 'default',
     onToolBlocked,
+    workspaceRoot,
   });
 }
 
@@ -89,6 +91,26 @@ describe('createClaudeExecutionCanUseTool', () => {
       interrupt: false,
     });
     expect(onToolBlocked).toHaveBeenCalledWith('native-tool-1');
+  });
+
+  it('routes direct edits outside the vault through the approval flow', async () => {
+    const port = createPort();
+    const handler = createHandler(port, jest.fn(), '/vault');
+
+    const result = await handler(
+      'Edit',
+      { file_path: '/Users/lee/Downloads/report.md' },
+      nativeOptions,
+    );
+
+    expect(result?.behavior).toBe('allow');
+    expect(port.requestApproval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: 'Edit',
+        input: { file_path: '/Users/lee/Downloads/report.md' },
+      }),
+      nativeOptions.signal,
+    );
   });
 
   it('routes questions and injects Claude Code compatible custom-answer support', async () => {

--- a/tests/unit/providers/claude/execution/ClaudeVaultBoundaryHook.test.ts
+++ b/tests/unit/providers/claude/execution/ClaudeVaultBoundaryHook.test.ts
@@ -1,0 +1,62 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { createVaultBoundaryHook } from '@/providers/claude/execution/ClaudeExecutionRequestEncoder';
+
+describe('createVaultBoundaryHook', () => {
+  it('asks before an Edit targets a file outside the vault', async () => {
+    const testRoot = mkdtempSync(path.join(tmpdir(), 'claudian-vault-hook-'));
+    const vaultRoot = path.join(testRoot, 'vault');
+    mkdirSync(vaultRoot);
+
+    try {
+      const hook = createVaultBoundaryHook(vaultRoot).hooks[0];
+      await expect(hook({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Edit',
+        tool_input: { file_path: path.join(testRoot, 'outside.md') },
+        cwd: vaultRoot,
+        session_id: 'session',
+        transcript_path: '',
+      } as never, 'tool-1', {
+        signal: new AbortController().signal,
+      } as never)).resolves.toEqual(expect.objectContaining({
+        continue: false,
+        hookSpecificOutput: expect.objectContaining({
+          permissionDecision: 'ask',
+        }),
+      }));
+    } finally {
+      rmSync(testRoot, { force: true, recursive: true });
+    }
+  });
+
+  it('asks before a Bash command writes to a file outside the vault', async () => {
+    const testRoot = mkdtempSync(path.join(tmpdir(), 'claudian-vault-hook-'));
+    const vaultRoot = path.join(testRoot, 'vault');
+    const outsideFile = path.join(testRoot, 'outside.md');
+    mkdirSync(vaultRoot);
+
+    try {
+      const hook = createVaultBoundaryHook(vaultRoot).hooks[0];
+      await expect(hook({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: `sed -i '' 's/a/b/' ${outsideFile}` },
+        cwd: vaultRoot,
+        session_id: 'session',
+        transcript_path: '',
+      } as never, 'tool-2', {
+        signal: new AbortController().signal,
+      } as never)).resolves.toEqual(expect.objectContaining({
+        continue: false,
+        hookSpecificOutput: expect.objectContaining({
+          permissionDecision: 'ask',
+        }),
+      }));
+    } finally {
+      rmSync(testRoot, { force: true, recursive: true });
+    }
+  });
+});

--- a/tests/unit/shared/mention/MentionDropdownController.test.ts
+++ b/tests/unit/shared/mention/MentionDropdownController.test.ts
@@ -731,7 +731,33 @@ describe('MentionDropdownController', () => {
       localController.destroy();
     });
 
-    it('inserts folder mention as plain text and does not attach file context', () => {
+    it('turns a vault file mention into a removable context attachment', () => {
+      const onAttachFile = jest.fn();
+      const localCallbacks = createMockCallbacks({
+        onAttachFile,
+        getCachedVaultFiles: jest.fn().mockReturnValue([
+          { name: 'note.md', path: 'note.md', stat: { mtime: 1000 } } as any,
+        ]),
+      });
+      const localInput = createMockInput();
+      const localController = new MentionDropdownController(createMockEl(), localInput, localCallbacks);
+
+      localInput.value = '@note';
+      localInput.selectionStart = 5;
+      localInput.selectionEnd = 5;
+      localController.handleInputChange();
+      jest.advanceTimersByTime(200);
+
+      const enterEvent = { key: 'Enter', preventDefault: jest.fn(), isComposing: false } as any;
+      localController.handleKeydown(enterEvent);
+
+      expect(localInput.value).toBe('');
+      expect(onAttachFile).toHaveBeenCalledWith('note.md');
+
+      localController.destroy();
+    });
+
+    it('turns a folder mention into a removable context attachment', () => {
       const onAttachFile = jest.fn();
       const localCallbacks = createMockCallbacks({
         onAttachFile,
@@ -751,8 +777,8 @@ describe('MentionDropdownController', () => {
       const enterEvent = { key: 'Enter', preventDefault: jest.fn(), isComposing: false } as any;
       localController.handleKeydown(enterEvent);
 
-      expect(localInput.value).toBe('@src/ ');
-      expect(onAttachFile).not.toHaveBeenCalled();
+      expect(localInput.value).toBe('');
+      expect(onAttachFile).toHaveBeenCalledWith('src/');
 
       localController.destroy();
     });

--- a/tests/unit/style/components/input.test.ts
+++ b/tests/unit/style/components/input.test.ts
@@ -7,12 +7,12 @@ describe('Chat input toolbar styles', () => {
     'utf8',
   );
 
-  it('keeps the send button in toolbar flow so it cannot cover the mode selector', () => {
-    expect(css).not.toMatch(
+  it('anchors the send button inside the composer and leaves room for the toolbar', () => {
+    expect(css).toMatch(
       /\.claudian-input-send-button\s*\{[\s\S]*?position:\s*absolute;/,
     );
     expect(css).toMatch(
-      /\.claudian-input-send-button\s*\{[\s\S]*?margin-inline-start:\s*8px;/,
+      /\.claudian-input-toolbar\s*\{[\s\S]*?padding:\s*4px 56px 8px 10px;/,
     );
   });
 


### PR DESCRIPTION
## Summary
- add provider-neutral path containment with symlink and missing-parent checks
- block external direct edits before Claude tool execution and route external writes through approval
- prevent Codex external context from becoming writable roots
- apply the shared boundary to ACP provider file operations

## Validation
- focused path-policy and Claude interaction tests pass
- branch is based on latest fork/main

## Scope
Context Pack remains isolated on `feat/context-pack-experiment` and is not included in this PR.