### PR TITLE
feat/chat: improve tab status and auto-scroll

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -310,6 +310,10 @@ export class ClaudianView extends ItemView {
           this.updateTabBar();
           this.notifyConversationNavigationChanged();
         },
+        onTabWorkChanged: () => {
+          this.updateTabBar();
+          this.notifyConversationNavigationChanged();
+        },
         onTabRewindingChanged: () => this.updateTabBar(),
         onTabTitleChanged: () => this.updateTabBar(),
         onTabAttentionChanged: () => {

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -145,7 +145,7 @@ export interface InputControllerDeps {
   toggleFastMode?: () => Promise<boolean>;
   restorePrePlanPermissionModeIfNeeded?: () => void | Promise<void>;
   /** Captures a review reporter when a terminal provider turn becomes visible. */
-  captureReviewableSettlement?: () => () => void;
+  captureReviewableSettlement?: (outcome?: 'completed' | 'error') => () => void;
   /** Opens provider diagnostics for failures before execution handoff. */
   onDiagnosticError?: (error: unknown) => void;
   /** Performs a lightweight provider check before starting a new turn. */
@@ -534,7 +534,9 @@ export class InputController {
         || (result.status === 'error' && result.accepted);
       if (shouldReportReviewableSettlement) {
         currentReviewableSettlementReporter =
-          this.deps.captureReviewableSettlement?.() ?? null;
+          this.deps.captureReviewableSettlement?.(
+            result.status === 'error' ? 'error' : 'completed',
+          ) ?? null;
       }
       if (result.status === 'cancelled') {
         wasInterrupted = true;
@@ -591,7 +593,7 @@ export class InputController {
         const errorMsg = stringifyDiagnosticError(error);
         await streamController.appendText(`\n\n**Error:** ${errorMsg}`);
         currentReviewableSettlementReporter =
-          this.deps.captureReviewableSettlement?.() ?? null;
+          this.deps.captureReviewableSettlement?.('error') ?? null;
       }
     } finally {
       const finalAssistantMsg = this.activeStreamingAssistantMessage ?? assistantMsg;

--- a/src/features/chat/state/ChatState.ts
+++ b/src/features/chat/state/ChatState.ts
@@ -1,11 +1,13 @@
 import type { UsageInfo } from '../../../core/types';
 import type {
+  AutoScrollNavigationIntent,
   ChatMessage,
   ChatStateCallbacks,
   ChatStateData,
   PendingToolCall,
   QueuedMessage,
   TabAttention,
+  TabReviewOutcome,
   ThinkingBlockState,
   TodoItem,
   WriteEditState,
@@ -38,6 +40,7 @@ function createInitialState(): ChatStateData {
     currentTodos: null,
     attention: null,
     autoScrollEnabled: true, // Default; controllers will override based on settings
+    navigationScrollIntent: null,
     responseStartTime: null,
     flavorTimerInterval: null,
     pendingNewSessionPlan: null,
@@ -50,7 +53,7 @@ export class ChatState {
   private state: ChatStateData;
   private _callbacks: ChatStateCallbacks;
   private readonly pendingActionIds = new Set<string>();
-  private pendingReviewSince: number | null = null;
+  private pendingReview: { outcome?: TabReviewOutcome; since: number } | null = null;
   private thinkingIndicatorTimeoutWindow: Window | null = null;
   private flavorTimerIntervalWindow: Window | null = null;
 
@@ -320,8 +323,11 @@ export class ChatState {
     if (this.pendingActionIds.has(interactionId)) return;
 
     this.pendingActionIds.add(interactionId);
-    if (this.state.attention?.kind === 'review' && this.pendingReviewSince === null) {
-      this.pendingReviewSince = this.state.attention.since;
+    if (this.state.attention?.kind === 'review' && this.pendingReview === null) {
+      this.pendingReview = {
+        ...(this.state.attention.outcome ? { outcome: this.state.attention.outcome } : {}),
+        since: this.state.attention.since,
+      };
     }
     if (!this.requiresAction) {
       this.setAttention({ kind: 'action-required', since: Date.now() });
@@ -331,25 +337,33 @@ export class ChatState {
   endActionRequired(interactionId: string): void {
     if (!this.pendingActionIds.delete(interactionId)) return;
     if (this.pendingActionIds.size === 0 && this.requiresAction) {
-      const reviewSince = this.pendingReviewSince;
-      this.pendingReviewSince = null;
-      this.setAttention(reviewSince === null
+      const review = this.pendingReview;
+      this.pendingReview = null;
+      this.setAttention(review === null
         ? null
-        : { kind: 'review', since: reviewSince });
+        : { kind: 'review', ...review });
     }
   }
 
-  markReviewRequired(): void {
-    if (this.state.attention?.kind === 'review') return;
-    if (this.requiresAction) {
-      this.pendingReviewSince ??= Date.now();
+  markReviewRequired(outcome?: TabReviewOutcome): void {
+    if (this.state.attention?.kind === 'review') {
+      if (outcome !== 'error' || this.state.attention.outcome === 'error') return;
+      this.setAttention({ kind: 'review', since: this.state.attention.since, outcome });
       return;
     }
-    this.setAttention({ kind: 'review', since: Date.now() });
+    if (this.requiresAction) {
+      if (this.pendingReview === null) {
+        this.pendingReview = { ...(outcome ? { outcome } : {}), since: Date.now() };
+      } else if (outcome === 'error') {
+        this.pendingReview.outcome = outcome;
+      }
+      return;
+    }
+    this.setAttention({ kind: 'review', since: Date.now(), ...(outcome ? { outcome } : {}) });
   }
 
   acknowledgeReview(): void {
-    this.pendingReviewSince = null;
+    this.pendingReview = null;
     if (this.state.attention?.kind === 'review') {
       this.setAttention(null);
     }
@@ -357,7 +371,7 @@ export class ChatState {
 
   clearAttention(): void {
     this.pendingActionIds.clear();
-    this.pendingReviewSince = null;
+    this.pendingReview = null;
     this.setAttention(null);
   }
 
@@ -367,6 +381,14 @@ export class ChatState {
 
   get autoScrollEnabled(): boolean {
     return this.state.autoScrollEnabled;
+  }
+
+  get navigationScrollIntent(): AutoScrollNavigationIntent | null {
+    return this.state.navigationScrollIntent;
+  }
+
+  set navigationScrollIntent(value: AutoScrollNavigationIntent | null) {
+    this.state.navigationScrollIntent = value;
   }
 
   set autoScrollEnabled(value: boolean) {

--- a/src/features/chat/state/types.ts
+++ b/src/features/chat/state/types.ts
@@ -44,10 +44,13 @@ export interface PendingToolCall {
 }
 
 export type TabAttentionKind = 'review' | 'action-required';
+export type TabReviewOutcome = 'completed' | 'error';
+export type AutoScrollNavigationIntent = 'away' | 'bottom';
 
 export type TabAttention = {
   kind: TabAttentionKind;
   since: number;
+  outcome?: TabReviewOutcome;
 } | null;
 
 /** Stored selection state from editor polling. */
@@ -115,6 +118,7 @@ export interface ChatStateData {
 
   // Auto-scroll control during streaming
   autoScrollEnabled: boolean;
+  navigationScrollIntent: AutoScrollNavigationIntent | null;
 
   // Response timer state
   responseStartTime: number | null;

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -851,7 +851,9 @@ async function handleTabSessionEvent(
       ...(event.result !== undefined ? { result: event.result } : {}),
     });
     if (applied && isCurrent()) {
-      const reportReviewableSettlement = tab.captureReviewableSettlement?.();
+      const reportReviewableSettlement = tab.captureReviewableSettlement?.(
+        event.status === 'error' ? 'error' : 'completed',
+      );
       try {
         await tab.controllers.conversationController?.save(true);
       } finally {
@@ -1480,7 +1482,12 @@ export function initializeTabUI(
   if (dom.messagesEl.parentElement) {
     tab.ui.navigationSidebar = new NavigationSidebar(
       dom.messagesEl.parentElement,
-      dom.messagesEl
+      dom.messagesEl,
+      (intent) => {
+        state.navigationScrollIntent = intent;
+        state.autoScrollEnabled = intent === 'bottom'
+          && (plugin.settings.enableAutoScroll ?? true);
+      },
     );
   }
 
@@ -2003,8 +2010,11 @@ export function wireTabInputEvents(tab: TabData, plugin: FeatureHost): void {
         reEnableTimeout = null;
       }
       state.autoScrollEnabled = false;
+      state.navigationScrollIntent = null;
       return;
     }
+
+    if (state.navigationScrollIntent !== null) return;
 
     const { scrollTop, scrollHeight, clientHeight } = dom.messagesEl;
     const isAtBottom = scrollHeight - scrollTop - clientHeight <= SCROLL_THRESHOLD;
@@ -2030,9 +2040,18 @@ export function wireTabInputEvents(tab: TabData, plugin: FeatureHost): void {
       }
     }
   };
+  const userScrollIntentHandler = (): void => {
+    if (state.navigationScrollIntent === null) return;
+    state.navigationScrollIntent = null;
+    state.autoScrollEnabled = false;
+  };
   dom.messagesEl.addEventListener('scroll', scrollHandler, { passive: true });
+  dom.messagesEl.addEventListener('wheel', userScrollIntentHandler, { passive: true });
+  dom.messagesEl.addEventListener('pointerdown', userScrollIntentHandler, { passive: true });
   dom.eventCleanups.push(() => {
     dom.messagesEl.removeEventListener('scroll', scrollHandler);
+    dom.messagesEl.removeEventListener('wheel', userScrollIntentHandler);
+    dom.messagesEl.removeEventListener('pointerdown', userScrollIntentHandler);
     if (reEnableTimeout) window.clearTimeout(reEnableTimeout);
   });
 }

--- a/src/features/chat/tabs/TabBar.ts
+++ b/src/features/chat/tabs/TabBar.ts
@@ -72,13 +72,15 @@ export class TabBar {
 
   /** Renders a single tab badge. */
   private renderBadge(item: TabBarItem): void {
-    // Determine state class (priority: active > attention > streaming > idle)
+    // Determine state class (priority: active > attention > working > idle)
     let stateClass = 'claudian-tab-badge-idle';
     if (item.isActive) {
       stateClass = 'claudian-tab-badge-active';
     } else if (item.needsAttention) {
-      stateClass = 'claudian-tab-badge-attention';
-    } else if (item.isStreaming) {
+      stateClass = item.attention?.outcome === 'error'
+        ? 'claudian-tab-badge-review-error'
+        : 'claudian-tab-badge-attention';
+    } else if (item.isWorking || item.isStreaming) {
       stateClass = 'claudian-tab-badge-streaming';
     }
 

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -198,6 +198,9 @@ export class TabManager implements TabManagerInterface {
         this.callbacks.onTabStreamingChanged?.(tab.id, isStreaming);
         if (!isStreaming) tab.executionCoordinator?.notifyMayCool();
       },
+      onWorkChanged: () => {
+        this.callbacks.onTabWorkChanged?.(tab.id);
+      },
       onRewindingChanged: (isRewinding) => {
         this.callbacks.onTabRewindingChanged?.(tab.id, isRewinding);
         if (!isRewinding) tab.executionCoordinator?.notifyMayCool();
@@ -211,7 +214,7 @@ export class TabManager implements TabManagerInterface {
           tab.executionCoordinator?.notifyMayCool();
         }
       },
-      captureReviewableSettlement: () => {
+      captureReviewableSettlement: (outcome) => {
         const shouldReport = this.isTabAlive(tab) && this.activeTabId !== tab.id;
         const activationRevision = this.tabActivationRevisions.get(tab.id) ?? 0;
         return () => {
@@ -220,7 +223,7 @@ export class TabManager implements TabManagerInterface {
             && this.isTabAlive(tab)
             && (this.tabActivationRevisions.get(tab.id) ?? 0) === activationRevision
           ) {
-            tab.state.markReviewRequired();
+            tab.state.markReviewRequired(outcome);
           }
         };
       },
@@ -535,13 +538,23 @@ export class TabManager implements TabManagerInterface {
         title: getTabTitle(tab, this.plugin),
         providerId: getTabProviderId(tab, this.plugin),
         isActive: tab.id === this.activeTabId,
-        isStreaming: tab.state.isStreaming,
+        isWorking: this.isTabWorking(tab.id),
         needsAttention: tab.state.needsAttention,
-        canClose: !tab.state.isRewinding && (this.tabs.size > 1 || !tab.state.isStreaming),
+        attention: tab.state.attention,
+        canClose: !tab.state.isRewinding && (this.tabs.size > 1 || !this.isTabWorking(tab.id)),
       });
     }
 
     return items;
+  }
+
+  /** True while a tab has foreground or queued background work in progress. */
+  private isTabWorking(tabId: TabId): boolean {
+    const tab = this.tabs.get(tabId);
+    if (!tab) return false;
+    return tab.state.isStreaming
+      || tab.session.activeTurn !== null
+      || tab.session.hasBackgroundWork;
   }
 
   // ============================================

--- a/src/features/chat/tabs/TabRuntimeFactory.ts
+++ b/src/features/chat/tabs/TabRuntimeFactory.ts
@@ -30,6 +30,7 @@ export function createTabRuntime(
     conversation,
     tabId,
     onStreamingChanged,
+    onWorkChanged,
     onRewindingChanged,
     onAttentionChanged,
     onConversationIdChanged,
@@ -68,7 +69,7 @@ export function createTabRuntime(
     draftModel,
     providerId: initialProviderId,
     conversationId: conversation?.id ?? null,
-  });
+  }, onWorkChanged);
   const tab: TabData = {
     session,
     get id() { return session.id; },

--- a/src/features/chat/tabs/TabSession.ts
+++ b/src/features/chat/tabs/TabSession.ts
@@ -13,10 +13,14 @@ export interface TabSessionState {
 export class TabSession {
   private activeTurnValue: Promise<void> | null = null;
   private backgroundWork: Promise<void> = Promise.resolve();
+  private backgroundWorkCount = 0;
   private backgroundWorkPauseDepth = 0;
   private coordinator: ChatExecutionCoordinator | null = null;
 
-  constructor(private readonly state: TabSessionState) {}
+  constructor(
+    private readonly state: TabSessionState,
+    private readonly onWorkChanged?: () => void,
+  ) {}
 
   get id(): string { return this.state.id; }
   get lifecycleState(): TabLifecycleState { return this.state.lifecycleState; }
@@ -29,8 +33,11 @@ export class TabSession {
   set draftModel(value: string | null) { this.state.draftModel = value; }
   get executionCoordinator(): ChatExecutionCoordinator | null { return this.coordinator; }
   get activeTurn(): Promise<void> | null { return this.activeTurnValue; }
+  get hasBackgroundWork(): boolean { return this.backgroundWorkCount > 0; }
   set activeTurn(value: Promise<void> | null) {
+    const wasWorking = this.activeTurnValue !== null;
     this.activeTurnValue = value;
+    if (wasWorking !== (value !== null)) this.onWorkChanged?.();
     if (value === null) this.coordinator?.notifyMayCool();
   }
 
@@ -47,10 +54,22 @@ export class TabSession {
   enqueueBackgroundWork(work: () => Promise<void>): Promise<void> | null {
     if (this.backgroundWorkPauseDepth > 0) return null;
 
+    this.backgroundWorkCount++;
     const pending = this.backgroundWork
       .catch(() => undefined)
       .then(work);
     this.backgroundWork = pending;
+    this.onWorkChanged?.();
+    void pending.then(
+      () => {
+        this.backgroundWorkCount = Math.max(0, this.backgroundWorkCount - 1);
+        this.onWorkChanged?.();
+      },
+      () => {
+        this.backgroundWorkCount = Math.max(0, this.backgroundWorkCount - 1);
+        this.onWorkChanged?.();
+      },
+    );
     return pending;
   }
 

--- a/src/features/chat/tabs/types.ts
+++ b/src/features/chat/tabs/types.ts
@@ -18,7 +18,7 @@ import type { ChatExecutionCoordinator } from '../execution/ChatExecutionCoordin
 import type { MessageRenderer } from '../rendering/MessageRenderer';
 import type { SubagentManager } from '../services/SubagentManager';
 import type { ChatState } from '../state/ChatState';
-import type { TabAttention } from '../state/types';
+import type { TabAttention, TabReviewOutcome } from '../state/types';
 import type { BangBashModeManager } from '../ui/BangBashModeManager';
 import type { ComposerContextTray } from '../ui/ComposerContextTray';
 import type { FileContextManager } from '../ui/FileContext';
@@ -93,10 +93,11 @@ export interface TabCreateOptions {
   draftModel?: string | null;
   lifecycleState?: Extract<TabData['lifecycleState'], 'provisional' | 'cold'>;
   onStreamingChanged?: (isStreaming: boolean) => void;
+  onWorkChanged?: () => void;
   onRewindingChanged?: (isRewinding: boolean) => void;
   onTitleChanged?: (title: string) => void;
   onAttentionChanged?: (attention: TabAttention) => void;
-  captureReviewableSettlement?: () => () => void;
+  captureReviewableSettlement?: (outcome?: TabReviewOutcome) => () => void;
   onConversationIdChanged?: (conversationId: string | null) => void;
 }
 
@@ -229,7 +230,7 @@ export interface TabData {
   providerCatalogResolver: ProviderCatalogResolver | null;
 
   /** Captures whether completed runtime work will need review after finalization. */
-  captureReviewableSettlement: (() => () => void) | null;
+  captureReviewableSettlement: ((outcome?: TabReviewOutcome) => () => void) | null;
 
   /** Per-tab chat state. */
   state: ChatState;
@@ -277,6 +278,9 @@ export interface TabManagerCallbacks {
   /** Called when tab streaming state changes. */
   onTabStreamingChanged?: (tabId: TabId, isStreaming: boolean) => void;
 
+  /** Called when user-visible work starts or finishes in a tab. */
+  onTabWorkChanged?: (tabId: TabId) => void;
+
   /** Called when tab rewind transaction state changes. */
   onTabRewindingChanged?: (tabId: TabId, isRewinding: boolean) => void;
 
@@ -303,7 +307,10 @@ export interface TabBarItem {
   title: string;
   providerId: ProviderId;
   isActive: boolean;
-  isStreaming: boolean;
+  isWorking: boolean;
+  /** @deprecated Use isWorking. Kept for integrations that construct tab items. */
+  isStreaming?: boolean;
   needsAttention: boolean;
+  attention?: TabAttention;
   canClose: boolean;
 }

--- a/src/features/chat/ui/NavigationSidebar.ts
+++ b/src/features/chat/ui/NavigationSidebar.ts
@@ -7,6 +7,8 @@ import {
 } from '../../../utils/animationFrame';
 import { formatConversationDirectoryTitle } from '../utils/conversationDirectoryTitle';
 
+export type NavigationScrollIntent = 'away' | 'bottom';
+
 /**
  * Floating sidebar for navigating chat history.
  * Provides quick access to top/bottom and previous/next user messages.
@@ -27,7 +29,8 @@ export class NavigationSidebar {
 
   constructor(
     private parentEl: HTMLElement,
-    private messagesEl: HTMLElement
+    private messagesEl: HTMLElement,
+    private onScrollIntent?: (intent: NavigationScrollIntent) => void,
   ) {
     this.container = this.parentEl.createDiv({ cls: 'claudian-nav-sidebar' });
 
@@ -56,15 +59,23 @@ export class NavigationSidebar {
 
     // Button clicks
     this.topBtn.addEventListener('click', () => {
+      this.onScrollIntent?.('away');
       this.messagesEl.scrollTo({ top: 0, behavior: 'smooth' });
     });
 
     this.bottomBtn.addEventListener('click', () => {
+      this.onScrollIntent?.('bottom');
       this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: 'smooth' });
     });
 
-    this.prevBtn.addEventListener('click', () => this.scrollToMessage('prev'));
-    this.nextBtn.addEventListener('click', () => this.scrollToMessage('next'));
+    this.prevBtn.addEventListener('click', () => {
+      const intent = this.scrollToMessage('prev');
+      this.onScrollIntent?.(intent);
+    });
+    this.nextBtn.addEventListener('click', () => {
+      const intent = this.scrollToMessage('next');
+      this.onScrollIntent?.(intent);
+    });
     this.tocBtn.addEventListener('click', (event) => {
       event.stopPropagation();
       this.toggleDirectory();
@@ -235,10 +246,10 @@ export class NavigationSidebar {
   /**
    * Scrolls to previous or next user message, skipping assistant messages.
    */
-  private scrollToMessage(direction: 'prev' | 'next'): void {
+  private scrollToMessage(direction: 'prev' | 'next'): NavigationScrollIntent {
     const messages = Array.from(this.messagesEl.querySelectorAll<HTMLElement>('.claudian-message-user'));
 
-    if (messages.length === 0) return;
+    if (messages.length === 0) return 'away';
 
     const scrollTop = this.messagesEl.scrollTop;
     const threshold = 30;
@@ -248,21 +259,23 @@ export class NavigationSidebar {
       for (let i = messages.length - 1; i >= 0; i--) {
         if (messages[i].offsetTop < scrollTop - threshold) {
           this.scrollToElement(messages[i]);
-          return;
+          return 'away';
         }
       }
       // Already at or above the first message — scroll to top
       this.messagesEl.scrollTo({ top: 0, behavior: 'smooth' });
+      return 'away';
     } else {
       // Find the first message strictly below the current scroll position
       for (let i = 0; i < messages.length; i++) {
         if (messages[i].offsetTop > scrollTop + threshold) {
           this.scrollToElement(messages[i]);
-          return;
+          return 'away';
         }
       }
       // Already at or past the last message — scroll to bottom
       this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: 'smooth' });
+      return 'bottom';
     }
   }
 

--- a/src/style/components/tabs.css
+++ b/src/style/components/tabs.css
@@ -102,6 +102,11 @@
   border-color: var(--text-error);
 }
 
+.claudian-tab-badge-review-error {
+  border-color: var(--text-error);
+  color: var(--text-error);
+}
+
 .claudian-tab-badge-idle {
   border-color: var(--background-modifier-border);
 }

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -1480,6 +1480,8 @@ describe('InputController coordinator execution', () => {
   it('reports a terminal accepted error as reviewable', async () => {
     const onReviewableSettlement = jest.fn();
     const fixture = createFixture({ onReviewableSettlement });
+    const captureReviewableSettlement = jest.fn(() => onReviewableSettlement);
+    fixture.deps.captureReviewableSettlement = captureReviewableSettlement as any;
     fixture.coordinator.execute.mockResolvedValueOnce({
       accepted: true,
       error: new Error('provider failed'),
@@ -1490,6 +1492,7 @@ describe('InputController coordinator execution', () => {
     await fixture.controller.sendMessage({ content: 'finish this' });
 
     expect(onReviewableSettlement).toHaveBeenCalledTimes(1);
+    expect(captureReviewableSettlement).toHaveBeenCalledWith('error');
   });
 
   it.each(['cancelled', 'invalidated', 'missing-session'] as const)(

--- a/tests/unit/features/chat/state/ChatState.test.ts
+++ b/tests/unit/features/chat/state/ChatState.test.ts
@@ -353,6 +353,18 @@ describe('ChatState', () => {
       expect(onAttentionChanged).toHaveBeenLastCalledWith(null);
     });
 
+    it('preserves whether a background result completed or failed', () => {
+      const chatState = new ChatState();
+
+      chatState.markReviewRequired('error');
+
+      expect(chatState.attention).toEqual({
+        kind: 'review',
+        outcome: 'error',
+        since: expect.any(Number),
+      });
+    });
+
     it('tracks multiple action-required interactions until the last one ends', () => {
       jest.spyOn(Date, 'now')
         .mockReturnValueOnce(100)

--- a/tests/unit/features/chat/tabs/TabBar.test.ts
+++ b/tests/unit/features/chat/tabs/TabBar.test.ts
@@ -20,7 +20,7 @@ function createTabBarItem(overrides: Partial<TabBarItem> = {}): TabBarItem {
     title: 'Test Tab',
     providerId: 'claude',
     isActive: false,
-    isStreaming: false,
+    isWorking: false,
     needsAttention: false,
     canClose: true,
     ...overrides,
@@ -274,6 +274,16 @@ describe('TabBar', () => {
       expect(containerEl._children[0]._classList.has('claudian-tab-badge-streaming')).toBe(true);
     });
 
+    it('should apply streaming class for a tab with background work', () => {
+      const containerEl = createMockEl();
+      const callbacks = createMockCallbacks();
+      const tabBar = new TabBar(containerEl, callbacks);
+
+      tabBar.update([createTabBarItem({ isWorking: true })]);
+
+      expect(containerEl._children[0]._classList.has('claudian-tab-badge-streaming')).toBe(true);
+    });
+
     it('should apply attention class for tab needing attention', () => {
       const containerEl = createMockEl();
       const callbacks = createMockCallbacks();
@@ -282,6 +292,20 @@ describe('TabBar', () => {
       tabBar.update([createTabBarItem({ needsAttention: true })]);
 
       expect(containerEl._children[0]._classList.has('claudian-tab-badge-attention')).toBe(true);
+    });
+
+    it('should apply an error review class when work stopped with an error', () => {
+      const containerEl = createMockEl();
+      const callbacks = createMockCallbacks();
+      const tabBar = new TabBar(containerEl, callbacks);
+
+      tabBar.update([createTabBarItem({
+        needsAttention: true,
+        attention: { kind: 'review', outcome: 'error', since: 1 },
+      })]);
+
+      expect(containerEl._children[0]._classList.has('claudian-tab-badge-review-error')).toBe(true);
+      expect(containerEl._children[0]._classList.has('claudian-tab-badge-attention')).toBe(false);
     });
 
     it('should prioritize active over attention', () => {

--- a/tests/unit/features/chat/tabs/TabSession.test.ts
+++ b/tests/unit/features/chat/tabs/TabSession.test.ts
@@ -1,0 +1,34 @@
+import { TabSession } from '@/features/chat/tabs/TabSession';
+
+function createState() {
+  return {
+    conversationId: null,
+    draftModel: null,
+    id: 'tab-1',
+    lifecycleState: 'cold' as const,
+    providerId: 'claude' as const,
+  };
+}
+
+describe('TabSession', () => {
+  it('reports queued background work until it settles', async () => {
+    let release!: () => void;
+    const onWorkChanged = jest.fn();
+    const session = new TabSession(createState(), onWorkChanged);
+    const pending = session.enqueueBackgroundWork(() => new Promise<void>((resolve) => {
+      release = resolve;
+    }));
+
+    expect(session.hasBackgroundWork).toBe(true);
+    expect(onWorkChanged).toHaveBeenCalledTimes(1);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    release();
+    await pending;
+    await Promise.resolve();
+
+    expect(session.hasBackgroundWork).toBe(false);
+    expect(onWorkChanged).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/features/chat/ui/NavigationSidebar.test.ts
+++ b/tests/unit/features/chat/ui/NavigationSidebar.test.ts
@@ -397,6 +397,20 @@ describe('NavigationSidebar', () => {
   });
 
   describe('scroll to top button', () => {
+    it('reports navigation intent before scrolling away from the bottom', () => {
+      const onScrollIntent = jest.fn();
+      sidebar = new NavigationSidebar(
+        parentEl as unknown as HTMLElement,
+        messagesEl as unknown as HTMLElement,
+        onScrollIntent,
+      );
+
+      const container = parentEl.querySelector('.claudian-nav-sidebar');
+      container!.children[0].click();
+
+      expect(onScrollIntent).toHaveBeenCalledWith('away');
+    });
+
     it('should scroll to top when clicked', () => {
       messagesEl.scrollHeight = 1000;
       messagesEl.clientHeight = 500;
@@ -418,6 +432,20 @@ describe('NavigationSidebar', () => {
   });
 
   describe('scroll to bottom button', () => {
+    it('reports bottom intent before smooth scrolling', () => {
+      const onScrollIntent = jest.fn();
+      sidebar = new NavigationSidebar(
+        parentEl as unknown as HTMLElement,
+        messagesEl as unknown as HTMLElement,
+        onScrollIntent,
+      );
+
+      const container = parentEl.querySelector('.claudian-nav-sidebar');
+      container!.children[4].click();
+
+      expect(onScrollIntent).toHaveBeenCalledWith('bottom');
+    });
+
     it('should scroll to bottom when clicked', () => {
       messagesEl.scrollHeight = 1000;
       messagesEl.clientHeight = 500;
@@ -557,10 +585,12 @@ describe('NavigationSidebar', () => {
       messagesEl.clientHeight = 500;
       addConversation(messagesEl, [0, 400, 800], [100, 500]);
       messagesEl.scrollTop = 790;
+      const onScrollIntent = jest.fn();
 
       sidebar = new NavigationSidebar(
         parentEl as unknown as HTMLElement,
-        messagesEl as unknown as HTMLElement
+        messagesEl as unknown as HTMLElement,
+        onScrollIntent,
       );
 
       const { next } = getButtons(parentEl);
@@ -568,6 +598,7 @@ describe('NavigationSidebar', () => {
 
       const lastCall = messagesEl.scrollToCalls[messagesEl.scrollToCalls.length - 1];
       expect(lastCall.top).toBe(2000);
+      expect(onScrollIntent).toHaveBeenCalledWith('bottom');
     });
 
     it('should scroll to top when at the first user message and prev is clicked', () => {


### PR DESCRIPTION
## Summary
- distinguish working tabs from streaming-only state, including active turns and background work
- preserve completed/error review outcomes for async and accepted execution failures
- keep auto-scroll enabled for intentional bottom navigation and avoid smooth-scroll false positives
- refresh the tab bar when background work changes

## Validation
- typecheck passed
- 328 targeted unit tests passed
- lint passed with 5 pre-existing sentence-case warnings
- production build passed with an isolated Obsidian target path

The full suite still has pre-existing sandbox failures in MCP HTTP tests that attempt to listen on 127.0.0.1.