### PR TITLE
fix(chat): avoid unsafe Mermaid DOM insertion

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "packageManager": "pnpm@10.34.5",
   "description": "Oh My Claudian - provider-backed coding agents embedded in the Obsidian sidebar",
   "main": "main.js",

--- a/src/features/chat/rendering/MermaidRenderer.ts
+++ b/src/features/chat/rendering/MermaidRenderer.ts
@@ -26,7 +26,11 @@ export async function renderMermaidDiagram(
 
   const result = await runtime.render(`claudian-mermaid-${nextDiagramId++}`, source);
   host.replaceChildren();
-  host.insertAdjacentHTML('afterbegin', result.svg);
+  const parsed = new DOMParser().parseFromString(result.svg, 'image/svg+xml');
+  const svg = parsed.documentElement;
+  if (svg.nodeName.toLowerCase() !== 'svg') {
+    throw new Error('Mermaid returned invalid SVG markup');
+  }
+  host.appendChild(host.ownerDocument.importNode(svg, true));
   result.bindFunctions?.(host);
 }
-


### PR DESCRIPTION
## Summary
- replace `insertAdjacentHTML` with parsed SVG DOM insertion
- reject invalid Mermaid output that is not an SVG element
- bump plugin version to 2.4.4

## Verification
- `pnpm run typecheck`
- `pnpm run lint` (5 existing sentence-case warnings)
- `pnpm run test` (405 suites, 6983 tests passed)
- `pnpm run test:architecture`
- targeted Mermaid renderer test