### PR TITLE
fix: stabilize Claude context usage updates

### DIFF
--- a/src/features/chat/controllers/StreamController.ts
+++ b/src/features/chat/controllers/StreamController.ts
@@ -131,6 +131,11 @@ export class StreamController {
   private viewportVisible = true;
   private pendingToolOutputFrames = new Map<string, ScheduledAnimationFrame>();
   private pendingScrollFrame: ScheduledAnimationFrame | null = null;
+  private highestContextUsage: {
+    model?: string;
+    contextWindow: number;
+    contextTokens: number;
+  } | null = null;
 
   // Provider lifecycle agent tracking (spawn → wait/close lifecycle)
   private lifecycleSubagentStates = new Map<string, SubagentState | AsyncSubagentState>(); // spawn callId → rendered state
@@ -289,6 +294,7 @@ export class StreamController {
         break;
 
       case 'context_compacted': {
+        this.highestContextUsage = null;
         this.flushPendingTools();
         if (state.currentThinkingState) {
           await this.finalizeCurrentThinkingBlock(msg);
@@ -326,9 +332,21 @@ export class StreamController {
     if (state.ignoreUsageUpdates) return;
 
     const activeModel = this.getActiveProviderModel();
-    state.usage = activeModel && !usage.model
+    const nextUsage = activeModel && !usage.model
       ? { ...usage, model: activeModel }
       : usage;
+    const previousHighest = this.highestContextUsage;
+    const isSameContext = previousHighest
+      && previousHighest.model === nextUsage.model
+      && previousHighest.contextWindow === nextUsage.contextWindow;
+    if (isSameContext && nextUsage.contextTokens < previousHighest.contextTokens) return;
+
+    this.highestContextUsage = {
+      model: nextUsage.model,
+      contextWindow: nextUsage.contextWindow,
+      contextTokens: nextUsage.contextTokens,
+    };
+    state.usage = nextUsage;
   }
 
   // ============================================
@@ -1977,6 +1995,7 @@ export class StreamController {
     state.currentTextContent = '';
     state.currentThinkingState = null;
     this.deps.subagentManager.resetStreamingState();
+    this.highestContextUsage = null;
     this.lifecycleSubagentStates.clear();
     this.lifecycleAgentIdToSpawnId.clear();
     state.pendingTools.clear();

--- a/src/providers/claude/stream/transformClaudeMessage.ts
+++ b/src/providers/claude/stream/transformClaudeMessage.ts
@@ -442,6 +442,18 @@ export function* transformSDKMessage(
         };
       } else if (message.subtype === 'compact_boundary') {
         yield { type: 'context_compacted' };
+        const postTokens = message.compact_metadata?.post_tokens;
+        if (typeof postTokens === 'number' && Number.isFinite(postTokens) && postTokens >= 0) {
+          yield {
+            type: 'usage',
+            usage: buildUsageInfo({
+              inputTokens: postTokens,
+              cacheCreationInputTokens: 0,
+              cacheReadInputTokens: 0,
+              contextTokens: postTokens,
+            }, options),
+          };
+        }
       } else if (message.subtype === 'task_notification') {
         const notification = transformTaskNotification(message);
         if (notification) {

--- a/tests/unit/features/chat/controllers/StreamController.test.ts
+++ b/tests/unit/features/chat/controllers/StreamController.test.ts
@@ -559,6 +559,24 @@ describe('StreamController - Text Content', () => {
 
       expect(msg.contentBlocks).toContainEqual({ type: 'context_compacted' });
     });
+
+    it('does not let a later Claude sub-request lower usage in the same stream', () => {
+      controller.updateUsage(createMockUsage({ contextTokens: 100, percentage: 100 }));
+      controller.updateUsage(createMockUsage({ contextTokens: 60, percentage: 60 }));
+
+      expect(deps.state.usage).toEqual(createMockUsage({ contextTokens: 100, percentage: 100 }));
+    });
+
+    it('allows usage to drop after an explicit compaction boundary', async () => {
+      const msg = createTestMessage();
+      controller.updateUsage(createMockUsage({ contextTokens: 100, percentage: 100 }));
+
+      await controller.handleStreamChunk({ type: 'context_compacted' }, msg);
+      expect(deps.state.usage).toEqual(createMockUsage({ contextTokens: 100, percentage: 100 }));
+      controller.updateUsage(createMockUsage({ contextTokens: 30, percentage: 30 }));
+
+      expect(deps.state.usage).toEqual(createMockUsage({ contextTokens: 30, percentage: 30 }));
+    });
   });
 
   describe('citation handling', () => {

--- a/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
+++ b/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
@@ -68,12 +68,29 @@ describe('transformSDKMessage', () => {
       const message = msg({
         type: 'system',
         subtype: 'compact_boundary',
+        compact_metadata: {
+          trigger: 'auto',
+          pre_tokens: 190000,
+          post_tokens: 30000,
+        },
       });
 
       const results = [...transformSDKMessage(message)];
 
       expect(results).toEqual([
         { type: 'context_compacted' },
+        {
+          type: 'usage',
+          usage: {
+            model: 'sonnet',
+            inputTokens: 30000,
+            cacheCreationInputTokens: 0,
+            cacheReadInputTokens: 0,
+            contextWindow: 1000000,
+            contextTokens: 30000,
+            percentage: 3,
+          },
+        },
       ]);
     });
 

--- a/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
+++ b/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
@@ -1040,6 +1040,54 @@ describe('transformSDKMessage', () => {
       ]);
     });
 
+    it('does not duplicate assistant usage at result or use cumulative model usage tokens', () => {
+      const usageState = createTransformUsageState();
+      const assistantMessage = msg({
+        type: 'assistant',
+        parent_tool_use_id: null,
+        message: {
+          content: [{ type: 'text', text: 'Done' }],
+          usage: {
+            input_tokens: 120,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 30,
+          },
+        },
+      });
+      const resultMessage = msg({
+        type: 'result',
+        subtype: 'success',
+        modelUsage: {
+          sonnet: {
+            inputTokens: 900,
+            cacheCreationInputTokens: 0,
+            cacheReadInputTokens: 500,
+            contextWindow: 200000,
+          },
+        },
+      });
+
+      const assistantResults = [...transformSDKMessage(assistantMessage, {
+        intendedModel: 'sonnet',
+        usageState,
+      })];
+      const resultResults = [...transformSDKMessage(resultMessage, {
+        intendedModel: 'sonnet',
+        usageState,
+      })];
+
+      expect(assistantResults).toContainEqual({
+        type: 'usage',
+        usage: expect.objectContaining({
+          contextTokens: 150,
+          percentage: 0,
+        }),
+      });
+      expect(resultResults).toEqual([
+        { type: 'context_window', contextWindow: 200000 },
+      ]);
+    });
+
     it('uses an authoritative context window supplied by the SDK runtime', () => {
       const usageState = createTransformUsageState();
       const assistantMessage = msg({


### PR DESCRIPTION
## Summary

- keep Claude context usage stable across multiple API sub-requests in one stream
- update usage after compaction from Claude SDK compact_metadata.post_tokens
- preserve the upstream result/modelUsage boundary so cumulative subagent usage does not inflate the meter
- add regression coverage for compaction and final result usage behavior

## Verification

- 229 related unit tests passed
- pnpm run typecheck passed
- git diff --check passed