### PR TITLE
feat: keep Pi extension questions inline

### DIFF
--- a/src/providers/pi/execution/PiExecutionSession.ts
+++ b/src/providers/pi/execution/PiExecutionSession.ts
@@ -68,6 +68,7 @@ import {
 } from '../normalizations/piEventNormalization';
 import { buildPiUsageInfo } from '../runtime/buildPiUsageInfo';
 import type { PiExtensionUiRenderer } from '../runtime/PiExtensionUiBridge';
+import { PiExtensionUiInteractionAdapter } from '../runtime/PiExtensionUiInteractionAdapter';
 import {
   buildPiLaunchSpec,
   type PiLaunchSpec,
@@ -617,7 +618,7 @@ implements ProviderExecutionSession, SteerableExecutionSession {
         },
       },
       this.config.lifecycle === 'persistent'
-        ? this.options.extensionUiRenderer
+        ? this.createExtensionUiRenderer()
         : null,
     );
     if (!this.isActive(active) || active.abortController.signal.aborted) {
@@ -650,6 +651,18 @@ implements ProviderExecutionSession, SteerableExecutionSession {
       return;
     }
     void this.publishCommands(kernel, generation);
+  }
+
+  private createExtensionUiRenderer(): PiExtensionUiRenderer | null {
+    if (!this.options.extensionUiRenderer) {
+      return null;
+    }
+
+    return new PiExtensionUiInteractionAdapter(this.options.extensionUiRenderer, {
+      getTurnId: () => this.activeRun?.turnId ?? null,
+      interactionPort: this.config.interactionPort,
+      sessionInstanceId: this.sessionInstanceId,
+    });
   }
 
   private async applyModelConfiguration(

--- a/src/providers/pi/runtime/PiExtensionUiInteractionAdapter.ts
+++ b/src/providers/pi/runtime/PiExtensionUiInteractionAdapter.ts
@@ -26,6 +26,8 @@ interface PiExtensionUiInteractionAdapterOptions {
  * through the provider-neutral chat interaction presentation.
  */
 export class PiExtensionUiInteractionAdapter implements PiExtensionUiRenderer {
+  private pendingCustomInputValue: string | null = null;
+
   constructor(
     private readonly fallback: PiExtensionUiRenderer,
     private readonly options: PiExtensionUiInteractionAdapterOptions,
@@ -35,27 +37,38 @@ export class PiExtensionUiInteractionAdapter implements PiExtensionUiRenderer {
     request: PiExtensionUiSelectRequest,
     signal: AbortSignal,
   ): Promise<{ cancelled?: boolean; value?: string }> {
+    this.pendingCustomInputValue = null;
     const turnId = this.options.getTurnId();
     if (!turnId) {
       return { cancelled: true };
     }
 
-    const question = createQuestion(request);
-    if (!question) {
+    const presentation = createQuestionPresentation(request);
+    if (!presentation) {
       return this.fallback.select(request, signal);
     }
 
     const response = await this.options.interactionPort.askUserQuestion({
       kind: 'question',
       interactionId: createInteractionId(this.options.sessionInstanceId, request.id),
-      input: { questions: [question] },
+      input: { questions: [presentation.question] },
       nativeContext: { extensionRequestId: request.id },
       sessionInstanceId: this.options.sessionInstanceId,
       turnId,
     }, signal);
-    const answer = response.answers?.[question.id];
+    const answer = response.answers?.[presentation.question.id];
     const value = typeof answer === 'string' ? answer : null;
-    return value === null ? { cancelled: true } : { value };
+    if (value === null) {
+      return { cancelled: true };
+    }
+    if (
+      presentation.customInputOptionValue
+      && !presentation.optionValues.has(value)
+    ) {
+      this.pendingCustomInputValue = value;
+      return { value: presentation.customInputOptionValue };
+    }
+    return { value };
   }
 
   confirm(
@@ -76,6 +89,13 @@ export class PiExtensionUiInteractionAdapter implements PiExtensionUiRenderer {
     request: PiExtensionUiInputRequest,
     signal: AbortSignal,
   ): Promise<{ cancelled?: boolean; value?: string }> {
+    const pendingCustomInputValue = this.pendingCustomInputValue;
+    this.pendingCustomInputValue = null;
+    if (pendingCustomInputValue !== null) {
+      return Promise.resolve(signal.aborted
+        ? { cancelled: true }
+        : { value: pendingCustomInputValue });
+    }
     return this.fallback.input(request, signal);
   }
 
@@ -104,28 +124,48 @@ function createInteractionId(sessionInstanceId: string, requestId: string): stri
   return `pi-extension:${sessionInstanceId}:${requestId}`;
 }
 
-function createQuestion(request: PiExtensionUiSelectRequest): {
+interface PiSelectQuestionPresentation {
+  readonly customInputOptionValue: string | null;
+  readonly optionValues: ReadonlySet<string>;
+  readonly question: {
   header: string;
   id: string;
-  isOther: false;
+  isOther: boolean;
   multiSelect: false;
   options: AskUserQuestionOption[];
   question: string;
-} | null {
+  };
+}
+
+function createQuestionPresentation(
+  request: PiExtensionUiSelectRequest,
+): PiSelectQuestionPresentation | null {
   const options = getOptions(request);
-  if (options.length === 0) {
+  const customInputOption = options.find(isCustomInputOption) ?? null;
+  const visibleOptions = customInputOption
+    ? options.filter(option => option !== customInputOption)
+    : options;
+  if (visibleOptions.length === 0 && !customInputOption) {
     return null;
   }
 
   const title = getString(request.title) ?? 'Pi extension';
   return {
-    header: title,
-    id: `pi-extension-ui-${request.id}`,
-    isOther: false,
-    multiSelect: false,
-    options,
-    question: getString(request.message) ?? title,
+    customInputOptionValue: customInputOption?.value ?? null,
+    optionValues: new Set(visibleOptions.map(option => option.value ?? option.label)),
+    question: {
+      header: title,
+      id: `pi-extension-ui-${request.id}`,
+      isOther: customInputOption !== null,
+      multiSelect: false,
+      options: visibleOptions,
+      question: getString(request.message) ?? title,
+    },
   };
+}
+
+function isCustomInputOption(option: AskUserQuestionOption): boolean {
+  return option.label.trim().toLowerCase() === 'type something.';
 }
 
 function getOptions(request: Record<string, unknown>): AskUserQuestionOption[] {

--- a/src/providers/pi/runtime/PiExtensionUiInteractionAdapter.ts
+++ b/src/providers/pi/runtime/PiExtensionUiInteractionAdapter.ts
@@ -1,0 +1,153 @@
+import type { ProviderInteractionPort } from '../../../core/execution';
+import type { AskUserQuestionOption } from '../../../core/types';
+import type {
+  PiExtensionUiConfirmRequest,
+  PiExtensionUiEditorRequest,
+  PiExtensionUiInputRequest,
+  PiExtensionUiNotifyRequest,
+  PiExtensionUiRenderer,
+  PiExtensionUiSelectRequest,
+  PiExtensionUiSetEditorTextRequest,
+  PiExtensionUiSetStatusRequest,
+  PiExtensionUiSetTitleRequest,
+  PiExtensionUiSetWidgetRequest,
+} from './PiExtensionUiBridge';
+
+export type { PiExtensionUiRenderer } from './PiExtensionUiBridge';
+
+interface PiExtensionUiInteractionAdapterOptions {
+  readonly getTurnId: () => string | null;
+  readonly interactionPort: ProviderInteractionPort;
+  readonly sessionInstanceId: string;
+}
+
+/**
+ * Keeps Pi extension RPC semantics provider-owned while routing select prompts
+ * through the provider-neutral chat interaction presentation.
+ */
+export class PiExtensionUiInteractionAdapter implements PiExtensionUiRenderer {
+  constructor(
+    private readonly fallback: PiExtensionUiRenderer,
+    private readonly options: PiExtensionUiInteractionAdapterOptions,
+  ) {}
+
+  async select(
+    request: PiExtensionUiSelectRequest,
+    signal: AbortSignal,
+  ): Promise<{ cancelled?: boolean; value?: string }> {
+    const turnId = this.options.getTurnId();
+    if (!turnId) {
+      return { cancelled: true };
+    }
+
+    const question = createQuestion(request);
+    if (!question) {
+      return this.fallback.select(request, signal);
+    }
+
+    const response = await this.options.interactionPort.askUserQuestion({
+      kind: 'question',
+      interactionId: createInteractionId(this.options.sessionInstanceId, request.id),
+      input: { questions: [question] },
+      nativeContext: { extensionRequestId: request.id },
+      sessionInstanceId: this.options.sessionInstanceId,
+      turnId,
+    }, signal);
+    const answer = response.answers?.[question.id];
+    const value = typeof answer === 'string' ? answer : null;
+    return value === null ? { cancelled: true } : { value };
+  }
+
+  confirm(
+    request: PiExtensionUiConfirmRequest,
+    signal: AbortSignal,
+  ): Promise<{ cancelled?: boolean; confirmed?: boolean }> {
+    return this.fallback.confirm(request, signal);
+  }
+
+  editor(
+    request: PiExtensionUiEditorRequest,
+    signal: AbortSignal,
+  ): Promise<{ cancelled?: boolean; value?: string }> {
+    return this.fallback.editor(request, signal);
+  }
+
+  input(
+    request: PiExtensionUiInputRequest,
+    signal: AbortSignal,
+  ): Promise<{ cancelled?: boolean; value?: string }> {
+    return this.fallback.input(request, signal);
+  }
+
+  notify(request: PiExtensionUiNotifyRequest): void {
+    this.fallback.notify(request);
+  }
+
+  setEditorText(request: PiExtensionUiSetEditorTextRequest): void {
+    this.fallback.setEditorText(request);
+  }
+
+  setStatus(request: PiExtensionUiSetStatusRequest): void {
+    this.fallback.setStatus(request);
+  }
+
+  setTitle(request: PiExtensionUiSetTitleRequest): void {
+    this.fallback.setTitle(request);
+  }
+
+  setWidget(request: PiExtensionUiSetWidgetRequest): void {
+    this.fallback.setWidget(request);
+  }
+}
+
+function createInteractionId(sessionInstanceId: string, requestId: string): string {
+  return `pi-extension:${sessionInstanceId}:${requestId}`;
+}
+
+function createQuestion(request: PiExtensionUiSelectRequest): {
+  header: string;
+  id: string;
+  isOther: false;
+  multiSelect: false;
+  options: AskUserQuestionOption[];
+  question: string;
+} | null {
+  const options = getOptions(request);
+  if (options.length === 0) {
+    return null;
+  }
+
+  const title = getString(request.title) ?? 'Pi extension';
+  return {
+    header: title,
+    id: `pi-extension-ui-${request.id}`,
+    isOther: false,
+    multiSelect: false,
+    options,
+    question: getString(request.message) ?? title,
+  };
+}
+
+function getOptions(request: Record<string, unknown>): AskUserQuestionOption[] {
+  const rawOptions = Array.isArray(request.options) ? request.options : [];
+  return rawOptions.flatMap((option): AskUserQuestionOption[] => {
+    if (typeof option === 'string' && option.trim()) {
+      const value = option.trim();
+      return [{ description: '', label: value, value }];
+    }
+    if (!option || typeof option !== 'object' || Array.isArray(option)) {
+      return [];
+    }
+
+    const record = option as Record<string, unknown>;
+    const value = getString(record.value);
+    if (!value) {
+      return [];
+    }
+    return [{ description: '', label: getString(record.label) ?? value, value }];
+  });
+}
+
+function getString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}

--- a/tests/unit/providers/pi/runtime/PiExtensionUiInteractionAdapter.test.ts
+++ b/tests/unit/providers/pi/runtime/PiExtensionUiInteractionAdapter.test.ts
@@ -92,6 +92,44 @@ describe('PiExtensionUiInteractionAdapter', () => {
     }, new AbortController().signal)).resolves.toEqual({ cancelled: true });
   });
 
+  it('keeps a custom answer in the shared question until Pi requests its input', async () => {
+    const interactionPort = createInteractionPort();
+    interactionPort.askUserQuestion.mockResolvedValue({
+      answers: { 'pi-extension-ui-42': 'Write release notes' },
+      interactionId: 'pi-extension:session-1:42',
+    });
+    const fallback = createFallback();
+    const adapter = new PiExtensionUiInteractionAdapter(fallback, {
+      interactionPort,
+      sessionInstanceId: 'session-1',
+      getTurnId: () => 'turn-1',
+    });
+
+    await expect(adapter.select({
+      id: '42',
+      options: [
+        { label: 'Modify files', value: 'modify' },
+        { label: 'Type something.', value: 'Type something.' },
+      ],
+      type: 'extension_ui_request',
+    }, new AbortController().signal)).resolves.toEqual({ value: 'Type something.' });
+
+    expect(interactionPort.askUserQuestion).toHaveBeenCalledWith(expect.objectContaining({
+      input: {
+        questions: [expect.objectContaining({
+          isOther: true,
+          options: [{ description: '', label: 'Modify files', value: 'modify' }],
+        })],
+      },
+    }), expect.any(AbortSignal));
+
+    await expect(adapter.input({
+      id: '43',
+      type: 'extension_ui_request',
+    }, new AbortController().signal)).resolves.toEqual({ value: 'Write release notes' });
+    expect(fallback.input).not.toHaveBeenCalled();
+  });
+
   it('keeps unsupported and out-of-turn requests on the native renderer', async () => {
     const interactionPort = createInteractionPort();
     const fallback = createFallback();

--- a/tests/unit/providers/pi/runtime/PiExtensionUiInteractionAdapter.test.ts
+++ b/tests/unit/providers/pi/runtime/PiExtensionUiInteractionAdapter.test.ts
@@ -1,0 +1,120 @@
+import type { ProviderInteractionPort } from '@/core/execution';
+import {
+  PiExtensionUiInteractionAdapter,
+  type PiExtensionUiRenderer,
+} from '@/providers/pi/runtime/PiExtensionUiInteractionAdapter';
+
+function createInteractionPort(): jest.Mocked<ProviderInteractionPort> {
+  return {
+    askUserQuestion: jest.fn(),
+    dismissInteraction: jest.fn(),
+    requestApproval: jest.fn(),
+    requestPlanDecision: jest.fn(),
+  };
+}
+
+function createFallback(): jest.Mocked<PiExtensionUiRenderer> {
+  return {
+    confirm: jest.fn(),
+    editor: jest.fn(),
+    input: jest.fn(),
+    notify: jest.fn(),
+    select: jest.fn(),
+    setEditorText: jest.fn(),
+    setStatus: jest.fn(),
+    setTitle: jest.fn(),
+    setWidget: jest.fn(),
+  };
+}
+
+describe('PiExtensionUiInteractionAdapter', () => {
+  it('adapts a Pi select request to the shared question presentation', async () => {
+    const interactionPort = createInteractionPort();
+    interactionPort.askUserQuestion.mockResolvedValue({
+      answers: { 'pi-extension-ui-42': 'choice-b' },
+      interactionId: 'pi-extension:session-1:42',
+    });
+    const adapter = new PiExtensionUiInteractionAdapter(createFallback(), {
+      interactionPort,
+      sessionInstanceId: 'session-1',
+      getTurnId: () => 'turn-1',
+    });
+
+    await expect(adapter.select({
+      id: '42',
+      message: 'Choose a deployment target.',
+      options: [
+        { label: 'Preview', value: 'preview' },
+        { label: 'Production', value: 'choice-b' },
+      ],
+      title: 'Deploy',
+      type: 'extension_ui_request',
+    }, new AbortController().signal)).resolves.toEqual({ value: 'choice-b' });
+
+    expect(interactionPort.askUserQuestion).toHaveBeenCalledWith({
+      interactionId: 'pi-extension:session-1:42',
+      input: {
+        questions: [{
+          header: 'Deploy',
+          id: 'pi-extension-ui-42',
+          isOther: false,
+          multiSelect: false,
+          options: [
+            { description: '', label: 'Preview', value: 'preview' },
+            { description: '', label: 'Production', value: 'choice-b' },
+          ],
+          question: 'Choose a deployment target.',
+        }],
+      },
+      kind: 'question',
+      nativeContext: { extensionRequestId: '42' },
+      sessionInstanceId: 'session-1',
+      turnId: 'turn-1',
+    }, expect.any(AbortSignal));
+  });
+
+  it('preserves cancellation when the shared question is dismissed', async () => {
+    const interactionPort = createInteractionPort();
+    interactionPort.askUserQuestion.mockResolvedValue({
+      answers: null,
+      interactionId: 'pi-extension:session-1:42',
+    });
+    const adapter = new PiExtensionUiInteractionAdapter(createFallback(), {
+      interactionPort,
+      sessionInstanceId: 'session-1',
+      getTurnId: () => 'turn-1',
+    });
+
+    await expect(adapter.select({
+      id: '42',
+      options: ['Preview'],
+      type: 'extension_ui_request',
+    }, new AbortController().signal)).resolves.toEqual({ cancelled: true });
+  });
+
+  it('keeps unsupported and out-of-turn requests on the native renderer', async () => {
+    const interactionPort = createInteractionPort();
+    const fallback = createFallback();
+    fallback.select.mockResolvedValue({ value: 'native-choice' });
+    fallback.confirm.mockResolvedValue({ confirmed: true });
+    const adapter = new PiExtensionUiInteractionAdapter(fallback, {
+      interactionPort,
+      sessionInstanceId: 'session-1',
+      getTurnId: () => null,
+    });
+
+    await expect(adapter.select({
+      id: '42',
+      options: ['Preview'],
+      type: 'extension_ui_request',
+    }, new AbortController().signal)).resolves.toEqual({ cancelled: true });
+    await expect(adapter.confirm({
+      id: '43',
+      type: 'extension_ui_request',
+    }, new AbortController().signal)).resolves.toEqual({ confirmed: true });
+
+    expect(interactionPort.askUserQuestion).not.toHaveBeenCalled();
+    expect(fallback.select).not.toHaveBeenCalled();
+    expect(fallback.confirm).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- route Pi extension select prompts through the shared inline chat question UI
- keep Type something. answers inline and supply them to the following Pi input request
- preserve native Pi dialogs for other extension UI requests

## Verification
- pnpm run typecheck
- pnpm run lint
- pnpm run test
- pnpm run build