### PR TITLE
chore: release v2.4.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "packageManager": "pnpm@10.34.5",
   "description": "Oh My Claudian - provider-backed coding agents embedded in the Obsidian sidebar",
   "main": "main.js",


### PR DESCRIPTION
## Release

Prepare version 2.4.1 after merging the upstream runtime reliability fixes.

## Changes

- Bump package and Obsidian manifest versions to 2.4.1.
- The preceding PR #82 contains the runtime fixes included in this release.

## Validation

- pnpm run typecheck
- pnpm run lint
- pnpm run test:unit
- pnpm run build