### PR TITLE
test: enforce provider execution contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ src/
 └── style/        # Modular CSS
 ```
 
+Provider execution follows a small, provider-neutral contract rather than a universal harness implementation. Each provider owns its native process, protocol, session state, history, and recovery policy behind `ProviderExecutionBackend` and `ProviderExecutionSession`; ACP providers share transport primitives only, while provider-specific behavior remains in the owning adapter. Shared contract tests cover lifecycle, streaming, cancellation, and terminal-state behavior, and provider-specific tests cover native differences.
+
+When extending a provider, preserve the shared execution contract without flattening provider capabilities into a lowest-common-denominator abstraction. Add or update the provider's contract harness and keep native state and protocol decisions behind its provider directory.
+
 ## Contributing
 
 Issues and focused pull requests are welcome. Before opening one, please search existing issues and pull requests to avoid duplicates. For substantial changes, open an issue first so the problem and scope can be discussed.

--- a/tests/helpers/providerExecutionContractRunner.ts
+++ b/tests/helpers/providerExecutionContractRunner.ts
@@ -1,0 +1,89 @@
+import type {
+  ProviderExecutionEvent,
+  ProviderExecutionRequest,
+  ProviderExecutionSession,
+} from '@/core/execution';
+
+export interface ProviderExecutionContractFactory {
+  createRequest(signal?: AbortSignal): ProviderExecutionRequest;
+  createSession(): ProviderExecutionSession;
+}
+
+export function createProviderExecutionContractCases(
+  factory: ProviderExecutionContractFactory,
+): Array<[string, () => Promise<void>]> {
+  return [
+    ['represents streaming and one-shot output with one correlated event stream', async () => {
+      const session = factory.createSession();
+      const run = session.execute(factory.createRequest());
+      const events = await collect(run.events);
+
+      expect(events.map((event) => event.type)).toContain('turn_completed');
+      expect(
+        events.filter((event) => (
+          event.type === 'turn_completed'
+          || event.type === 'cancelled'
+          || event.type === 'execution_error'
+        )),
+      ).toHaveLength(1);
+      expect(events.every((event) => (
+        event.scope.kind === 'requested'
+        && event.scope.sessionInstanceId === session.sessionInstanceId
+        && event.scope.executionId === run.executionId
+        && event.scope.turnId === run.turnId
+      ))).toBe(true);
+      expect(session.getStatus()).toBe('idle');
+      await session.dispose();
+    }],
+    ['rejects overlapping requested executions', async () => {
+      const session = factory.createSession();
+      const first = session.execute(factory.createRequest());
+
+      expect(() => session.execute(factory.createRequest())).toThrow();
+
+      await collect(first.events);
+      expect(() => session.execute(factory.createRequest())).not.toThrow();
+      await session.dispose();
+    }],
+    ['terminates cancellation through the run, request, and session controls', async () => {
+      const runSession = factory.createSession();
+      const run = runSession.execute(factory.createRequest());
+      run.cancel();
+      expectTerminal(await collect(run.events));
+      await runSession.dispose();
+
+      const requestSession = factory.createSession();
+      const requestAbort = new AbortController();
+      const requestRun = requestSession.execute(factory.createRequest(requestAbort.signal));
+      requestAbort.abort();
+      expectTerminal(await collect(requestRun.events));
+      await requestSession.dispose();
+
+      const session = factory.createSession();
+      const sessionRun = session.execute(factory.createRequest());
+      session.cancel();
+      expectTerminal(await collect(sessionRun.events));
+      await session.dispose();
+    }],
+  ];
+}
+
+async function collect(
+  events: AsyncIterable<ProviderExecutionEvent>,
+): Promise<ProviderExecutionEvent[]> {
+  const collected: ProviderExecutionEvent[] = [];
+  for await (const event of events) {
+    collected.push(event);
+  }
+  return collected;
+}
+
+function expectTerminal(events: readonly ProviderExecutionEvent[]): void {
+  const terminal = events.at(-1)?.type;
+  expect(['cancelled', 'execution_error', 'turn_completed']).toContain(terminal);
+  expect(events.filter((event) => (
+    event.type === 'turn_completed'
+    || event.type === 'cancelled'
+    || event.type === 'execution_error'
+  ))).toHaveLength(1);
+}

--- a/tests/unit/core/execution/ProviderExecutionContract.test.ts
+++ b/tests/unit/core/execution/ProviderExecutionContract.test.ts
@@ -1,3 +1,5 @@
+import { createProviderExecutionContractCases } from '@test/helpers/providerExecutionContractRunner';
+
 import {
   isModeConfigurableExecutionSession,
   isRewindableExecutionSession,
@@ -263,67 +265,12 @@ async function collect(
 }
 
 describe('provider execution contracts', () => {
-  it('represents streaming and one-shot output with one correlated event stream', async () => {
-    const session = new ContractSession();
-    const run = session.execute(createRequest());
-
-    const events = await collect(run.events);
-
-    expect(events.map((event) => event.type)).toEqual([
-      'turn_started',
-      'text_delta',
-      'session_state_changed',
-      'turn_completed',
-    ]);
-    expect(events.map((event) => event.scope.sequence)).toEqual([0, 1, 2, 3]);
-    expect(
-      events.filter((event) =>
-        ['turn_completed', 'cancelled', 'execution_error'].includes(event.type),
-      ),
-    ).toHaveLength(1);
-    expect(
-      events.every(
-        (event) =>
-          event.scope.kind === 'requested' &&
-          event.scope.sessionInstanceId === session.sessionInstanceId &&
-          event.scope.executionId === run.executionId &&
-          event.scope.turnId === run.turnId,
-      ),
-    ).toBe(true);
-    expect(session.getStatus()).toBe('idle');
-  });
-
-  it('fails immediately when a second requested execution is active', async () => {
-    const session = new ContractSession();
-    const first = session.execute(createRequest());
-
-    expect(() => session.execute(createRequest())).toThrow(
-      'A requested execution is already active',
-    );
-
-    await collect(first.events);
-    expect(() => session.execute(createRequest())).not.toThrow();
-  });
-
-  it('terminates cancellation through the event stream for run, request, and session cancellation', async () => {
-    const runSession = new ContractSession();
-    const run = runSession.execute(createRequest());
-    run.cancel();
-    await expect(collect(run.events)).resolves.toEqual([
-      expect.objectContaining({ type: 'turn_started' }),
-      expect.objectContaining({ type: 'cancelled' }),
-    ]);
-
-    const requestSession = new ContractSession();
-    const requestAbort = new AbortController();
-    const requestRun = requestSession.execute(createRequest(requestAbort.signal));
-    requestAbort.abort();
-    expect((await collect(requestRun.events)).at(-1)?.type).toBe('cancelled');
-
-    const session = new ContractSession();
-    const sessionRun = session.execute(createRequest());
-    session.cancel();
-    expect((await collect(sessionRun.events)).at(-1)?.type).toBe('cancelled');
+  it.each(createProviderExecutionContractCases({
+    createRequest,
+    createSession: () => new ContractSession(),
+  }))('%s', async (_name, test) => {
+    expect(typeof test).toBe('function');
+    await test();
   });
 
   it('cancels when iteration ends early and disposes idempotently', async () => {

--- a/tests/unit/providers/claude/execution/ClaudeExecutionBackend.test.ts
+++ b/tests/unit/providers/claude/execution/ClaudeExecutionBackend.test.ts
@@ -1,6 +1,7 @@
 import '@/providers';
 
 import * as sdkModule from '@anthropic-ai/claude-agent-sdk';
+import { createProviderExecutionContractCases } from '@test/helpers/providerExecutionContractRunner';
 import { createProviderRecoveryTestHarness } from '@test/unit/features/chat/execution/ProviderRecoveryTestHarness';
 
 import type {
@@ -2181,6 +2182,43 @@ describe('ClaudeExecutionBackend', () => {
     }));
     expect(session.getSnapshot().status).toBe('invalidated');
     await session.dispose();
+  });
+});
+
+describe('Claude provider execution contract', () => {
+  it.each(createProviderExecutionContractCases({
+    createRequest: signal => signal ? createRequest({ signal }) : createRequest(),
+    createSession: () => {
+      sdkMock.setMockMessages([
+        {
+          type: 'system',
+          subtype: 'init',
+          session_id: 'contract-session',
+        },
+        {
+          type: 'stream_event',
+          parent_tool_use_id: null,
+          event: {
+            type: 'content_block_delta',
+            delta: { type: 'text_delta', text: 'contract response' },
+          },
+        },
+        {
+          type: 'assistant',
+          uuid: 'contract-assistant',
+          message: {
+            content: [{ type: 'text', text: 'contract response' }],
+          },
+        },
+        { type: 'result', subtype: 'success' },
+      ], { appendResult: false });
+      const { services } = createServices();
+      return new ClaudeExecutionBackend(createHost(), services)
+        .createSession(createConfig());
+    },
+  }))('%s', async (_name, test) => {
+    expect(typeof test).toBe('function');
+    await test();
   });
 });
 

--- a/tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts
+++ b/tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts
@@ -1,4 +1,5 @@
 import { TEST_CODEX_MODEL } from '@test/helpers/codexModels';
+import { createProviderExecutionContractCases } from '@test/helpers/providerExecutionContractRunner';
 
 import type {
   ProviderExecutionEvent,
@@ -2805,5 +2806,62 @@ describe('CodexExecutionBackend', () => {
     );
 
     await session.dispose();
+  });
+});
+
+describe('Codex provider execution contract', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    captureHandlers();
+    mockProcessIsAlive.mockReturnValue(true);
+    mockResolveLaunchSpec.mockResolvedValue({
+      target: {
+        method: 'host-native',
+        platformFamily: 'unix',
+        platformOs: 'macos',
+      },
+      command: '/usr/local/bin/codex',
+      args: ['app-server', '--listen', 'stdio://'],
+      spawnCwd: '/vault',
+      targetCwd: '/vault',
+      env: { HOME: '/tmp' },
+      pathMapper: {
+        target: {
+          method: 'host-native',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        },
+        toTargetPath: (value: string) => value,
+        toHostPath: (value: string) => value,
+        mapTargetPathList: (values: string[]) => values,
+        canRepresentHostPath: () => true,
+      },
+    });
+    mockTransportRequest.mockImplementation(async (method: string) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'test',
+          codexHome: '/tmp/.codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'thread/start') return createThreadResult('contract-thread');
+      if (method === 'turn/start') {
+        queueMicrotask(() => completeTurn('contract-thread', 'contract-turn'));
+        return createTurnResult('contract-turn');
+      }
+      if (method === 'turn/interrupt') return {};
+      throw new Error(`Unexpected method: ${method}`);
+    });
+  });
+
+  it.each(createProviderExecutionContractCases({
+    createRequest: signal => signal ? createRequest(signal) : createRequest(),
+    createSession: () => new CodexExecutionBackend(createPlugin())
+      .createSession(createSessionConfig()),
+  }))('%s', async (_name, test) => {
+    expect(typeof test).toBe('function');
+    await test();
   });
 });

--- a/tests/unit/providers/cursor/CursorExecutionSession.test.ts
+++ b/tests/unit/providers/cursor/CursorExecutionSession.test.ts
@@ -1,3 +1,5 @@
+import { createProviderExecutionContractCases } from '@test/helpers/providerExecutionContractRunner';
+
 import { CursorExecutionSession } from '@/providers/cursor/execution/CursorExecutionSession';
 
 function deferred<T>() {
@@ -101,5 +103,59 @@ describe('CursorExecutionSession', () => {
       providerSessionId: 'cursor-session',
       status: 'idle',
     });
+  });
+});
+
+describe('Cursor provider execution contract', () => {
+  it.each(createProviderExecutionContractCases({
+    createRequest: signal => ({
+      configuration: {
+        model: 'cursor:claude-4-sonnet',
+        systemInstructions: { kind: 'provider-default' },
+      },
+      input: [{ text: 'Hello', type: 'text' }],
+      signal: signal ?? new AbortController().signal,
+      toolPolicy: { kind: 'provider-default' },
+    }),
+    createSession: () => {
+      let kernelOptions: any;
+      const kernel = {
+        cancel: jest.fn(),
+        connect: jest.fn().mockResolvedValue(undefined),
+        dispose: jest.fn().mockResolvedValue(undefined),
+        openSession: jest.fn().mockResolvedValue({ sessionId: 'contract-session' }),
+        prompt: jest.fn().mockImplementation(async () => {
+          await flush();
+          await kernelOptions.onNotification({
+            sessionId: 'contract-session',
+            update: {
+              content: { text: 'contract response', type: 'text' },
+              sessionUpdate: 'agent_message_chunk',
+            },
+          });
+          return {
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            userMessageId: 'contract-user',
+          };
+        }),
+        setConfigOption: jest.fn().mockResolvedValue(undefined),
+        setMode: jest.fn().mockResolvedValue(undefined),
+        setModel: jest.fn().mockResolvedValue(undefined),
+      };
+      return new CursorExecutionSession({ settings: {} } as never, {
+        interactionPort: {} as never,
+        lifecycle: 'persistent',
+        nativePersistence: 'provider-default',
+        vaultWorkingDirectory: '/vault',
+      }, {
+        createKernel: options => {
+          kernelOptions = options;
+          return kernel;
+        },
+      });
+    },
+  }))('%s', async (_name, test) => {
+    expect(typeof test).toBe('function');
+    await test();
   });
 });

--- a/tests/unit/providers/grok/execution/GrokExecutionBackend.test.ts
+++ b/tests/unit/providers/grok/execution/GrokExecutionBackend.test.ts
@@ -12,6 +12,8 @@ jest.mock('@/providers/grok/history/GrokHistoryPathResolver', () => ({
   resolveGrokSessionDirectory: (...args: unknown[]) => mockResolveGrokSessionDirectory(...args),
 }));
 
+import { createProviderExecutionContractCases } from '@test/helpers/providerExecutionContractRunner';
+
 import type {
   ProviderExecutionEvent,
   ProviderExecutionRequest,
@@ -2099,5 +2101,41 @@ describe('GrokExecutionBackend', () => {
       missingProviderSessionId: 'session-existing',
       type: 'execution_error',
     });
+  });
+});
+
+describe('Grok provider execution contract', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLoadGrokPromptIndexAfterAssistant.mockResolvedValue(3);
+    mockResolveGrokSessionDirectory.mockImplementation(
+      (_hint: unknown, sessionId: string | undefined) => (
+        sessionId ? `/trusted/grok/sessions/${sessionId}` : null
+      ),
+    );
+  });
+
+  it.each(createProviderExecutionContractCases({
+    createRequest: signal => ({
+      ...executionRequest(),
+      ...(signal ? { signal } : {}),
+    }),
+    createSession: () => {
+      const native = new FakeNativeConnection();
+      native.promptImplementation = async () => {
+        native.emit({
+          content: { text: 'contract response', type: 'text' },
+          sessionUpdate: 'agent_message_chunk',
+        });
+        return { stopReason: 'end_turn' };
+      };
+      return new GrokExecutionBackend(
+        { settings: {} } as ProviderHost,
+        { nativeFactory: { create: () => native } },
+      ).createSession(sessionConfig);
+    },
+  }))('%s', async (_name, test) => {
+    expect(typeof test).toBe('function');
+    await test();
   });
 });

--- a/tests/unit/providers/omp/OmpExecutionSession.test.ts
+++ b/tests/unit/providers/omp/OmpExecutionSession.test.ts
@@ -1,3 +1,5 @@
+import { createProviderExecutionContractCases } from '@test/helpers/providerExecutionContractRunner';
+
 import { OmpExecutionSession } from '@/providers/omp/execution/OmpExecutionSession';
 
 function deferred<T>() {
@@ -93,5 +95,52 @@ describe('OmpExecutionSession', () => {
       type: 'usage_updated',
       usage: expect.objectContaining({ contextTokens: 42_000, percentage: 21 }),
     }));
+  });
+});
+
+describe('OMP provider execution contract', () => {
+  it.each(createProviderExecutionContractCases({
+    createRequest: signal => ({
+      configuration: { systemInstructions: { kind: 'provider-default' } },
+      input: [{ text: 'Hello', type: 'text' }],
+      signal: signal ?? new AbortController().signal,
+      toolPolicy: { kind: 'provider-default' },
+    }),
+    createSession: () => {
+      let kernelOptions: any;
+      const kernel = {
+        cancel: jest.fn(),
+        connect: jest.fn().mockResolvedValue(undefined),
+        dispose: jest.fn().mockResolvedValue(undefined),
+        openSession: jest.fn().mockResolvedValue({ configOptions: [], sessionId: 'contract-session' }),
+        prompt: jest.fn().mockImplementation(async () => {
+          await flush();
+          await kernelOptions.onNotification({
+            sessionId: 'contract-session',
+            update: {
+              content: { text: 'contract response', type: 'text' },
+              sessionUpdate: 'agent_message_chunk',
+            },
+          });
+          return { userMessageId: 'contract-user' };
+        }),
+        setConfigOption: jest.fn().mockResolvedValue(undefined),
+        setModel: jest.fn().mockResolvedValue(undefined),
+      };
+      return new OmpExecutionSession({ settings: {} } as never, {
+        interactionPort: {} as never,
+        lifecycle: 'persistent',
+        nativePersistence: 'provider-default',
+        vaultWorkingDirectory: '/vault',
+      }, {
+        createKernel: options => {
+          kernelOptions = options;
+          return kernel;
+        },
+      });
+    },
+  }))('%s', async (_name, test) => {
+    expect(typeof test).toBe('function');
+    await test();
   });
 });

--- a/tests/unit/providers/opencode/execution/OpencodeExecutionBackend.test.ts
+++ b/tests/unit/providers/opencode/execution/OpencodeExecutionBackend.test.ts
@@ -1,3 +1,5 @@
+import { createProviderExecutionContractCases } from '@test/helpers/providerExecutionContractRunner';
+
 import type {
   ProviderExecutionEvent,
   ProviderExecutionRequest,
@@ -287,7 +289,10 @@ async function waitForCondition(condition: () => boolean): Promise<void> {
   expect(condition()).toBe(true);
 }
 
-function createHarness(config = createConfig()) {
+function createHarness(
+  config = createConfig(),
+  onKernelCreated?: (kernel: FakeKernel) => void,
+) {
   const kernels: FakeKernel[] = [];
   const commandCatalog = {
     setCommandSnapshot: jest.fn(),
@@ -297,6 +302,7 @@ function createHarness(config = createConfig()) {
     createKernel: (options) => {
       const kernel = new FakeKernel(options);
       kernels.push(kernel);
+      onKernelCreated?.(kernel);
       return kernel;
     },
   });
@@ -1209,5 +1215,48 @@ describe('OpencodeExecutionBackend', () => {
         type: 'session_error',
       }),
     ]);
+  });
+});
+
+describe('OpenCode provider execution contract', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockProcessShutdown.mockResolvedValue(undefined);
+    mockConnectionInitialize.mockResolvedValue({});
+    mockPrepareLaunchArtifacts.mockResolvedValue({
+      configContent: '{}',
+      configPath: '/vault/.claudian/opencode/config.json',
+      databasePath: '/native/opencode.db',
+      launchKey: 'launch-key',
+      systemPromptPath: '/vault/.claudian/opencode/system.md',
+    });
+  });
+
+  it.each(createProviderExecutionContractCases({
+    createRequest: signal => signal ? createRequest({ signal }) : createRequest(),
+    createSession: () => {
+      const harness = createHarness(
+        createConfig(),
+        (kernel) => {
+          const complete = (): void => {
+            if (kernel.cancelCalls > 0 || kernel.disposeCalls > 0) return;
+            if (kernel.prompts.length === 0) {
+              setImmediate(complete);
+              return;
+            }
+            kernel.notify({
+              content: { type: 'text', text: 'contract response' },
+              sessionUpdate: 'agent_message_chunk',
+            });
+            kernel.completePrompt();
+          };
+          setImmediate(complete);
+        },
+      );
+      return harness.session;
+    },
+  }))('%s', async (_name, test) => {
+    expect(typeof test).toBe('function');
+    await test();
   });
 });

--- a/tests/unit/providers/pi/execution/PiExecutionBackend.test.ts
+++ b/tests/unit/providers/pi/execution/PiExecutionBackend.test.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
+import { createProviderExecutionContractCases } from '@test/helpers/providerExecutionContractRunner';
 import { createProviderRecoveryTestHarness } from '@test/unit/features/chat/execution/ProviderRecoveryTestHarness';
 
 import type {
@@ -2035,5 +2036,26 @@ describe('PiExecutionBackend', () => {
       'Pi execution session is disposed',
     );
     expect(harness.kernels).toHaveLength(0);
+  });
+});
+
+describe('Pi provider execution contract', () => {
+  it.each(createProviderExecutionContractCases({
+    createRequest: signal => signal ? createRequest({ signal }) : createRequest(),
+    createSession: () => {
+      const harness = createHarness(
+        undefined,
+        kernel => {
+          queueMicrotask(() => {
+            kernel.emit({ type: 'agent_start' });
+            kernel.emit({ type: 'agent_end' });
+          });
+        },
+      );
+      return harness.session;
+    },
+  }))('%s', async (_name, test) => {
+    expect(typeof test).toBe('function');
+    await test();
   });
 });


### PR DESCRIPTION
## Summary
- Add a reusable provider execution contract runner for correlated streaming, overlap protection, cancellation, and terminal-state convergence.
- Apply the contract harness to Claude, Codex, Cursor, Grok, OMP, OpenCode, and Pi native test doubles.
- Keep provider-specific native harness behavior in each provider test instead of introducing a universal ACP/provider runtime abstraction.
- Document the provider execution design and contract-test expectations in README.md.

## Verification
- pnpm run typecheck
- pnpm run lint
- pnpm run test (405 suites, 7012 tests)

## Notes
- Lint reports five existing Obsidian sentence-case warnings; no lint errors remain.