### PR TITLE
chore: sync 2.3.0 version to main

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "packageManager": "pnpm@10.34.5",
   "description": "Oh My Claudian - provider-backed coding agents embedded in the Obsidian sidebar",
   "main": "main.js",


### PR DESCRIPTION
## Summary

- Sync `package.json` and `manifest.json` to `2.3.0` on `main`.
- Complete the version synchronization that was omitted when PR #76 was merged.
- Keep the release tag and the default branch version aligned.

## Validation

- `node scripts/check-release-version.mjs 2.3.0`

## Note

This is a release metadata correction only; the product changes are already included in PR #76.