### PR TITLE
chore: release 2.4.6

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "packageManager": "pnpm@10.34.5",
   "description": "Oh My Claudian - provider-backed coding agents embedded in the Obsidian sidebar",
   "main": "main.js",


### PR DESCRIPTION
## Summary
- bump package and plugin manifest versions to 2.4.6

## Verification
- node scripts/check-release-version.mjs 2.4.6
- pnpm run typecheck
- pnpm run lint (9 existing warnings)
- pnpm run test
- pnpm run build