### PR TITLE
fix: honor Pi native automatic retries

### DIFF
--- a/src/providers/pi/execution/PiExecutionSession.ts
+++ b/src/providers/pi/execution/PiExecutionSession.ts
@@ -125,6 +125,7 @@ interface ActiveRun {
   nativeRequestDispatched: boolean;
   nativeAssistantId?: string;
   nativeUserMessageId?: string;
+  pendingTerminalError: Error | null;
   sequence: number;
   terminal: boolean;
   terminalSignal: Deferred<void>;
@@ -374,6 +375,7 @@ implements ProviderExecutionSession, SteerableExecutionSession {
       accepted: false,
       assistantStarted: false,
       nativeRequestDispatched: false,
+      pendingTerminalError: null,
       sequence: 0,
       terminal: false,
       terminalSignal: createDeferred<void>(),
@@ -714,6 +716,13 @@ implements ProviderExecutionSession, SteerableExecutionSession {
     if (event.type === 'agent_end') {
       this.ensureAccepted(active);
       if (event.willRetry === true) {
+        active.pendingTerminalError = null;
+        return;
+      }
+      const pendingTerminalError = active.pendingTerminalError;
+      active.pendingTerminalError = null;
+      if (pendingTerminalError) {
+        active.terminalSignal.reject(pendingTerminalError);
         return;
       }
       active.terminalSignal.resolve();
@@ -721,6 +730,12 @@ implements ProviderExecutionSession, SteerableExecutionSession {
     }
     if (event.type === 'agent_settled') {
       this.ensureAccepted(active);
+      const pendingTerminalError = active.pendingTerminalError;
+      active.pendingTerminalError = null;
+      if (pendingTerminalError) {
+        active.terminalSignal.reject(pendingTerminalError);
+        return;
+      }
       active.terminalSignal.resolve();
       return;
     }
@@ -731,14 +746,17 @@ implements ProviderExecutionSession, SteerableExecutionSession {
       return;
     }
 
+    const terminalError = getPiTerminalErrorMessage(event);
+    if (terminalError) {
+      this.ensureAccepted(active);
+      active.pendingTerminalError = new Error(terminalError);
+      return;
+    }
+
     const chunks = normalizePiRpcEvent(event, this.normalizationState);
     if (chunks.length > 0) this.ensureAccepted(active);
     for (const chunk of chunks) {
       this.handleStreamChunk(kernel, generation, chunk);
-    }
-    const terminalError = getPiTerminalErrorMessage(event);
-    if (terminalError) {
-      active.terminalSignal.reject(new Error(terminalError));
     }
   }
 

--- a/src/providers/pi/normalizations/piEventNormalization.ts
+++ b/src/providers/pi/normalizations/piEventNormalization.ts
@@ -58,6 +58,7 @@ export function getPiTerminalErrorMessage(event: Record<string, unknown>): strin
 
   const terminalEvent = getNestedRecord(event, 'assistantMessageEvent')
     ?? getNestedRecord(event, 'assistant_message_event')
+    ?? getNestedRecord(event, 'message')
     ?? event;
   const records = terminalEvent === event ? [event] : [terminalEvent, event];
   const stopReason = getStringField(records, ['stopReason', 'stop_reason']);

--- a/tests/unit/providers/pi/execution/PiExecutionBackend.test.ts
+++ b/tests/unit/providers/pi/execution/PiExecutionBackend.test.ts
@@ -585,6 +585,161 @@ describe('PiExecutionBackend', () => {
     expect(events.at(-1)).toMatchObject({ type: 'turn_completed' });
   });
 
+  it('keeps one execution open across native Pi retries and commits the recovered answer', async () => {
+    const harness = createHarness();
+    const run = harness.session.execute(createRequest());
+    const eventsPromise = collect(run.events);
+    await waitFor(() => harness.kernels.length === 1);
+    let settled = false;
+    void eventsPromise.then(() => {
+      settled = true;
+    });
+
+    const kernel = harness.kernels[0];
+    kernel.emit({ type: 'agent_start' });
+    kernel.emit({
+      errorMessage: 'OpenRouter rate limit (attempt 1)',
+      role: 'assistant',
+      stopReason: 'error',
+      type: 'message_end',
+    });
+    kernel.emit({ messages: [], type: 'agent_end', willRetry: true });
+    kernel.emit({ attempt: 1, type: 'auto_retry_start' });
+    await flush();
+    await flush();
+    expect(settled).toBe(false);
+
+    kernel.emit({ type: 'agent_start' });
+    kernel.emit({
+      message: {
+        content: [],
+        errorMessage: 'OpenRouter rate limit (attempt 2)',
+        role: 'assistant',
+        stopReason: 'error',
+      },
+      type: 'message_end',
+    });
+    kernel.emit({ messages: [], type: 'agent_end', willRetry: true });
+    kernel.emit({ attempt: 2, type: 'auto_retry_start' });
+    await flush();
+    await flush();
+    expect(settled).toBe(false);
+
+    harness.responses.set('get_state', {
+      leafEntryId: 'assistant-recovered',
+      parentSession: 'parent-session',
+      sessionFile: '/tmp/pi-session.jsonl',
+      sessionId: 'pi-session-1',
+    });
+    kernel.emit({ type: 'agent_start' });
+    kernel.emit({
+      assistantMessageEvent: { text_delta: 'Recovered answer' },
+      type: 'message_update',
+    });
+    kernel.emit({
+      message: {
+        content: [{ text: 'Recovered answer', type: 'text' }],
+        role: 'assistant',
+        stopReason: 'stop',
+      },
+      type: 'message_end',
+    });
+    kernel.emit({ attempt: 2, success: true, type: 'auto_retry_end' });
+    kernel.emit({ messages: [], type: 'agent_end', willRetry: false });
+
+    const events = await eventsPromise;
+    expect(events.filter(event => event.type === 'text_delta')).toEqual([
+      expect.objectContaining({ text: 'Recovered answer' }),
+    ]);
+    expect(events.filter(event => event.type === 'notice')).toEqual([
+      expect.objectContaining({ message: 'Pi is retrying the turn.' }),
+      expect.objectContaining({ message: 'Pi is retrying the turn.' }),
+      expect.objectContaining({ message: 'Pi retry finished.' }),
+    ]);
+    expect(events).not.toContainEqual(expect.objectContaining({
+      type: 'execution_error',
+    }));
+    expect(events.at(-1)).toMatchObject({
+      nativeAssistantId: 'assistant-recovered',
+      nativeCheckpointId: 'assistant-recovered',
+      type: 'turn_completed',
+    });
+  });
+
+  it('surfaces a native Pi terminal error after a non-retrying agent end', async () => {
+    const harness = createHarness();
+    const run = harness.session.execute(createRequest());
+    const eventsPromise = collect(run.events);
+    await waitFor(() => harness.kernels.length === 1);
+
+    harness.kernels[0].emit({ type: 'agent_start' });
+    harness.kernels[0].emit({
+      message: {
+        content: [],
+        errorMessage: 'OpenRouter retry budget exhausted',
+        role: 'assistant',
+        stopReason: 'error',
+      },
+      type: 'message_end',
+    });
+    harness.kernels[0].emit({ messages: [], type: 'agent_end', willRetry: false });
+
+    const events = await eventsPromise;
+    expect(events.at(-1)).toMatchObject({
+      message: 'OpenRouter retry budget exhausted',
+      type: 'execution_error',
+    });
+    expect(events).not.toContainEqual(expect.objectContaining({
+      type: 'turn_completed',
+    }));
+  });
+
+  it('can cancel while native Pi is waiting to retry and fences later events', async () => {
+    const harness = createHarness();
+    const run = harness.session.execute(createRequest());
+    const eventsPromise = collect(run.events);
+    await waitFor(() => harness.kernels.length === 1);
+    let settled = false;
+    void eventsPromise.then(() => {
+      settled = true;
+    });
+
+    const kernel = harness.kernels[0];
+    kernel.emit({ type: 'agent_start' });
+    kernel.emit({
+      message: {
+        content: [],
+        errorMessage: 'OpenRouter rate limit',
+        role: 'assistant',
+        stopReason: 'error',
+      },
+      type: 'message_end',
+    });
+    kernel.emit({ messages: [], type: 'agent_end', willRetry: true });
+    kernel.emit({ attempt: 1, type: 'auto_retry_start' });
+    await flush();
+    await flush();
+    expect(settled).toBe(false);
+
+    run.cancel();
+    kernel.emit({
+      assistantMessageEvent: { text_delta: 'late recovered answer' },
+      type: 'message_update',
+    });
+    kernel.emit({ messages: [], type: 'agent_end', willRetry: false });
+
+    const events = await eventsPromise;
+    expect(events.filter(event => (
+      event.type === 'cancelled'
+      || event.type === 'execution_error'
+      || event.type === 'turn_completed'
+    ))).toEqual([expect.objectContaining({ type: 'cancelled' })]);
+    expect(events).not.toContainEqual(expect.objectContaining({
+      text: 'late recovered answer',
+      type: 'text_delta',
+    }));
+  });
+
   it('launches resumed persistent sessions with their native session file', async () => {
     const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-resume-session-'));
     const sessionFile = path.join(sessionDir, 'pi-session-1.jsonl');


### PR DESCRIPTION
## Summary

When a Pi attempt fails, Pi RPC emits a `message_end` with `stopReason: 'error'` followed by `agent_end` with `willRetry: true` while Pi retries natively. We rejected the run immediately on the failing `message_end`, so turns Pi would have recovered surfaced as execution errors — and when the retry budget was exhausted, the error was swallowed entirely and the turn completed silently.

Terminal message errors are now stashed as pending state instead of rejecting, cleared when Pi reports a retrying agent end, and flushed as a rejection when the run settles without a retry. Terminal errors nested under a `message` record are now detected, so exhausted retries surface as `execution_error`.


## Adaptation notes

- Ported by hand rather than cherry-pick: this fork's `handleRpcEvent` has an extra `agent_settled` terminal path, which now flushes a stashed error the same way `agent_end` does.
- Verified the recovered attempt still refreshes the session pointer via `get_state` so the pointer-preservation work in #105 is not regressed.
- Retry/cancel notices already existed locally; upstream's normalization change reduces to the nested `message` lookup here.

## Testing

- New tests: retry recovery across attempts (flat and nested error shapes), exhausted-retry error surfacing, cancel-during-retry fencing. The first two fail on the pre-fix code.
- Full suite: 407 suites / 7,030 tests green; typecheck, lint, and production build clean.