### PR TITLE
feat: preview and persist chat context scope

### DIFF
--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -40,6 +40,7 @@ import type { TabAttention } from '../state/types';
 import type { FileContextManager } from '../ui/FileContext';
 import type { ImageContextManager } from '../ui/ImageContext';
 import type { ExternalContextSelector, McpServerSelector } from '../ui/InputToolbar';
+import type { ScopePreview } from '../ui/ScopePreview';
 import type { StatusPanel } from '../ui/StatusPanel';
 
 function runConversationAction(action: () => Promise<void>, failureMessage: string): void {
@@ -83,6 +84,7 @@ export interface ConversationControllerDeps {
   getImageContextManager: () => ImageContextManager | null;
   getMcpServerSelector: () => McpServerSelector | null;
   getExternalContextSelector: () => ExternalContextSelector | null;
+  getScopePreview?: () => ScopePreview | null;
   clearQueuedMessage: () => void;
   getTitleGenerationService: () => TitleGenerationService | null;
   getStatusPanel: () => StatusPanel | null;
@@ -273,6 +275,7 @@ export class ConversationController {
       this.deps.getExternalContextSelector()?.clearExternalContexts(
         plugin.settings.persistentExternalContextPaths || []
       );
+      this.syncScopePreview();
       this.deps.clearQueuedMessage();
 
       this.callbacks.onNewConversation?.();
@@ -315,6 +318,7 @@ export class ConversationController {
       this.deps.getExternalContextSelector()?.clearExternalContexts(
         plugin.settings.persistentExternalContextPaths || []
       );
+      this.syncScopePreview();
 
       this.deps.getMcpServerSelector()?.clearEnabled();
 
@@ -717,6 +721,14 @@ export class ConversationController {
       // Session with messages: restore exactly what was saved
       externalContextSelector.setExternalContexts(savedPaths || []);
     }
+    this.syncScopePreview();
+  }
+
+  private syncScopePreview(): void {
+    const preview = this.deps.getScopePreview?.();
+    if (!preview) return;
+    preview.setCurrentNote(this.deps.getFileContextManager()?.getCurrentNotePath() ?? null);
+    preview.setExternalContextPaths(this.deps.getExternalContextSelector()?.getExternalContexts() ?? []);
   }
 
   // ============================================

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -1413,6 +1413,11 @@ function initializeInputToolbar(
   // Wire external context changes
   tab.ui.externalContextSelector.setOnChange((paths) => {
     tab.ui.scopePreview?.setExternalContextPaths(paths);
+    if (tab.conversationId) {
+      void plugin.updateConversation(tab.conversationId, {
+        externalContextPaths: paths.length > 0 ? [...paths] : undefined,
+      });
+    }
     tab.ui.fileContextManager?.preScanExternalContexts();
     onCommandContextChanged?.();
     onUserModified?.();

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -67,6 +67,7 @@ import { createInputToolbar } from '../ui/InputToolbar';
 import { InstructionModeManager as InstructionModeManagerClass } from '../ui/InstructionModeManager';
 import { NavigationSidebar } from '../ui/NavigationSidebar';
 import { renderProviderDiagnosticCard } from '../ui/ProviderDiagnosticCard';
+import { ScopePreview } from '../ui/ScopePreview';
 import { StatusPanel } from '../ui/StatusPanel';
 import { autoResizeTextarea } from '../ui/textareaResize';
 import { recalculateUsageForModel } from '../utils/usageInfo';
@@ -1088,6 +1089,7 @@ function initializeContextManagers(
           currentNote: notePath ?? undefined,
         });
       },
+      onScopeChanged: (notePath) => tab.ui.scopePreview?.setCurrentNote(notePath),
     },
     dom.inputContainerEl,
     contextTray,
@@ -1409,7 +1411,8 @@ function initializeInputToolbar(
   });
 
   // Wire external context changes
-  tab.ui.externalContextSelector.setOnChange(() => {
+  tab.ui.externalContextSelector.setOnChange((paths) => {
+    tab.ui.scopePreview?.setExternalContextPaths(paths);
     tab.ui.fileContextManager?.preScanExternalContexts();
     onCommandContextChanged?.();
     onUserModified?.();
@@ -1458,6 +1461,7 @@ export function initializeTabUI(
       tab.renderer?.scrollToBottomIfNeeded();
     },
   });
+  tab.ui.scopePreview = new ScopePreview(dom.scopePreviewEl);
   initializeContextManagers(tab, plugin, onUserModified);
 
   const catalogInfo = options.getProviderCatalogConfig?.() ?? null;
@@ -2127,6 +2131,10 @@ export async function destroyTab(tab: TabData): Promise<void> {
   cleanup.register('tab composer context tray', () => {
     tab.ui.contextTray?.destroy();
     tab.ui.contextTray = null;
+  });
+  cleanup.register('tab scope preview', () => {
+    tab.ui.scopePreview?.destroy();
+    tab.ui.scopePreview = null;
   });
   cleanup.register('tab image context manager', () => tab.ui.imageContextManager?.destroy());
   cleanup.register('tab file context manager', () => tab.ui.fileContextManager?.destroy());

--- a/src/features/chat/tabs/TabConversationControllerFactory.ts
+++ b/src/features/chat/tabs/TabConversationControllerFactory.ts
@@ -42,6 +42,7 @@ export function createTabConversationController(
       getImageContextManager: () => ui.imageContextManager,
       getMcpServerSelector: () => ui.mcpServerSelector,
       getExternalContextSelector: () => ui.externalContextSelector,
+      getScopePreview: () => ui.scopePreview,
       clearQueuedMessage: () => tab.controllers.inputController?.clearQueuedMessage(),
       getTitleGenerationService: () => services.titleGenerationService,
       getStatusPanel: () => ui.statusPanel,

--- a/src/features/chat/tabs/TabRuntimeFactory.ts
+++ b/src/features/chat/tabs/TabRuntimeFactory.ts
@@ -102,6 +102,7 @@ export function createTabRuntime(
     },
     ui: {
       contextTray: null,
+      scopePreview: null,
       fileContextManager: null,
       imageContextManager: null,
       modelSelector: null,
@@ -143,6 +144,7 @@ function buildTabDOM(contentEl: HTMLElement): TabDOMElements {
   const navRowEl = inputContainerEl.createDiv({ cls: 'claudian-input-nav-row' });
   const inputWrapper = inputContainerEl.createDiv({ cls: 'claudian-input-wrapper' });
   const contextRowEl = inputWrapper.createDiv({ cls: 'claudian-context-row' });
+  const scopePreviewEl = inputWrapper.createDiv({ cls: 'claudian-scope-preview' });
   const inputEl = inputWrapper.createEl('textarea', {
     cls: 'claudian-input',
     attr: {
@@ -174,6 +176,7 @@ function buildTabDOM(contentEl: HTMLElement): TabDOMElements {
     sendButtonEl,
     navRowEl,
     contextRowEl,
+    scopePreviewEl,
     eventCleanups: [],
   };
 }

--- a/src/features/chat/tabs/types.ts
+++ b/src/features/chat/tabs/types.ts
@@ -35,6 +35,7 @@ import type {
 } from '../ui/InputToolbar';
 import type { InstructionModeManager } from '../ui/InstructionModeManager';
 import type { NavigationSidebar } from '../ui/NavigationSidebar';
+import type { ScopePreview } from '../ui/ScopePreview';
 import type { StatusPanel } from '../ui/StatusPanel';
 import type { TabSession } from './TabSession';
 
@@ -132,6 +133,7 @@ export interface TabServices {
  */
 export interface TabUIComponents {
   contextTray: ComposerContextTray | null;
+  scopePreview: ScopePreview | null;
   fileContextManager: FileContextManager | null;
   imageContextManager: ImageContextManager | null;
   modelSelector: ModelSelector | null;
@@ -173,6 +175,8 @@ export interface TabDOMElements {
 
   /** Composer-owned context tray container inside the input wrapper. */
   contextRowEl: HTMLElement;
+  /** Read-only context scope summary shown above the composer input. */
+  scopePreviewEl: HTMLElement;
 
   /** Cleanup functions for event listeners (prevents memory leaks). */
   eventCleanups: Array<() => void>;

--- a/src/features/chat/ui/FileContext.ts
+++ b/src/features/chat/ui/FileContext.ts
@@ -26,6 +26,7 @@ export interface FileContextCallbacks {
   onChipsChanged?: () => void;
   onUserChipsChanged?: () => void;
   onCurrentNoteChanged?: (notePath: string | null) => void;
+  onScopeChanged?: (notePath: string | null) => void;
   getExternalContexts?: () => string[];
   /** Called when an agent is selected from the @ mention dropdown. */
   onAgentMentionSelect?: (agentId: string) => void;
@@ -170,6 +171,7 @@ export class FileContextManager {
     this.currentNotePath = null;
     this.state.resetForNewConversation();
     this.refreshCurrentNoteChip();
+    this.callbacks.onScopeChanged?.(null);
   }
 
   /** Resets state for loading an existing conversation. */
@@ -177,6 +179,7 @@ export class FileContextManager {
     this.currentNotePath = null;
     this.state.resetForLoadedConversation(hasMessages);
     this.refreshCurrentNoteChip();
+    this.callbacks.onScopeChanged?.(null);
   }
 
   /** Sets current note (for restoring persisted state). */
@@ -186,6 +189,7 @@ export class FileContextManager {
       this.state.attachFile(notePath);
     }
     this.refreshCurrentNoteChip();
+    this.callbacks.onScopeChanged?.(notePath);
   }
 
   /** Auto-attaches the currently focused file (for new sessions). */
@@ -197,6 +201,7 @@ export class FileContextManager {
         this.currentNotePath = normalizedPath;
         this.state.attachFile(normalizedPath);
         this.refreshCurrentNoteChip();
+        this.callbacks.onScopeChanged?.(normalizedPath);
       }
     }
   }

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -745,6 +745,9 @@ export class ExternalContextSelector {
     this.container.empty();
 
     const iconWrapper = this.container.createDiv({ cls: 'claudian-external-context-icon-wrapper' });
+    iconWrapper.setAttribute('role', 'button');
+    iconWrapper.setAttribute('tabindex', '0');
+    iconWrapper.setAttribute('aria-label', 'Add external context folder');
 
     this.iconEl = iconWrapper.createDiv({ cls: 'claudian-external-context-icon' });
     setIcon(this.iconEl, 'folder');
@@ -756,6 +759,11 @@ export class ExternalContextSelector {
     // Click to open native folder picker
     iconWrapper.addEventListener('click', (e) => {
       e.stopPropagation();
+      void this.openFolderPicker();
+    });
+    iconWrapper.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      event.preventDefault();
       void this.openFolderPicker();
     });
 
@@ -892,6 +900,10 @@ export class ExternalContextSelector {
     if (count > 0) {
       this.iconEl.addClass('active');
       this.iconEl.setAttribute('title', `${count} external context${count > 1 ? 's' : ''} (click to add more)`);
+      this.iconEl.parentElement?.setAttribute(
+        'aria-label',
+        `${count} external context folder${count > 1 ? 's' : ''}. Click to add more.`,
+      );
 
       // Show badge only when more than 1 path
       if (count > 1) {
@@ -903,6 +915,7 @@ export class ExternalContextSelector {
     } else {
       this.iconEl.removeClass('active');
       this.iconEl.setAttribute('title', 'Add external contexts (click)');
+      this.iconEl.parentElement?.setAttribute('aria-label', 'Add external context folder');
       this.badgeEl.removeClass('visible');
     }
   }

--- a/src/features/chat/ui/ScopePreview.ts
+++ b/src/features/chat/ui/ScopePreview.ts
@@ -1,0 +1,87 @@
+import { setIcon } from 'obsidian';
+
+export interface ScopePreviewModel {
+  label: string;
+  detail: string;
+  title: string;
+}
+
+function getPathName(path: string): string {
+  const normalized = path.replace(/\\/g, '/').replace(/\/$/, '');
+  return normalized.split('/').pop() || path;
+}
+
+export function buildScopePreviewModel(
+  currentNotePath: string | null,
+  externalContextPaths: readonly string[],
+): ScopePreviewModel | null {
+  const note = currentNotePath ? getPathName(currentNotePath) : null;
+  const folders = externalContextPaths.map(getPathName);
+  if (!note && folders.length === 0) return null;
+
+  const parts = [
+    ...(note ? [`note: ${note}`] : []),
+    ...(folders.length > 0
+      ? [`folder${folders.length === 1 ? '' : 's'}: ${folders.join(', ')}`]
+      : []),
+  ];
+  return {
+    label: 'Context scope',
+    detail: parts.join(' · '),
+    title: `${parts.join(' · ')}. Writes remain governed by the selected provider's permissions.`,
+  };
+}
+
+/** Presents the context boundary without owning context selection or execution. */
+export class ScopePreview {
+  private readonly containerEl: HTMLElement;
+  private currentNotePath: string | null = null;
+  private externalContextPaths: string[] = [];
+
+  constructor(containerEl: HTMLElement) {
+    this.containerEl = containerEl;
+    this.containerEl.addClass('claudian-scope-preview');
+    this.render();
+  }
+
+  setCurrentNote(path: string | null): void {
+    this.currentNotePath = path;
+    this.render();
+  }
+
+  setExternalContextPaths(paths: readonly string[]): void {
+    this.externalContextPaths = [...paths];
+    this.render();
+  }
+
+  clear(): void {
+    this.currentNotePath = null;
+    this.externalContextPaths = [];
+    this.render();
+  }
+
+  destroy(): void {
+    this.containerEl.empty();
+    this.containerEl.removeClass('claudian-scope-preview');
+  }
+
+  private render(): void {
+    this.containerEl.empty();
+    const model = buildScopePreviewModel(this.currentNotePath, this.externalContextPaths);
+    this.containerEl.toggleClass('has-content', model !== null);
+    if (!model) return;
+
+    const iconEl = this.containerEl.createSpan({ cls: 'claudian-scope-preview-icon' });
+    setIcon(iconEl, 'layers-3');
+    this.containerEl.createSpan({
+      cls: 'claudian-scope-preview-label',
+      text: `${model.label}:`,
+    });
+    const detailEl = this.containerEl.createSpan({
+      cls: 'claudian-scope-preview-detail',
+      text: model.detail,
+    });
+    detailEl.setAttribute('title', model.title);
+    this.containerEl.setAttribute('aria-label', model.title);
+  }
+}

--- a/src/style/components/context-tray.css
+++ b/src/style/components/context-tray.css
@@ -14,6 +14,47 @@
   display: flex;
 }
 
+/* Read-only explanation of the context that will accompany the next turn. */
+.claudian-scope-preview {
+  display: none;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  max-width: 100%;
+  padding: 6px 8px 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+.claudian-scope-preview.has-content {
+  display: flex;
+}
+
+.claudian-scope-preview-icon {
+  display: flex;
+  flex: 0 0 auto;
+  color: var(--text-faint);
+}
+
+.claudian-scope-preview-icon svg {
+  width: 12px;
+  height: 12px;
+}
+
+.claudian-scope-preview-label {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.claudian-scope-preview-detail {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .claudian-context-chip {
   display: inline-flex;
   align-items: center;

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -445,6 +445,32 @@ describe('Tab provider execution ownership', () => {
     globalThis.ResizeObserver = originalResizeObserver;
   });
 
+  it('persists external context changes for a bound conversation', async () => {
+    const originalResizeObserver = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = jest.fn().mockImplementation(() => ({
+      disconnect: jest.fn(),
+      observe: jest.fn(),
+    })) as unknown as typeof ResizeObserver;
+    const conversation = createConversation();
+    const updateConversation = jest.fn().mockResolvedValue(undefined);
+    const plugin = createPlugin({ updateConversation });
+    const tab = createTab({
+      plugin,
+      containerEl: createMockEl() as any,
+      conversation,
+    });
+    initializeTabUI(tab, plugin);
+
+    const result = tab.ui.externalContextSelector?.addExternalContext('/tmp');
+    await new Promise<void>(resolve => setImmediate(resolve));
+
+    expect(result?.success).toBe(true);
+    expect(updateConversation).toHaveBeenCalledWith(conversation.id, {
+      externalContextPaths: ['/tmp'],
+    });
+    globalThis.ResizeObserver = originalResizeObserver;
+  });
+
   it('binds persisted native state and prepares only for a bound conversation', async () => {
     const conversation = createConversation();
     const plugin = createPlugin({

--- a/tests/unit/features/chat/ui/ExternalContextSelector.test.ts
+++ b/tests/unit/features/chat/ui/ExternalContextSelector.test.ts
@@ -75,6 +75,14 @@ describe('ExternalContextSelector', () => {
   });
 
   describe('Persistent Paths Management', () => {
+    it('exposes the folder picker as a keyboard-accessible control', () => {
+      const picker = parentEl.querySelector('.claudian-external-context-icon-wrapper');
+
+      expect(picker?.getAttribute('role')).toBe('button');
+      expect(picker?.getAttribute('tabindex')).toBe('0');
+      expect(picker?.getAttribute('aria-label')).toBe('Add external context folder');
+    });
+
     it('should initialize with empty persistent paths', () => {
       expect(selector.getPersistentPaths()).toEqual([]);
     });

--- a/tests/unit/features/chat/ui/ScopePreview.test.ts
+++ b/tests/unit/features/chat/ui/ScopePreview.test.ts
@@ -1,0 +1,39 @@
+import { createMockEl } from '@test/helpers/MockElement';
+
+import {
+  buildScopePreviewModel,
+  ScopePreview,
+} from '@/features/chat/ui/ScopePreview';
+
+jest.mock('obsidian', () => ({
+  setIcon: jest.fn(),
+}));
+
+describe('ScopePreview', () => {
+  it('does not present a scope when no context is selected', () => {
+    expect(buildScopePreviewModel(null, [])).toBeNull();
+  });
+
+  it('summarizes the active note and selected folders', () => {
+    expect(buildScopePreviewModel('notes/Plan.md', ['docs', 'src/'])).toEqual({
+      label: 'Context scope',
+      detail: 'note: Plan.md · folders: docs, src',
+      title: expect.stringContaining('Writes remain governed'),
+    });
+  });
+
+  it('renders and clears the non-interactive preview', () => {
+    const containerEl = createMockEl();
+    const preview = new ScopePreview(containerEl as unknown as HTMLElement);
+
+    expect(containerEl.hasClass('has-content')).toBe(false);
+    preview.setCurrentNote('notes/Plan.md');
+    expect(containerEl.hasClass('has-content')).toBe(true);
+    expect(containerEl.querySelector('.claudian-scope-preview-label')?.textContent).toBe('Context scope:');
+    expect(containerEl.querySelector('.claudian-scope-preview-detail')?.textContent).toBe('note: Plan.md');
+
+    preview.clear();
+    expect(containerEl.hasClass('has-content')).toBe(false);
+    expect(containerEl.children).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What changed

- Add a compact, provider-neutral context scope preview above the composer.
- Show the active note and selected external folders before sending a turn.
- Keep the preview honest: writes remain governed by provider permissions.
- Make the external folder picker keyboard-accessible with a clear label.
- Persist external context changes immediately for bound conversations.
- Restore the preview and selected folders when reopening a conversation.

## Validation

- 403 test suites passed
- 6,964 tests passed
- 19 architecture/release checks passed
- Typecheck passed
- Lint passed with existing sentence-case warnings only
- Production build passed and synced to the test Vault
- Manual Obsidian smoke verified folder selection, reload restoration, and cleanup
