### PR TITLE
chore: release v2.4.5

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "packageManager": "pnpm@10.34.5",
   "description": "Oh My Claudian - provider-backed coding agents embedded in the Obsidian sidebar",
   "main": "main.js",


### PR DESCRIPTION
## Summary

- bump package and Obsidian manifest versions from 2.4.4 to 2.4.5
- release the changes merged in PR #99

## Validation

- pnpm run typecheck
- pnpm run lint (0 errors; 5 existing sentence-case warnings)
- pnpm run test:architecture
- pnpm run build
- git diff --check