### PR TITLE
fix: preserve Claude rate-limit reset time

### DIFF
--- a/src/providers/claude/stream/transformClaudeMessage.ts
+++ b/src/providers/claude/stream/transformClaudeMessage.ts
@@ -139,6 +139,19 @@ function isResultError(message: { type: 'result'; subtype: string }): message is
   return !!message.subtype && message.subtype !== 'success';
 }
 
+function getAssistantText(message: Extract<SDKMessage, { type: 'assistant' }>): string | undefined {
+  if (!message.message?.content || !Array.isArray(message.message.content)) {
+    return undefined;
+  }
+
+  const text = message.message.content
+    .flatMap(block => block.type === 'text' && 'text' in block && typeof block.text === 'string' ? [block.text.trim()] : [])
+    .filter(Boolean)
+    .join('\n');
+
+  return text || undefined;
+}
+
 function normalizeClaudeModelId(model: string): string {
   const normalized = model.trim().toLowerCase();
   const claudeIndex = normalized.indexOf('claude-');
@@ -446,10 +459,16 @@ export function* transformSDKMessage(
 
     case 'assistant': {
       const parentToolUseId = message.parent_tool_use_id ?? null;
+      const assistantText = getAssistantText(message);
 
       // Errors on assistant messages (e.g. rate_limit, billing_error)
       if (message.error) {
-        yield { type: 'error', content: message.error };
+        yield {
+          type: 'error',
+          content: 'isApiErrorMessage' in message && message.isApiErrorMessage && assistantText
+            ? assistantText
+            : message.error,
+        };
       }
 
       if (message.message?.content && Array.isArray(message.message.content)) {

--- a/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
+++ b/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
@@ -1811,6 +1811,27 @@ describe('transformSDKMessage', () => {
   });
 
   describe('error messages', () => {
+    it('uses descriptive assistant text for API errors when available', () => {
+      const message = msg({
+        type: 'assistant',
+        error: 'rate_limit',
+        isApiErrorMessage: true,
+        apiErrorStatus: 429,
+        message: {
+          content: [
+            { type: 'text', text: "You've hit your session limit · resets 4:10pm (Europe/Berlin)" },
+          ],
+        },
+      });
+
+      const results = [...transformSDKMessage(message)];
+
+      expect(results[0]).toEqual({
+        type: 'error',
+        content: "You've hit your session limit · resets 4:10pm (Europe/Berlin)",
+      });
+    });
+
     it('yields error event from assistant message with error field', () => {
       const message = msg({
         type: 'assistant',


### PR DESCRIPTION
## Summary

- Preserve the human-readable assistant text for Claude API error messages.
- Keep the short provider error code as a fallback when no descriptive text is present.
- Add regression coverage for the session-limit reset time message.

Fixes upstream issue: https://github.com/YishenTu/claudian/issues/1102

## Validation

- pnpm run typecheck
- pnpm exec jest tests/unit/providers/claude/stream/transformSDKMessage.test.ts tests/unit/providers/claude/execution/ClaudeExecutionEventNormalizer.test.ts --runInBand
- pnpm run lint

Lint reports only the repository’s existing UI sentence-case warnings.