### PR TITLE
fix: preserve Pi session pointer on relaunch

### DIFF
--- a/src/providers/pi/execution/PiExecutionSession.ts
+++ b/src/providers/pi/execution/PiExecutionSession.ts
@@ -157,6 +157,7 @@ implements ProviderExecutionSession, SteerableExecutionSession {
   private kernel: PiExecutionKernel | null = null;
   private kernelGeneration = 0;
   private processKey: string | null = null;
+  private readonly protectedResumeSessionTarget: string | null;
   private readonly kernelSessionTargets = new Set<string>();
   private lifecycleError: Error | null = null;
   private normalizationState: PiEventNormalizationState =
@@ -202,6 +203,9 @@ implements ProviderExecutionSession, SteerableExecutionSession {
         ? { sessionId: providerSessionId }
         : {}),
     };
+    this.protectedResumeSessionTarget = !nativePersistenceDisabled && !state.forkSource
+      ? state.sessionFile ?? providerSessionId
+      : null;
     this.resumeSeedNeedsValidation = !nativePersistenceDisabled
       && !state.forkSource
       && Boolean(state.sessionFile || providerSessionId);
@@ -909,7 +913,9 @@ implements ProviderExecutionSession, SteerableExecutionSession {
     });
   }
 
-  private async refreshState(signal: AbortSignal): Promise<void> {
+  private async refreshState(
+    signal: AbortSignal,
+  ): Promise<void> {
     if (!this.kernel) throw new Error('Pi execution kernel is unavailable.');
     const response = await this.kernel.request<unknown>(
       'get_state',
@@ -925,15 +931,22 @@ implements ProviderExecutionSession, SteerableExecutionSession {
       return;
     }
     const state = extractStateRecord(response);
-    const sessionId = getString(state.sessionId)
+    const reportedSessionId = getString(state.sessionId)
       ?? getString(state.session_id)
-      ?? getString(getRecord(state.session).id)
-      ?? getPiState(this.providerState).sessionId;
-    const sessionFile = getString(state.sessionFile)
+      ?? getString(getRecord(state.session).id);
+    const reportedSessionFile = getString(state.sessionFile)
       ?? getString(state.session_file)
       ?? getString(state.sessionPath)
       ?? getString(state.session_path)
-      ?? getString(state.path)
+      ?? getString(state.path);
+    assertPiSessionTargetIntegrity(
+      this.protectedResumeSessionTarget,
+      reportedSessionId,
+      reportedSessionFile,
+    );
+    const sessionId = reportedSessionId
+      ?? getPiState(this.providerState).sessionId;
+    const sessionFile = reportedSessionFile
       ?? getPiState(this.providerState).sessionFile;
     const leafEntryId = getString(state.leafEntryId)
       ?? getString(state.leaf_entry_id)
@@ -1389,6 +1402,15 @@ class PiProviderSessionMissingError extends Error {
   }
 }
 
+class PiSessionTargetMismatchError extends Error {
+  constructor(expectedSessionTarget: string, reportedSessionTarget: string) {
+    super(
+      `Pi resumed a different native session. Expected '${expectedSessionTarget}', received '${reportedSessionTarget}'. The original conversation pointer was preserved.`,
+    );
+    this.name = 'PiSessionTargetMismatchError';
+  }
+}
+
 class PiForkRollbackError extends Error {
   constructor(readonly cleanupError: Error) {
     super(cleanupError.message);
@@ -1585,6 +1607,32 @@ function getFirstRejectedError(
 
 function isSamePath(left: string, right: string): boolean {
   return path.resolve(left) === path.resolve(right);
+}
+
+function assertPiSessionTargetIntegrity(
+  expectedSessionTarget: string | null,
+  reportedSessionId: string | null,
+  reportedSessionFile: string | null,
+): void {
+  if (!expectedSessionTarget) return;
+  if (isPiSessionPathReference(expectedSessionTarget)) {
+    if (
+      reportedSessionFile
+      && !isSamePath(expectedSessionTarget, reportedSessionFile)
+    ) {
+      throw new PiSessionTargetMismatchError(
+        expectedSessionTarget,
+        reportedSessionFile,
+      );
+    }
+    return;
+  }
+  if (reportedSessionId && reportedSessionId !== expectedSessionTarget) {
+    throw new PiSessionTargetMismatchError(
+      expectedSessionTarget,
+      reportedSessionId,
+    );
+  }
 }
 
 function toError(error: unknown): Error {

--- a/tests/unit/providers/pi/execution/PiExecutionBackend.test.ts
+++ b/tests/unit/providers/pi/execution/PiExecutionBackend.test.ts
@@ -626,6 +626,52 @@ describe('PiExecutionBackend', () => {
     await fs.rm(sessionDir, { force: true, recursive: true });
   });
 
+  it('preserves the resumed session pointer when Pi reports a different session file', async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-session-pointer-'));
+    const originalSessionFile = path.join(sessionDir, 'original.jsonl');
+    const replacementSessionFile = path.join(sessionDir, 'replacement.jsonl');
+    await fs.writeFile(originalSessionFile, '{"type":"session","id":"original"}\n');
+    await fs.writeFile(replacementSessionFile, '{"type":"session","id":"replacement"}\n');
+    const harness = createHarness(createConfig({
+      resumeSeed: {
+        providerSessionId: 'original',
+        providerState: {
+          sessionFile: originalSessionFile,
+          sessionId: 'original',
+        },
+      },
+      vaultWorkingDirectory: sessionDir,
+    }));
+    harness.host.settings.providerConfigs.pi.environmentVariables =
+      `PI_CODING_AGENT_SESSION_DIR=${sessionDir}`;
+    harness.responses.set('get_state', {
+      sessionFile: replacementSessionFile,
+      sessionId: 'replacement',
+    });
+
+    const run = harness.session.execute(createRequest());
+    const eventsPromise = collect(run.events);
+    await flush();
+    completeTurn(harness.kernels[0]);
+    const events = await eventsPromise;
+
+    expect(harness.kernels[0].launchSpec.args).toContain(originalSessionFile);
+    expect(events.at(-1)).toMatchObject({
+      category: 'provider',
+      recoverable: true,
+      type: 'execution_error',
+    });
+    expect(harness.session.getSnapshot()).toMatchObject({
+      providerSessionId: 'original',
+      providerState: {
+        sessionFile: originalSessionFile,
+        sessionId: 'original',
+      },
+      status: 'invalidated',
+    });
+    await fs.rm(sessionDir, { force: true, recursive: true });
+  });
+
   it('retains a missing persisted session path until recovery resolves it', async () => {
     const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-missing-path-'));
     const missingSessionFile = path.join(sessionDir, 'missing.jsonl');


### PR DESCRIPTION
## Summary
- reject a Pi runtime state report that points a resumed conversation at a different native session
- preserve the persisted sessionId and sessionFile instead of silently rebinding metadata
- keep intentional fork-created sessions eligible to establish their own native target

## Verification
- pnpm run typecheck
- pnpm run lint
- pnpm run test
- pnpm run build