### PR TITLE
fix: sync upstream runtime reliability fixes

### DIFF
--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -261,6 +261,7 @@ export interface ProviderServiceTierToggleConfig {
   inactiveLabel: string;
   activeValue: string;
   activeLabel: string;
+  isActive?: boolean;
   description?: string;
 }
 

--- a/src/features/chat/actions/toggleServiceTier.ts
+++ b/src/features/chat/actions/toggleServiceTier.ts
@@ -19,7 +19,8 @@ export async function toggleServiceTier(
     return false;
   }
 
-  const next = settings.serviceTier === toggleConfig.activeValue
+  const isActive = toggleConfig.isActive ?? settings.serviceTier === toggleConfig.activeValue;
+  const next = isActive
     ? toggleConfig.inactiveValue
     : toggleConfig.activeValue;
   await context.onServiceTierChange(next);

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -539,14 +539,17 @@ export class ServiceTierToggle {
 
     this.container.removeClass('claudian-hidden');
     const current = this.callbacks.getSettings().serviceTier;
-    const isActive = current === toggleConfig.activeValue;
+    const isActive = toggleConfig.isActive ?? current === toggleConfig.activeValue;
     if (isActive) {
       this.buttonEl.addClass('active');
     } else {
       this.buttonEl.removeClass('active');
     }
 
-    this.container.setAttribute('title', 'Toggle on/off fast mode');
+    const currentLabel = isActive
+      ? toggleConfig.activeLabel
+      : toggleConfig.inactiveLabel;
+    this.container.setAttribute('title', `Fast mode: ${currentLabel}`);
   }
 
   async toggle(): Promise<boolean> {

--- a/src/providers/claude/execution/ClaudeInteractionHandler.ts
+++ b/src/providers/claude/execution/ClaudeInteractionHandler.ts
@@ -191,7 +191,13 @@ export class ClaudeInteractionHandler {
           interrupt: true,
         };
       }
-      if (decision === 'allow' || decision === 'allow-always') {
+      if (decision === 'allow') {
+        return {
+          behavior: 'allow',
+          updatedInput: input,
+        };
+      }
+      if (decision === 'allow-always') {
         return {
           behavior: 'allow',
           updatedInput: input,

--- a/src/providers/codex/execution/CodexExecutionSession.ts
+++ b/src/providers/codex/execution/CodexExecutionSession.ts
@@ -44,6 +44,7 @@ import {
 import { getCodexModelOptions } from '../modelOptions';
 import {
   findCodexModel,
+  resolveCodexModelServiceTier,
   resolveCodexReasoningEffort,
 } from '../models';
 import { toCodexRuntimeModelId } from '../modelSelection';
@@ -103,6 +104,8 @@ const LEGACY_WORKSPACE_DEPENDENCY_INSTRUCTIONS =
   'This thread predates Oh My Claudian client-hosted workspace dependency tools. Do not emulate load_workspace_dependencies or install replacement dependencies.';
 const CODEX_SUPPORTS_EXACT_BUILT_IN_TOOL_ALLOW_LIST = false;
 const MISSED_TURN_COMPLETION_GRACE_MS = 1_000;
+const MISSED_TURN_COMPLETION_MAX_ATTEMPTS = 3;
+const MISSED_TURN_COMPLETION_RETRY_BASE_MS = 500;
 const THREAD_READ_RECOVERY_TIMEOUT_MS = 5_000;
 const CODEX_CONSUMED_FORK_STATE_KEYS = [
   'forkSource',
@@ -285,6 +288,10 @@ export class CodexExecutionSession
   private forkSetupPromise: Promise<CodexEnsuredThread> | null = null;
   private disposePromise: Promise<void> | null = null;
   private completionRecoveryTimer: number | null = null;
+  private completionRecoveryRetryTimer: number | null = null;
+  private completionRecoveryRun: CodexExecutionRun | null = null;
+  private completionRecoveryAttempts = 0;
+  private completionRecoveryInFlight = false;
   private disposed = false;
   private lifecycleGeneration = 0;
 
@@ -798,10 +805,16 @@ export class CodexExecutionSession
   private scheduleMissedTurnCompletionRecovery(run: CodexExecutionRun): void {
     if (
       this.completionRecoveryTimer
+      || this.completionRecoveryRetryTimer
       || !run.nativeThreadId
       || !run.nativeTurnId
+      || this.completionRecoveryInFlight
     ) {
       return;
+    }
+    if (this.completionRecoveryRun !== run) {
+      this.completionRecoveryRun = run;
+      this.completionRecoveryAttempts = 0;
     }
     const generation = this.lifecycleGeneration;
     this.completionRecoveryTimer = window.setTimeout(() => {
@@ -811,9 +824,17 @@ export class CodexExecutionSession
   }
 
   private cancelMissedTurnCompletionRecovery(): void {
-    if (this.completionRecoveryTimer === null) return;
-    window.clearTimeout(this.completionRecoveryTimer);
+    if (this.completionRecoveryTimer !== null) {
+      window.clearTimeout(this.completionRecoveryTimer);
+    }
+    if (this.completionRecoveryRetryTimer !== null) {
+      window.clearTimeout(this.completionRecoveryRetryTimer);
+    }
     this.completionRecoveryTimer = null;
+    this.completionRecoveryRetryTimer = null;
+    this.completionRecoveryRun = null;
+    this.completionRecoveryAttempts = 0;
+    this.completionRecoveryInFlight = false;
   }
 
   private async recoverMissedTurnCompletion(
@@ -835,6 +856,9 @@ export class CodexExecutionSession
       return;
     }
 
+    this.completionRecoveryInFlight = true;
+    this.completionRecoveryAttempts += 1;
+
     let result: ThreadReadResult;
     try {
       result = await transport.request<ThreadReadResult>(
@@ -843,8 +867,32 @@ export class CodexExecutionSession
         THREAD_READ_RECOVERY_TIMEOUT_MS,
       );
     } catch {
+      this.completionRecoveryInFlight = false;
+      this.retryMissedTurnCompletion(run, generation);
       return;
     }
+    this.completionRecoveryInFlight = false;
+    if (
+      this.activeRun !== run
+      || run.isTerminal
+      || run.isCancellationRequested
+      || generation !== this.lifecycleGeneration
+    ) {
+      this.retryMissedTurnCompletion(run, generation);
+      return;
+    }
+    const turn = result.thread.turns.find(candidate => candidate.id === turnId);
+    if (!turn || turn.status === 'inProgress') {
+      this.retryMissedTurnCompletion(run, generation);
+      return;
+    }
+    this.handleNotification('turn/completed', { threadId, turn });
+  }
+
+  private retryMissedTurnCompletion(
+    run: CodexExecutionRun,
+    generation: number,
+  ): void {
     if (
       this.activeRun !== run
       || run.isTerminal
@@ -853,9 +901,22 @@ export class CodexExecutionSession
     ) {
       return;
     }
-    const turn = result.thread.turns.find(candidate => candidate.id === turnId);
-    if (!turn || turn.status === 'inProgress') return;
-    this.handleNotification('turn/completed', { threadId, turn });
+    if (this.completionRecoveryAttempts < MISSED_TURN_COMPLETION_MAX_ATTEMPTS) {
+      const delay = MISSED_TURN_COMPLETION_RETRY_BASE_MS
+        * (2 ** (this.completionRecoveryAttempts - 1));
+      this.completionRecoveryRetryTimer = window.setTimeout(() => {
+        this.completionRecoveryRetryTimer = null;
+        this.scheduleMissedTurnCompletionRecovery(run);
+      }, delay);
+      return;
+    }
+    this.cancelMissedTurnCompletionRecovery();
+    this.finishError(
+      run,
+      'provider',
+      'Codex became idle, but its completed turn could not be recovered.',
+      true,
+    );
   }
 
   private observeNativeTurn(threadId: string, nativeTurnId: string): boolean {
@@ -2026,18 +2087,7 @@ function resolveCodexServiceTier(
     getCodexProviderSettings(settings).discoveredModels,
     modelId,
   );
-  if (!model) return null;
-  if (typeof serviceTier === 'string') {
-    if (model.serviceTiers.some(tier => tier.id === serviceTier)) {
-      return serviceTier;
-    }
-    if (serviceTier === 'fast') {
-      return model.serviceTiers.find(
-        tier => tier.name.toLowerCase() === 'fast',
-      )?.id ?? null;
-    }
-  }
-  return model.defaultServiceTier;
+  return resolveCodexModelServiceTier(model, serviceTier);
 }
 
 function shouldExposeDynamicTools(policy: ProviderToolPolicy): boolean {

--- a/src/providers/codex/models.ts
+++ b/src/providers/codex/models.ts
@@ -38,6 +38,7 @@ export const CODEX_FALLBACK_REASONING_EFFORT_VALUES = [
 
 const DEFAULT_INPUT_MODALITIES: Array<'text' | 'image'> = ['text', 'image'];
 const ULTRA_REASONING_EFFORT = 'ultra';
+export const CODEX_DEFAULT_SERVICE_TIER = 'default';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
@@ -254,4 +255,23 @@ export function getCodexFastServiceTier(
   model: CodexDiscoveredModel,
 ): CodexModelServiceTier | null {
   return model.serviceTiers.find(tier => tier.name.trim().toLowerCase() === 'fast') ?? null;
+}
+
+export function resolveCodexModelServiceTier(
+  model: CodexDiscoveredModel | null,
+  selectedServiceTier: unknown,
+): string | null {
+  if (!model) return null;
+  if (selectedServiceTier === CODEX_DEFAULT_SERVICE_TIER) {
+    return CODEX_DEFAULT_SERVICE_TIER;
+  }
+  if (typeof selectedServiceTier === 'string') {
+    if (model.serviceTiers.some(tier => tier.id === selectedServiceTier)) {
+      return selectedServiceTier;
+    }
+    if (selectedServiceTier === 'fast') {
+      return getCodexFastServiceTier(model)?.id ?? null;
+    }
+  }
+  return model.defaultServiceTier;
 }

--- a/src/providers/codex/runtime/CodexNotificationRouter.ts
+++ b/src/providers/codex/runtime/CodexNotificationRouter.ts
@@ -112,7 +112,7 @@ export class CodexNotificationRouter {
   private sawPlanDelta = false;
   private startedUserMessageIds = new Set<string>();
   private startedAgentMessageIds = new Set<string>();
-  private agentMessageDeltaIds = new Set<string>();
+  private streamedAgentMessageTextById = new Map<string, string>();
   private emittedMemoryCitationIds = new Set<string>();
   private emittedMemoryCitationKeys = new Set<string>();
   private streamedAssistantTurnText = '';
@@ -208,7 +208,7 @@ export class CodexNotificationRouter {
     this.sawPlanDelta = false;
     this.startedUserMessageIds.clear();
     this.startedAgentMessageIds.clear();
-    this.agentMessageDeltaIds.clear();
+    this.streamedAgentMessageTextById.clear();
     this.emittedMemoryCitationIds.clear();
     this.emittedMemoryCitationKeys.clear();
     this.resetAssistantTextTracking();
@@ -248,7 +248,7 @@ export class CodexNotificationRouter {
     this.sawPlanDelta = false;
     this.startedUserMessageIds.clear();
     this.startedAgentMessageIds.clear();
-    this.agentMessageDeltaIds.clear();
+    this.streamedAgentMessageTextById.clear();
     this.emittedMemoryCitationIds.clear();
     this.emittedMemoryCitationKeys.clear();
     this.resetAssistantTextTracking();
@@ -338,7 +338,8 @@ export class CodexNotificationRouter {
   }
 
   private onAgentMessageDelta(params: AgentMessageDeltaNotification): void {
-    this.agentMessageDeltaIds.add(params.itemId);
+    const previousText = this.streamedAgentMessageTextById.get(params.itemId) ?? '';
+    this.streamedAgentMessageTextById.set(params.itemId, previousText + params.delta);
     this.appendAssistantText(params.delta, params.itemId);
     this.emit({ type: 'text', content: params.delta });
   }
@@ -965,6 +966,22 @@ export class CodexNotificationRouter {
     this.emit({ type: 'text', content: missingText });
   }
 
+  private emitMissingAgentMessageText(text: string, itemId: string): void {
+    const streamedText = this.streamedAgentMessageTextById.get(itemId) ?? '';
+    const missingText = normalizeAgentMessageCompletionText(text, streamedText);
+    if (text) {
+      this.streamedAgentMessageTextById.set(itemId, text);
+    }
+    if (!missingText) {
+      return;
+    }
+
+    this.claimAssistantSegment(itemId);
+    this.currentAssistantSegmentText = text;
+    this.streamedAssistantTurnText += missingText;
+    this.emit({ type: 'text', content: missingText });
+  }
+
   private emitMissingAssistantTurnText(text: string): void {
     const missingText = normalizeAgentMessageCompletionText(
       text,
@@ -976,6 +993,12 @@ export class CodexNotificationRouter {
 
     this.streamedAssistantTurnText += missingText;
     this.currentAssistantSegmentText += missingText;
+    if (this.currentAssistantSegmentId) {
+      this.streamedAgentMessageTextById.set(
+        this.currentAssistantSegmentId,
+        this.currentAssistantSegmentText,
+      );
+    }
     this.emit({ type: 'text', content: missingText });
   }
 
@@ -1723,8 +1746,8 @@ export class CodexNotificationRouter {
     }
 
     const visibleText = stripCodexMemoryCitationMarkup(item.text);
-    if (!this.agentMessageDeltaIds.has(item.id) && visibleText) {
-      this.emitMissingAssistantSegmentText(visibleText, item.id);
+    if (visibleText) {
+      this.emitMissingAgentMessageText(visibleText, item.id);
     }
 
     this.emitMemoryCitation(item.memoryCitation, item.id);

--- a/src/providers/codex/ui/CodexChatUIConfig.ts
+++ b/src/providers/codex/ui/CodexChatUIConfig.ts
@@ -12,6 +12,7 @@ import type {
 import { OPENAI_PROVIDER_ICON } from '../../../shared/icons';
 import { getCodexModelOptions } from '../modelOptions';
 import {
+  CODEX_DEFAULT_SERVICE_TIER,
   CODEX_FALLBACK_REASONING_EFFORT_VALUES,
   findCodexModel,
   getCodexDefaultReasoningEffort,
@@ -19,6 +20,7 @@ import {
   getCodexReasoningEffortOptions,
   getDefaultCodexModel,
   isCodexModelAvailable,
+  resolveCodexModelServiceTier,
 } from '../models';
 import {
   isCodexModelSelectionId,
@@ -44,7 +46,6 @@ const CODEX_PERMISSION_MODE_TOGGLE: ProviderPermissionModeToggleConfig = {
   planLabel: 'Plan',
 };
 
-const DEFAULT_SERVICE_TIER_VALUE = 'default';
 const DEFAULT_SERVICE_TIER_LABEL = 'Standard';
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
@@ -184,10 +185,11 @@ export const codexChatUIConfig: ProviderChatUIConfig = {
     }
 
     return {
-      inactiveValue: model.defaultServiceTier ?? DEFAULT_SERVICE_TIER_VALUE,
+      inactiveValue: CODEX_DEFAULT_SERVICE_TIER,
       inactiveLabel: DEFAULT_SERVICE_TIER_LABEL,
       activeValue: tier.id,
       activeLabel: tier.name,
+      isActive: resolveCodexModelServiceTier(model, settings.serviceTier) === tier.id,
       description: tier.description || undefined,
     };
   },

--- a/src/style/features/slash-commands.css
+++ b/src/style/features/slash-commands.css
@@ -7,8 +7,6 @@
   right: 0;
   margin-bottom: 4px;
   background: var(--background-secondary);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
   border: 1px solid var(--background-modifier-border);
   border-radius: 6px;
   box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.2);

--- a/tests/unit/features/chat/ui/InputToolbar.test.ts
+++ b/tests/unit/features/chat/ui/InputToolbar.test.ts
@@ -805,7 +805,7 @@ describe('ServiceTierToggle', () => {
     const container = parentEl.querySelector('.claudian-service-tier-toggle');
     expect(button?.hasClass('active')).toBe(false);
     expect(icon).not.toBeNull();
-    expect(container?.getAttribute('title')).toBe('Toggle on/off fast mode');
+    expect(container?.getAttribute('title')).toBe('Fast mode: Standard');
   });
 
   it('renders the icon button in the active state when fast mode is on', () => {
@@ -822,7 +822,7 @@ describe('ServiceTierToggle', () => {
     const button = parentEl2.querySelector('.claudian-service-tier-button');
     const container = parentEl2.querySelector('.claudian-service-tier-toggle');
     expect(button?.hasClass('active')).toBe(true);
-    expect(container?.getAttribute('title')).toBe('Toggle on/off fast mode');
+    expect(container?.getAttribute('title')).toBe('Fast mode: Fast');
   });
 
   it('toggles from Standard to Fast on click', async () => {

--- a/tests/unit/providers/claude/execution/ClaudeInteractionHandler.test.ts
+++ b/tests/unit/providers/claude/execution/ClaudeInteractionHandler.test.ts
@@ -93,6 +93,21 @@ describe('createClaudeExecutionCanUseTool', () => {
     expect(onToolBlocked).toHaveBeenCalledWith('native-tool-1');
   });
 
+  it('keeps allow-once approvals scoped to the current invocation', async () => {
+    const port = createPort();
+    port.requestApproval.mockResolvedValue({
+      interactionId: 'claude:session-local:native-tool-1',
+      decision: 'allow',
+    });
+    const handler = createHandler(port);
+
+    await expect(handler('Bash', { command: 'git status' }, nativeOptions))
+      .resolves.toEqual({
+        behavior: 'allow',
+        updatedInput: { command: 'git status' },
+      });
+  });
+
   it('routes direct edits outside the vault through the approval flow', async () => {
     const port = createPort();
     const handler = createHandler(port, jest.fn(), '/vault');

--- a/tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts
@@ -42,6 +42,28 @@ describe('CodexNotificationRouter', () => {
       ]);
     });
 
+    it('reconciles the completed agent message when the final delta is missing', () => {
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'agentMessage', id: 'msg1', text: '', phase: 'streaming', memoryCitation: null },
+      });
+      router.handleNotification('item/agentMessage/delta', {
+        threadId: 't1', turnId: 'turn1', itemId: 'msg1', delta: 'Hello',
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'agentMessage', id: 'msg1', text: 'Hello world', phase: 'final', memoryCitation: null },
+      });
+
+      expect(chunks).toEqual([
+        { type: 'assistant_message_start', itemId: 'msg1' },
+        { type: 'text', content: 'Hello' },
+        { type: 'text', content: ' world' },
+      ]);
+    });
+
     it('emits only missing assistant text from raw completed messages', () => {
       router.handleNotification('item/agentMessage/delta', {
         threadId: 't1',

--- a/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
+++ b/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
@@ -670,6 +670,7 @@ describe('CodexChatUIConfig', () => {
         inactiveLabel: 'Standard',
         activeValue: 'priority',
         activeLabel: 'Fast',
+        isActive: false,
         description: '1.5x speed',
       });
     });

--- a/tests/unit/style/features/slash-commands.test.ts
+++ b/tests/unit/style/features/slash-commands.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+describe('slash command dropdown styles', () => {
+  it('does not use backdrop filtering that can leave stale dropdown pixels', () => {
+    const css = readFileSync(
+      path.resolve('src/style/features/slash-commands.css'),
+      'utf8',
+    );
+
+    expect(css).not.toContain('backdrop-filter');
+    expect(css).not.toContain('-webkit-backdrop-filter');
+  });
+});


### PR DESCRIPTION
## Summary

- Prevent one-time Claude approvals from persisting beyond the current tool invocation.
- Improve Codex streaming reliability by recovering missing assistant text and retrying missed turn completions.
- Keep Codex Fast/Standard mode state aligned with the effective model configuration used by the next query.
- Remove slash-command dropdown backdrop filtering to avoid stale rendering artifacts.
- Add regression tests for the updated permission, streaming, service-tier, and dropdown behavior.

## Validation

- pnpm run typecheck
- pnpm run lint
- pnpm run test:unit — 402 suites, 6,960 tests passed
- pnpm run build

The change is limited to targeted reliability and UI fixes; it does not include the upstream MCP or large tab/runtime architecture migration.