### PR TITLE
feat(chat): make system prompts opt-in

### DIFF
--- a/src/core/execution/ProviderExecutionRequest.ts
+++ b/src/core/execution/ProviderExecutionRequest.ts
@@ -29,12 +29,29 @@ export interface ProviderExecutionContext {
 
 export type ProviderSystemInstructions =
   | {
+      readonly kind: 'none';
+    }
+  | {
       readonly kind: 'provider-default';
     }
   | {
       readonly kind: 'explicit';
       readonly instructions: string;
     };
+
+export function resolveProviderSystemInstructions(
+  instructions: ProviderSystemInstructions,
+  buildDefault: () => string,
+): string | undefined {
+  switch (instructions.kind) {
+    case 'none':
+      return undefined;
+    case 'explicit':
+      return instructions.instructions;
+    case 'provider-default':
+      return buildDefault();
+  }
+}
 
 export interface ProviderExecutionConfiguration {
   readonly systemInstructions: ProviderSystemInstructions;

--- a/src/core/execution/index.ts
+++ b/src/core/execution/index.ts
@@ -66,6 +66,7 @@ export {
   type ProviderExecutionRequest,
   type ProviderSystemInstructions,
   type ProviderToolPolicy,
+  resolveProviderSystemInstructions,
 } from './ProviderExecutionRequest';
 export {
   type ProviderExecutionRun,

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -1077,6 +1077,9 @@ export class InputController {
     const mode = permissionMode === 'plan' && this.getActiveCapabilities().supportsPlanMode
       ? permissionMode
       : undefined;
+    const customSystemPrompt = typeof this.deps.plugin.settings.systemPrompt === 'string'
+      ? this.deps.plugin.settings.systemPrompt.trim()
+      : '';
     const images = [...(request.images ?? [])];
     const existingUserTurns = this.deps.state.messages.filter(isCanonicalUserMessage).length;
 
@@ -1096,7 +1099,9 @@ export class InputController {
         ...(mode ? { mode } : {}),
         ...(reasoning ? { reasoning } : {}),
         ...(serviceTier ? { serviceTier } : {}),
-        systemInstructions: { kind: 'provider-default' },
+        systemInstructions: customSystemPrompt
+          ? { kind: 'explicit', instructions: customSystemPrompt }
+          : { kind: 'none' },
       },
       context: {
         ...(request.browserSelection

--- a/src/providers/claude/execution/ClaudeExecutionRequestEncoder.ts
+++ b/src/providers/claude/execution/ClaudeExecutionRequestEncoder.ts
@@ -8,6 +8,7 @@ import type {
   ProviderExecutionRequest,
   ProviderSessionConfig,
 } from '../../../core/execution';
+import { resolveProviderSystemInstructions } from '../../../core/execution';
 import type { McpServerManager } from '../../../core/mcp/McpServerManager';
 import { buildSystemPrompt } from '../../../core/prompt/mainAgent';
 import type { ProviderHost } from '../../../core/providers/ProviderHost';
@@ -152,24 +153,30 @@ export class ClaudeExecutionRequestEncoder {
       createVaultBoundaryHook(sessionConfig.vaultWorkingDirectory),
       ...(policy.hooks?.PreToolUse ?? []),
     ];
-    const systemPrompt = request.configuration.systemInstructions.kind === 'explicit'
-      ? [
-        request.configuration.systemInstructions.instructions.trim(),
-        EXPLICIT_PROTOCOL_INSTRUCTIONS,
-      ].filter(Boolean).join('\n\n')
-      : buildSystemPrompt({
+    const resolvedSystemPrompt = resolveProviderSystemInstructions(
+      request.configuration.systemInstructions,
+      () => buildSystemPrompt({
         mediaFolder: settings.mediaFolder,
         customPrompt: settings.systemPrompt,
         vaultPath: sessionConfig.vaultWorkingDirectory,
         userName: settings.userName,
-      });
+      }),
+    );
+    const systemPrompt = resolvedSystemPrompt === undefined
+      ? undefined
+      : request.configuration.systemInstructions.kind === 'explicit'
+        ? [
+          resolvedSystemPrompt.trim(),
+          EXPLICIT_PROTOCOL_INSTRUCTIONS,
+        ].filter(Boolean).join('\n\n')
+        : resolvedSystemPrompt;
     const externalPaths = uniqueStrings([
       ...(request.context?.externalContextPaths ?? []),
       ...(request.configuration.externalWorkspaceRoots ?? []),
     ]);
     const options: Options = {
       cwd: sessionConfig.vaultWorkingDirectory,
-      systemPrompt,
+      ...(systemPrompt ? { systemPrompt } : {}),
       model,
       effort,
       thinking: { type: 'adaptive' },

--- a/src/providers/codex/execution/CodexExecutionSession.ts
+++ b/src/providers/codex/execution/CodexExecutionSession.ts
@@ -16,6 +16,7 @@ import {
   type ProviderSessionSnapshot,
   type ProviderSessionStatus,
   type ProviderToolPolicy,
+  resolveProviderSystemInstructions,
   type SteerableExecutionSession,
 } from '../../../core/execution';
 import {
@@ -1737,12 +1738,14 @@ export class CodexExecutionSession
   }
 
   private resolveBaseInstructions(request: ProviderExecutionRequest): string {
-    const base = request.configuration.systemInstructions.kind === 'explicit'
-      ? request.configuration.systemInstructions.instructions
-      : buildSystemPrompt(this.getSystemPromptSettings());
-    return request.toolPolicy.kind === 'passive'
-      ? `${base}\n\n${PASSIVE_INSTRUCTIONS}`
-      : base;
+    const base = resolveProviderSystemInstructions(
+      request.configuration.systemInstructions,
+      () => buildSystemPrompt(this.getSystemPromptSettings()),
+    ) ?? '';
+    return [
+      base,
+      ...(request.toolPolicy.kind === 'passive' ? [PASSIVE_INSTRUCTIONS] : []),
+    ].filter(Boolean).join('\n\n');
   }
 
   private getSystemPromptSettings(): SystemPromptSettings {

--- a/src/providers/opencode/execution/OpencodeAcpSessionKernel.ts
+++ b/src/providers/opencode/execution/OpencodeAcpSessionKernel.ts
@@ -35,6 +35,7 @@ import { getEnhancedPath } from '@/utils/env';
 
 import {
   type OpencodeManagedAgentConfig,
+  type OpencodeSystemPrompt,
   prepareOpencodeLaunchArtifacts,
 } from '../runtime/OpencodeLaunchArtifacts';
 import { buildOpencodeRuntimeEnv } from '../runtime/OpencodeRuntimeEnvironment';
@@ -192,17 +193,11 @@ export class DefaultOpencodeAcpSessionKernel
             managedAgents: [buildAgentConfig(options.profile)],
           }),
         runtimeEnv,
-        ...(options.systemInstructions.kind === 'explicit'
-          ? {
-            systemPromptKey: options.systemInstructions.instructions,
-            systemPromptText: options.systemInstructions.instructions,
-          }
-          : {
-            settings: getSystemPromptSettings(
-              this.options.plugin,
-              this.options.config.vaultWorkingDirectory,
-            ),
-          }),
+        systemPrompt: toOpencodeSystemPrompt(
+          options.systemInstructions,
+          this.options.plugin,
+          this.options.config.vaultWorkingDirectory,
+        ),
         workspaceRoot: this.options.config.vaultWorkingDirectory,
       });
       this.assertNotDisposed();
@@ -446,6 +441,28 @@ export class DefaultOpencodeAcpSessionKernel
   private requireConnection(): AcpClientConnection {
     if (!this.connection) throw new Error('OpenCode ACP kernel is not connected');
     return this.connection;
+  }
+}
+
+function toOpencodeSystemPrompt(
+  instructions: ProviderSystemInstructions,
+  plugin: ProviderHost,
+  vaultWorkingDirectory: string,
+): OpencodeSystemPrompt {
+  switch (instructions.kind) {
+    case 'none':
+      return { kind: 'none' };
+    case 'explicit':
+      return {
+        key: instructions.instructions,
+        kind: 'explicit',
+        text: instructions.instructions,
+      };
+    case 'provider-default':
+      return {
+        kind: 'default',
+        settings: getSystemPromptSettings(plugin, vaultWorkingDirectory),
+      };
   }
 }
 

--- a/src/providers/opencode/metadata/OpencodeMetadataService.ts
+++ b/src/providers/opencode/metadata/OpencodeMetadataService.ts
@@ -280,7 +280,7 @@ class DefaultOpencodeMetadataProbe implements OpencodeMetadataProbe {
     this.kernel = kernel;
     await kernel.connect({
       profile: 'passive',
-      systemInstructions: { kind: 'provider-default' },
+      systemInstructions: { kind: 'none' },
     });
     signal?.throwIfAborted();
     this.native = await kernel.openSession();

--- a/src/providers/opencode/runtime/OpencodeLaunchArtifacts.ts
+++ b/src/providers/opencode/runtime/OpencodeLaunchArtifacts.ts
@@ -29,6 +29,20 @@ export interface OpencodeManagedAgentConfig {
   id: string;
 }
 
+export type OpencodeSystemPrompt =
+  | {
+      readonly kind: 'none';
+    }
+  | {
+      readonly kind: 'default';
+      readonly settings: SystemPromptSettings;
+    }
+  | {
+      readonly kind: 'explicit';
+      readonly key: string;
+      readonly text: string;
+    };
+
 const DEFAULT_OPENCODE_MANAGED_AGENT_CONFIGS: readonly OpencodeManagedAgentConfig[] = [
   { id: OPENCODE_BUILD_MODE_ID },
   {
@@ -61,9 +75,7 @@ export interface PrepareOpencodeLaunchArtifactsParams {
   defaultAgentId?: string;
   managedAgents?: readonly OpencodeManagedAgentConfig[];
   runtimeEnv: NodeJS.ProcessEnv;
-  settings?: SystemPromptSettings;
-  systemPromptKey?: string;
-  systemPromptText?: string;
+  systemPrompt: OpencodeSystemPrompt;
   userName?: string;
   workspaceRoot: string;
 }
@@ -78,13 +90,9 @@ export async function prepareOpencodeLaunchArtifacts(
   );
   const systemPromptPath = path.join(artifactsDir, 'system.md');
   const configPath = path.join(artifactsDir, 'config.json');
-  const systemPrompt = normalizeSystemPrompt(
-    params.systemPromptText ?? buildSystemPrompt(requireSettings(params)),
-  );
-  const promptKey = params.systemPromptKey
-    ?? (params.systemPromptText !== undefined
-      ? params.systemPromptText
-      : computeSystemPromptKey(requireSettings(params)));
+  const systemPrompt = resolveSystemPrompt(params.systemPrompt);
+  const systemPromptPathForConfig = systemPrompt ? systemPromptPath : undefined;
+  const promptKey = resolveSystemPromptKey(params.systemPrompt);
   const baseConfig = await loadOpencodeBaseConfig(
     params.runtimeEnv.OPENCODE_CONFIG,
     params.workspaceRoot,
@@ -92,8 +100,11 @@ export async function prepareOpencodeLaunchArtifacts(
   const configContent = `${JSON.stringify(
     buildOpencodeManagedConfig(
       baseConfig,
-      systemPromptPath,
-      params.userName ?? params.settings?.userName,
+      systemPromptPathForConfig,
+      params.userName
+        ?? (params.systemPrompt.kind === 'default'
+          ? params.systemPrompt.settings.userName
+          : undefined),
       params.managedAgents,
       params.defaultAgentId,
     ),
@@ -104,7 +115,9 @@ export async function prepareOpencodeLaunchArtifacts(
 
   await fs.mkdir(artifactsDir, { recursive: true });
   await ensureOpencodeDatabaseDirectory(databasePath);
-  await writeIfChanged(systemPromptPath, systemPrompt);
+  if (systemPrompt) {
+    await writeIfChanged(systemPromptPath, systemPrompt);
+  }
   await writeIfChanged(configPath, configContent);
 
   return {
@@ -121,6 +134,28 @@ export async function prepareOpencodeLaunchArtifacts(
   };
 }
 
+function resolveSystemPrompt(systemPrompt: OpencodeSystemPrompt): string {
+  switch (systemPrompt.kind) {
+    case 'none':
+      return '';
+    case 'explicit':
+      return normalizeSystemPrompt(systemPrompt.text);
+    case 'default':
+      return normalizeSystemPrompt(buildSystemPrompt(systemPrompt.settings));
+  }
+}
+
+function resolveSystemPromptKey(systemPrompt: OpencodeSystemPrompt): string {
+  switch (systemPrompt.kind) {
+    case 'none':
+      return 'none';
+    case 'explicit':
+      return systemPrompt.key;
+    case 'default':
+      return computeSystemPromptKey(systemPrompt.settings);
+  }
+}
+
 async function ensureOpencodeDatabaseDirectory(databasePath: string | null): Promise<void> {
   if (!databasePath || databasePath === ':memory:') {
     return;
@@ -131,7 +166,7 @@ async function ensureOpencodeDatabaseDirectory(databasePath: string | null): Pro
 
 export function buildOpencodeManagedConfig(
   baseConfig: Record<string, unknown>,
-  systemPromptPath: string,
+  systemPromptPath?: string,
   userName?: string,
   managedAgents: readonly OpencodeManagedAgentConfig[] = DEFAULT_OPENCODE_MANAGED_AGENT_CONFIGS,
   defaultAgentId?: string,
@@ -158,7 +193,7 @@ export function buildOpencodeManagedConfig(
     nextAgents[agentConfig.id] = {
       ...existingAgent,
       ...(isPlainObject(agentConfig.definition) ? agentConfig.definition : {}),
-      prompt: `{file:${systemPromptPath}}`,
+      ...(systemPromptPath ? { prompt: `{file:${systemPromptPath}}` } : {}),
     };
   }
 
@@ -218,14 +253,4 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function normalizeSystemPrompt(systemPrompt: string): string {
   return systemPrompt.endsWith('\n') ? systemPrompt : `${systemPrompt}\n`;
-}
-
-function requireSettings(
-  params: PrepareOpencodeLaunchArtifactsParams,
-): SystemPromptSettings {
-  if (params.settings) {
-    return params.settings;
-  }
-
-  throw new Error('prepareOpencodeLaunchArtifacts requires settings when no systemPromptText is provided');
 }

--- a/src/providers/pi/execution/PiExecutionSession.ts
+++ b/src/providers/pi/execution/PiExecutionSession.ts
@@ -16,6 +16,7 @@ import {
   type ProviderSessionSnapshot,
   type ProviderSessionStatus,
   type ProviderToolPolicy,
+  resolveProviderSystemInstructions,
   type SteerableExecutionSession,
 } from '../../../core/execution';
 import {
@@ -1471,18 +1472,18 @@ function resolveSystemPrompt(
   request: ProviderExecutionRequest,
   settings: Record<string, unknown>,
   vaultPath: string,
-): string {
-  if (request.configuration.systemInstructions.kind === 'explicit') {
-    return request.configuration.systemInstructions.instructions;
-  }
-  return buildSystemPrompt({
-    customPrompt: getString(settings.systemPrompt) ?? undefined,
-    mediaFolder: getString(settings.mediaFolder) ?? undefined,
-    userName: getString(settings.userName) ?? undefined,
-    vaultPath,
-  } satisfies SystemPromptSettings, {
-    toolGuidanceProfile: 'provider-native',
-  });
+): string | undefined {
+  return resolveProviderSystemInstructions(
+    request.configuration.systemInstructions,
+    () => buildSystemPrompt({
+      customPrompt: getString(settings.systemPrompt) ?? undefined,
+      mediaFolder: getString(settings.mediaFolder) ?? undefined,
+      userName: getString(settings.userName) ?? undefined,
+      vaultPath,
+    } satisfies SystemPromptSettings, {
+      toolGuidanceProfile: 'provider-native',
+    }),
+  );
 }
 
 function encodePrompt(

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -121,6 +121,7 @@ function createFixture(overrides: Record<string, unknown> = {}) {
     settings: {
       enableAutoTitleGeneration: false,
       permissionMode: 'normal',
+      systemPrompt: '',
     },
     updateConversation: jest.fn().mockResolvedValue(undefined),
   };
@@ -271,6 +272,30 @@ describe('InputController coordinator execution', () => {
     expect(second.userTurnOrdinal).toBe(2);
     expect(second.conversationHistory).toHaveLength(2);
     expect(fixture.deps.conversationController.save).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not add the Claudian default system instructions when no custom prompt is configured', async () => {
+    const fixture = createFixture();
+    fixture.input.value = 'first';
+
+    await fixture.controller.sendMessage();
+
+    const submission = fixture.coordinator.execute.mock.calls[0][0] as ChatTurnSubmission;
+    expect(submission.configuration.systemInstructions).toEqual({ kind: 'none' });
+  });
+
+  it('passes a configured custom prompt as explicit system instructions', async () => {
+    const fixture = createFixture();
+    fixture.plugin.settings.systemPrompt = 'Use concise answers.';
+    fixture.input.value = 'first';
+
+    await fixture.controller.sendMessage();
+
+    const submission = fixture.coordinator.execute.mock.calls[0][0] as ChatTurnSubmission;
+    expect(submission.configuration.systemInstructions).toEqual({
+      instructions: 'Use concise answers.',
+      kind: 'explicit',
+    });
   });
 
   it('blocks the first turn when provider preflight reports a blocking error', async () => {

--- a/tests/unit/providers/claude/execution/ClaudeExecutionBackend.test.ts
+++ b/tests/unit/providers/claude/execution/ClaudeExecutionBackend.test.ts
@@ -310,6 +310,29 @@ describe('ClaudeExecutionBackend', () => {
     }));
   });
 
+  it('omits the Claudian system prompt when system instructions are disabled', async () => {
+    sdkMock.setMockMessages([
+      {
+        type: 'system',
+        subtype: 'init',
+        session_id: 'native-session',
+      },
+      { type: 'result', subtype: 'success' },
+    ], { appendResult: false });
+    const { services } = createServices();
+    const session = new ClaudeExecutionBackend(createHost(), services)
+      .createSession(createConfig());
+
+    await collectEvents(session.execute(createRequest({
+      configuration: {
+        systemInstructions: { kind: 'none' },
+        model: 'claude-sonnet-4-5',
+      },
+    })).events);
+
+    expect(sdkMock.getLastOptions()?.systemPrompt).toBeUndefined();
+  });
+
   it('uses resumable ephemeral turns and honors passive non-persistent policy', async () => {
     const { services } = createServices();
     const backend = new ClaudeExecutionBackend(createHost(), services);

--- a/tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts
+++ b/tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts
@@ -493,6 +493,47 @@ describe('CodexExecutionBackend', () => {
     await session.dispose();
   });
 
+  it('does not add Claudian base instructions when system instructions are disabled', async () => {
+    mockTransportRequest.mockImplementation(async (method: string) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'test',
+          codexHome: '/tmp/.codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'thread/start') return createThreadResult('thread-none');
+      if (method === 'turn/start') return createTurnResult('turn-none');
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const session = new CodexExecutionBackend(createPlugin())
+      .createSession(createSessionConfig());
+    const run = session.execute(createRequest(undefined, {
+      configuration: {
+        systemInstructions: { kind: 'none' },
+        model: TEST_CODEX_MODEL,
+        reasoning: 'high',
+        serviceTier: 'priority',
+        permissionMode: 'normal',
+      },
+    }));
+    await waitForCondition(() => mockTransportRequest.mock.calls.some(
+      ([method]) => method === 'thread/start',
+    ));
+
+    const threadStart = mockTransportRequest.mock.calls.find(
+      ([method]) => method === 'thread/start',
+    );
+    expect(threadStart?.[1]).toEqual(expect.objectContaining({
+      baseInstructions: '',
+    }));
+    run.cancel();
+    await collectEvents(run.events);
+    await session.dispose();
+  });
+
   it('recovers a completed turn when the terminal notification is missed', async () => {
     jest.useFakeTimers();
     const threadId = 'thread-missed-completion';

--- a/tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts
+++ b/tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts
@@ -77,6 +77,32 @@ describe('buildOpencodeManagedConfig', () => {
     });
   });
 
+  it('leaves managed agents without a Claudian prompt when system instructions are disabled', () => {
+    expect(buildOpencodeManagedConfig({}, undefined)).toEqual({
+      $schema: 'https://opencode.ai/config.json',
+      agent: {
+        build: {},
+        [OPENCODE_YOLO_MODE_ID]: {
+          mode: 'primary',
+          permission: {
+            plan_enter: 'allow',
+            question: 'allow',
+          },
+        },
+        [OPENCODE_SAFE_MODE_ID]: {
+          mode: 'primary',
+          permission: {
+            bash: 'ask',
+            edit: 'ask',
+            plan_enter: 'allow',
+            question: 'allow',
+          },
+        },
+        plan: {},
+      },
+    });
+  });
+
   it('merges the user config instead of replacing it', () => {
     expect(buildOpencodeManagedConfig({
       agent: {
@@ -162,12 +188,16 @@ describe('prepareOpencodeLaunchArtifacts', () => {
         HOME: tmpRoot,
         OPENCODE_CONFIG: baseConfigPath,
       } as NodeJS.ProcessEnv,
-      settings: {
-        customPrompt: '',
-        mediaFolder: '',
-        userName: 'Yishen',
-        vaultPath: tmpRoot,
+      systemPrompt: {
+        kind: 'default',
+        settings: {
+          customPrompt: '',
+          mediaFolder: '',
+          userName: 'Yishen',
+          vaultPath: tmpRoot,
+        },
       },
+      userName: 'Yishen',
       workspaceRoot: tmpRoot,
     });
 
@@ -216,11 +246,14 @@ describe('prepareOpencodeLaunchArtifacts', () => {
   it('keeps the launch key stable when the resolved default database is later passed as OPENCODE_DB', async () => {
     const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'claudian-opencode-artifacts-'));
     const baseParams = {
-      settings: {
-        customPrompt: '',
-        mediaFolder: '',
-        userName: '',
-        vaultPath: tmpRoot,
+      systemPrompt: {
+        kind: 'default' as const,
+        settings: {
+          customPrompt: '',
+          mediaFolder: '',
+          userName: '',
+          vaultPath: tmpRoot,
+        },
       },
       workspaceRoot: tmpRoot,
     };
@@ -253,11 +286,14 @@ describe('prepareOpencodeLaunchArtifacts', () => {
         HOME: path.join(tmpRoot, 'home'),
         XDG_DATA_HOME: xdgDataHome,
       } as NodeJS.ProcessEnv,
-      settings: {
-        customPrompt: '',
-        mediaFolder: '',
-        userName: '',
-        vaultPath: tmpRoot,
+      systemPrompt: {
+        kind: 'default',
+        settings: {
+          customPrompt: '',
+          mediaFolder: '',
+          userName: '',
+          vaultPath: tmpRoot,
+        },
       },
       workspaceRoot: tmpRoot,
     });

--- a/tests/unit/providers/pi/execution/PiExecutionBackend.test.ts
+++ b/tests/unit/providers/pi/execution/PiExecutionBackend.test.ts
@@ -1188,6 +1188,24 @@ describe('PiExecutionBackend', () => {
     expect(harness.kernels[0].launchSpec.args).toContain(expected);
   });
 
+  it('does not pass a system prompt to Pi when system instructions are disabled', async () => {
+    const harness = createHarness();
+    const run = harness.session.execute(createRequest({
+      configuration: {
+        model: 'pi:anthropic/claude-sonnet-4',
+        reasoning: 'high',
+        systemInstructions: { kind: 'none' },
+      },
+    }));
+    const eventsPromise = collect(run.events);
+    await waitFor(() => harness.kernels.length === 1);
+    harness.kernels[0].emit({ type: 'agent_start' });
+    harness.kernels[0].emit({ type: 'agent_end' });
+    await eventsPromise;
+
+    expect(harness.kernels[0].launchSpec.args).not.toContain('--system-prompt');
+  });
+
   it('maps an explicit allow-list exactly and falls back to provider model settings', async () => {
     const harness = createHarness();
     const run = harness.session.execute(createRequest({


### PR DESCRIPTION
## Summary
- Make the main chat system prompt opt-in: empty settings no longer inject Claudian default prompts.
- Preserve explicit user prompts, provider-native behavior, and passive/read-only runtime instructions.
- Centralize provider system-instruction resolution and make OpenCode prompt mode explicit.
- Add provider regression coverage for Claude, Codex, Pi, and OpenCode.

## Verification
- pnpm run typecheck
- pnpm run lint
- pnpm run test (405 suites, 6991 tests)
- pnpm run build