### PR TITLE
chore: release v2.4.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "packageManager": "pnpm@10.34.5",
   "description": "Oh My Claudian - provider-backed coding agents embedded in the Obsidian sidebar",
   "main": "main.js",


### PR DESCRIPTION
## Release checklist

- bump `package.json` and `manifest.json` from `2.4.2` to `2.4.3`
- release branch is based on merged `fork/main` / PR #93
- no changelog file is used; the tag-triggered workflow generates GitHub Release notes from commits since `2.4.2`

## Validation

- `node scripts/check-release-version.mjs 2.4.3`
- `CI=true pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run typecheck`
- `pnpm run test` — 405 suites, 6983 tests passed
- `pnpm run lint` — existing sentence-case warnings only
- `OBSIDIAN_VAULT=/private/tmp/claudian-build-vault pnpm run build`
- `git diff --check`

After merge, create tag `2.4.3` on the merge commit. The release workflow will validate versions, build artifacts, attest them, and create the GitHub Release.