### PR TITLE
fix: clarify waits and deduplicate restored chat history

### DIFF
--- a/src/features/chat/controllers/StreamController.ts
+++ b/src/features/chat/controllers/StreamController.ts
@@ -48,7 +48,6 @@ import { hasStreamingMathDelimiters } from '../../../utils/markdownMath';
 import { openVaultFile } from '../../../utils/obsidianCompat';
 import { getVaultPath, normalizePathForVault } from '../../../utils/path';
 import type { FeatureHost } from '../../FeatureHost';
-import { FLAVOR_TEXTS } from '../constants';
 import type { MessageRenderer, RenderContentOptions } from '../rendering/MessageRenderer';
 import { resolveSubagentAdapter } from '../rendering/subagentAdapterResolution';
 import {
@@ -1727,6 +1726,18 @@ export class StreamController {
 
   /** Debounce delay before showing thinking indicator (ms). */
   private static readonly THINKING_INDICATOR_DELAY = 400;
+  private static readonly FIRST_RESPONSE_WAIT_THRESHOLD = 5_000;
+  private static readonly SLOW_RESPONSE_THRESHOLD = 15_000;
+
+  private getThinkingStatus(elapsedMs: number): string {
+    if (elapsedMs >= StreamController.SLOW_RESPONSE_THRESHOLD) {
+      return 'The provider is taking longer than usual. You can stop and retry.';
+    }
+    if (elapsedMs >= StreamController.FIRST_RESPONSE_WAIT_THRESHOLD) {
+      return 'Waiting for the first response...';
+    }
+    return 'Starting agent...';
+  }
 
   /**
    * Schedules showing the thinking indicator after a delay.
@@ -1769,13 +1780,14 @@ export class StreamController {
         ? `claudian-thinking ${overrideCls}`
         : 'claudian-thinking';
       state.thinkingEl = state.currentContentEl.createDiv({ cls });
-      const text = overrideText || FLAVOR_TEXTS[Math.floor(Math.random() * FLAVOR_TEXTS.length)];
-      state.thinkingEl.createSpan({ text });
+      const statusSpan = state.thinkingEl.createSpan({
+        text: overrideText ?? this.getThinkingStatus(0),
+      });
 
       // Create timer span with initial value
       const timerSpan = state.thinkingEl.createSpan({ cls: 'claudian-thinking-hint' });
       const updateTimer = () => {
-        if (!state.responseStartTime) return;
+        if (state.responseStartTime === null) return;
         // Check if element is still connected to DOM (prevents orphaned interval updates)
         if (!timerSpan.isConnected) {
           if (state.flavorTimerInterval) {
@@ -1783,7 +1795,11 @@ export class StreamController {
           }
           return;
         }
-        const elapsedSeconds = Math.floor((performance.now() - state.responseStartTime) / 1000);
+        const elapsedMs = performance.now() - state.responseStartTime;
+        if (!overrideText) {
+          statusSpan.setText(this.getThinkingStatus(elapsedMs));
+        }
+        const elapsedSeconds = Math.floor(elapsedMs / 1000);
         timerSpan.setText(` (esc to interrupt · ${formatDurationMmSs(elapsedSeconds)})`);
       };
       updateTimer(); // Initial update

--- a/src/providers/claude/history/ClaudeConversationHistoryService.ts
+++ b/src/providers/claude/history/ClaudeConversationHistoryService.ts
@@ -217,13 +217,22 @@ function dedupeMessages(messages: ChatMessage[]): ChatMessage[] {
   const result: ChatMessage[] = [];
 
   for (const message of messages) {
-    const existing = byId.get(message.id);
+    const keys = [
+      message.id,
+      message.userMessageId ? `user:${message.userMessageId}` : null,
+      message.assistantMessageId ? `assistant:${message.assistantMessageId}` : null,
+    ].filter((key): key is string => key !== null);
+    const existing = keys
+      .map(key => byId.get(key))
+      .find((candidate): candidate is ChatMessage => candidate !== undefined);
     if (existing) {
       mergeDuplicateMessage(existing, message);
       continue;
     }
 
-    byId.set(message.id, message);
+    for (const key of keys) {
+      byId.set(key, message);
+    }
     result.push(message);
   }
 

--- a/tests/unit/features/chat/controllers/StreamController.test.ts
+++ b/tests/unit/features/chat/controllers/StreamController.test.ts
@@ -1302,6 +1302,27 @@ describe('StreamController - Text Content', () => {
       expect(deps.state.flavorTimerInterval).not.toBeNull();
     });
 
+    it('should explain long initial waits instead of showing random flavor text', () => {
+      deps.state.responseStartTime = performance.now();
+
+      controller.showThinkingIndicator();
+      jest.advanceTimersByTime(500); // Past the debounce delay
+
+      const thinkingEl = deps.state.thinkingEl;
+      expect(thinkingEl?.children[0].textContent).toBe('Starting agent...');
+      (thinkingEl!.children[1] as any).isConnected = true;
+
+      deps.state.responseStartTime = performance.now() - 5_000;
+      jest.advanceTimersByTime(1_000);
+      expect(thinkingEl?.children[0].textContent).toBe('Waiting for the first response...');
+
+      deps.state.responseStartTime = performance.now() - 15_000;
+      jest.advanceTimersByTime(1_000);
+      expect(thinkingEl?.children[0].textContent).toBe(
+        'The provider is taking longer than usual. You can stop and retry.',
+      );
+    });
+
     it('should clear timer interval when hiding thinking indicator', () => {
       deps.state.responseStartTime = performance.now();
 

--- a/tests/unit/providers/claude/history/ClaudeConversationHistoryService.test.ts
+++ b/tests/unit/providers/claude/history/ClaudeConversationHistoryService.test.ts
@@ -374,6 +374,58 @@ describe('ClaudeConversationHistoryService', () => {
   });
 
   describe('hydrateConversationHistory', () => {
+    it('does not duplicate live messages when native history uses different local ids', async () => {
+      const service = new ClaudeConversationHistoryService();
+      const conversation = createConversation({
+        messages: [
+          {
+            id: 'live-user',
+            role: 'user',
+            content: 'PING',
+            timestamp: 1,
+            userMessageId: 'native-user',
+          },
+          {
+            id: 'live-assistant',
+            role: 'assistant',
+            content: 'PONG',
+            timestamp: 2,
+            assistantMessageId: 'native-assistant',
+          },
+        ],
+      });
+      jest.spyOn(historyStore, 'locateSDKSessions').mockResolvedValue(new Map([
+        ['session-1', {
+          availability: 'available',
+          sessionPath: '/vault/session-1.jsonl',
+        }],
+      ]));
+      jest.spyOn(historyStore, 'loadSDKSessionMessages').mockResolvedValue({
+        messages: [
+          {
+            id: 'native-user-local',
+            role: 'user',
+            content: 'PING',
+            timestamp: 1,
+            userMessageId: 'native-user',
+          },
+          {
+            id: 'native-assistant-local',
+            role: 'assistant',
+            content: 'PONG',
+            timestamp: 2,
+            assistantMessageId: 'native-assistant',
+          },
+        ],
+        skippedLines: 0,
+      });
+
+      await service.hydrateConversationHistory(conversation, '/vault');
+
+      expect(conversation.messages).toHaveLength(2);
+      expect(conversation.messages.map(message => message.content)).toEqual(['PING', 'PONG']);
+    });
+
     it('recovers an unlinked native transcript from the conversation timestamps', async () => {
       const service = new ClaudeConversationHistoryService();
       const conversation = createConversation({


### PR DESCRIPTION
## What changed

- Deduplicate live Claude messages against native history using provider message IDs.
- Replace random waiting flavor text with explicit startup, first-response, and slow-response states.
- Preserve the existing stop/retry flow; this change does not auto-cancel slow runs.

## Validation

- 402 test suites passed
- 6,956 tests passed
- 19 architecture/release checks passed
- Typecheck passed
- Production build passed and synced to the test Vault
- Manual smoke verified a newly created turn reopens once

## Follow-ups

- Historical duplicate records already persisted before this fix need a separate cleanup/compatibility pass.
- Complete task modal/save-path errors are not included because that UI is not present on this base branch.