### PR TITLE
chore: release 2.4.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "packageManager": "pnpm@10.34.5",
   "description": "Oh My Claudian - provider-backed coding agents embedded in the Obsidian sidebar",
   "main": "main.js",


### PR DESCRIPTION
## Summary

- Bump package and Obsidian manifest versions from 2.4.1 to 2.4.2.
- Include the merged Claude rate-limit reset-time fix from #84.
- Include Mermaid diagram rendering from #85.

## Validation

- package.json and manifest.json versions match
- pnpm run typecheck
- git diff --check