### PR TITLE
fix: re-evaluate linked current note on metadata changes

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -1298,6 +1298,12 @@ export class ClaudianView extends ItemView {
     this.tabManager?.getActiveTab()?.ui.fileContextManager?.handleFileOpen(file);
   }
 
+  private handleLinkedNoteMetadataChanged(file: TFile | null): void {
+    if (this.linkedNoteNavigationDepth > 0) return;
+    this.tabManager?.getActiveTab()?.ui.fileContextManager
+      ?.handleActiveFileMetadataChanged(file);
+  }
+
   private activateSessionSearch(): void {
     if (this.isSessionSearchActive) {
       this.focusSessionSearchInput();
@@ -2153,6 +2159,23 @@ export class ClaudianView extends ItemView {
         if (file) {
           this.handleWorkspaceFileOpen(file);
         }
+      })
+    );
+
+    // Metadata changes re-evaluate the auto-linked current note (excluded tags)
+    this.registerEvent(
+      this.plugin.app.metadataCache.on('changed', (file) => {
+        this.handleLinkedNoteMetadataChanged(file);
+      })
+    );
+    this.registerEvent(
+      this.plugin.app.metadataCache.on('resolve', (file) => {
+        this.handleLinkedNoteMetadataChanged(file);
+      })
+    );
+    this.registerEvent(
+      this.plugin.app.metadataCache.on('resolved', () => {
+        this.handleLinkedNoteMetadataChanged(null);
       })
     );
 

--- a/src/features/chat/ui/FileContext.ts
+++ b/src/features/chat/ui/FileContext.ts
@@ -21,6 +21,12 @@ import { ComposerContextTray } from './ComposerContextTray';
 import { FileContextState } from './file-context/state/FileContextState';
 import { FileChipsView } from './file-context/view/FileChipsView';
 
+/**
+ * Metadata-driven exclusion verdict for a note. `unknown` means the cache has
+ * not resolved yet, so exclusion cannot be ruled out (fail closed).
+ */
+type ExcludedTagState = 'excluded' | 'not-excluded' | 'unknown';
+
 export interface FileContextCallbacks {
   getExcludedTags: () => string[];
   onChipsChanged?: () => void;
@@ -195,7 +201,7 @@ export class FileContextManager {
   /** Auto-attaches the currently focused file (for new sessions). */
   autoAttachActiveFile() {
     const activeFile = this.app.workspace.getActiveFile();
-    if (activeFile && !this.hasExcludedTag(activeFile)) {
+    if (activeFile && this.getExcludedTagState(activeFile) === 'not-excluded') {
       const normalizedPath = this.normalizePathForVault(activeFile.path);
       if (normalizedPath) {
         this.currentNotePath = normalizedPath;
@@ -208,43 +214,17 @@ export class FileContextManager {
 
   /** Handles file open event. */
   handleFileOpen(file: TFile) {
-    const normalizedPath = this.normalizePathForVault(file.path);
-    if (!normalizedPath) return;
+    this.reconcileCurrentNote(file, true);
+  }
 
-    if (!this.state.isSessionStarted()) {
-      this.state.clearAttachments();
-      if (!this.hasExcludedTag(file)) {
-        this.currentNotePath = normalizedPath;
-        this.state.attachFile(normalizedPath);
-      } else {
-        this.currentNotePath = null;
-      }
-      this.callbacks.onCurrentNoteChanged?.(this.currentNotePath);
-      this.refreshCurrentNoteChip();
-      return;
-    }
-
-    if (this.hasExcludedTag(file)) {
-      if (this.currentNotePath) {
-        this.state.detachFile(this.currentNotePath);
-      }
-      this.currentNotePath = null;
-      this.state.markCurrentNoteChanged();
-      this.callbacks.onCurrentNoteChanged?.(null);
-      this.refreshCurrentNoteChip();
-      return;
-    }
-
-    if (this.currentNotePath !== normalizedPath) {
-      if (this.currentNotePath) {
-        this.state.detachFile(this.currentNotePath);
-      }
-      this.currentNotePath = normalizedPath;
-      this.state.attachFile(normalizedPath);
-      this.state.markCurrentNoteChanged();
-      this.callbacks.onCurrentNoteChanged?.(normalizedPath);
-      this.refreshCurrentNoteChip();
-    }
+  /**
+   * Re-evaluates the auto-linked current note after a metadata cache change.
+   * Pass `null` when the changed file is unknown (cache-wide resolution).
+   */
+  handleActiveFileMetadataChanged(file: TFile | null) {
+    const activeFile = this.app.workspace.getActiveFile();
+    if (file !== null && activeFile?.path !== file.path) return;
+    this.reconcileCurrentNote(activeFile, false);
   }
 
   markFileCacheDirty() {
@@ -516,12 +496,56 @@ export class FileContextManager {
     this.mentionDropdown.updateMcpMentionsFromText(text);
   }
 
-  private hasExcludedTag(file: TFile): boolean {
+  private reconcileCurrentNote(file: TFile | null, isFileOpen: boolean): void {
+    const normalizedPath = file ? this.normalizePathForVault(file.path) : null;
+    if (isFileOpen && !normalizedPath) return;
+
+    const linkablePath = file && normalizedPath && this.getExcludedTagState(file) === 'not-excluded'
+      ? normalizedPath
+      : null;
+
+    if (!this.state.isSessionStarted()) {
+      if (isFileOpen) this.state.clearAttachments();
+      if (!isFileOpen && linkablePath === this.currentNotePath) return;
+      this.currentNotePath = linkablePath;
+      if (linkablePath) {
+        this.state.attachFile(linkablePath);
+      }
+      this.callbacks.onCurrentNoteChanged?.(this.currentNotePath);
+      this.refreshCurrentNoteChip();
+      return;
+    }
+
+    if (!linkablePath) {
+      if (!isFileOpen && !this.currentNotePath) return;
+      if (this.currentNotePath) {
+        this.state.detachFile(this.currentNotePath);
+      }
+      this.currentNotePath = null;
+      this.state.markCurrentNoteChanged();
+      this.callbacks.onCurrentNoteChanged?.(null);
+      this.refreshCurrentNoteChip();
+      return;
+    }
+
+    if (this.currentNotePath !== linkablePath) {
+      if (this.currentNotePath) {
+        this.state.detachFile(this.currentNotePath);
+      }
+      this.currentNotePath = linkablePath;
+      this.state.attachFile(linkablePath);
+      this.state.markCurrentNoteChanged();
+      this.callbacks.onCurrentNoteChanged?.(linkablePath);
+      this.refreshCurrentNoteChip();
+    }
+  }
+
+  private getExcludedTagState(file: TFile): ExcludedTagState {
     const excludedTags = this.callbacks.getExcludedTags();
-    if (excludedTags.length === 0) return false;
+    if (excludedTags.length === 0) return 'not-excluded';
 
     const cache = this.app.metadataCache.getFileCache(file);
-    if (!cache) return false;
+    if (!cache) return 'unknown';
 
     const fileTags: string[] = [];
 
@@ -538,6 +562,7 @@ export class FileContextManager {
       fileTags.push(...cache.tags.map(t => t.tag.replace(/^#/, '')));
     }
 
-    return fileTags.some(tag => excludedTags.includes(tag));
+    const normalizedExcluded = new Set(excludedTags.map(tag => tag.replace(/^#/, '')));
+    return fileTags.some(tag => normalizedExcluded.has(tag)) ? 'excluded' : 'not-excluded';
   }
 }

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -2579,6 +2579,13 @@ describe('ClaudianView Escape handling', () => {
             return ref;
           }),
         },
+        metadataCache: {
+          on: jest.fn((_event: string, handler: unknown) => {
+            const ref = { handler };
+            eventRefs.push(ref);
+            return ref;
+          }),
+        },
       },
     };
     view.tabManager = {
@@ -2594,6 +2601,7 @@ describe('ClaudianView Escape handling', () => {
             markFolderCacheDirty: jest.fn(),
             handleFileOpen: jest.fn(),
             handleClickOutside: jest.fn(),
+            handleActiveFileMetadataChanged: jest.fn(),
           },
         },
       }),
@@ -2641,6 +2649,13 @@ describe('ClaudianView Escape handling', () => {
             return ref;
           }),
         },
+        metadataCache: {
+          on: jest.fn((_event: string, handler: unknown) => {
+            const ref = { handler };
+            eventRefs.push(ref);
+            return ref;
+          }),
+        },
       },
     };
     view.tabManager = {
@@ -2656,6 +2671,7 @@ describe('ClaudianView Escape handling', () => {
             markFolderCacheDirty: jest.fn(),
             handleFileOpen: jest.fn(),
             handleClickOutside: jest.fn(),
+            handleActiveFileMetadataChanged: jest.fn(),
           },
         },
       }),
@@ -2663,6 +2679,32 @@ describe('ClaudianView Escape handling', () => {
 
     return { inputEl, sendMessage, view };
   }
+
+  it('routes metadata cache refreshes to the active tab file context', () => {
+    const { view } = createEscapeHarness({ isStreaming: false });
+    view.wireEventHandlers();
+
+    const cacheOn = view.plugin.app.metadataCache.on as jest.Mock;
+    const changedHandler = cacheOn.mock.calls
+      .find(([event]: unknown[]) => event === 'changed')?.[1] as (file: unknown) => void;
+    const resolveHandler = cacheOn.mock.calls
+      .find(([event]: unknown[]) => event === 'resolve')?.[1] as (file: unknown) => void;
+    const resolvedHandler = cacheOn.mock.calls
+      .find(([event]: unknown[]) => event === 'resolved')?.[1] as () => void;
+    expect(changedHandler).toBeDefined();
+    expect(resolveHandler).toBeDefined();
+    expect(resolvedHandler).toBeDefined();
+
+    const file = { path: 'Notes/Current.md' };
+    changedHandler(file);
+    resolveHandler(file);
+    resolvedHandler();
+
+    const { handleActiveFileMetadataChanged } = view.tabManager.getActiveTab().ui.fileContextManager;
+    expect(handleActiveFileMetadataChanged).toHaveBeenNthCalledWith(1, file);
+    expect(handleActiveFileMetadataChanged).toHaveBeenNthCalledWith(2, file);
+    expect(handleActiveFileMetadataChanged).toHaveBeenNthCalledWith(3, null);
+  });
 
   it('registers Escape on the Obsidian view scope instead of document keydown capture', () => {
     const { view } = createEscapeHarness({ isStreaming: true });

--- a/tests/unit/features/chat/ui/FileContextManager.test.ts
+++ b/tests/unit/features/chat/ui/FileContextManager.test.ts
@@ -223,6 +223,7 @@ describe('FileContextManager', () => {
   it('auto-attaches active file unless excluded by tag', () => {
     const fileCacheByPath = new Map<string, any>([
       ['notes/private.md', { frontmatter: { tags: ['private'] } }],
+      ['notes/public.md', { tags: [] }],
     ]);
     const app = createMockApp({
       files: ['notes/private.md', 'notes/public.md'],
@@ -751,6 +752,147 @@ describe('FileContextManager', () => {
 
       manager.autoAttachActiveFile();
       expect(manager.getCurrentNotePath()).toBeNull();
+      manager.destroy();
+    });
+  });
+
+  describe('metadata-driven current note refresh', () => {
+    it('delays auto-attach until the active note metadata resolves', () => {
+      const fileCacheByPath = new Map<string, any>();
+      const app = createMockApp({
+        files: ['notes/startup.md'],
+        activeFilePath: 'notes/startup.md',
+        fileCacheByPath,
+      });
+      const manager = new FileContextManager(
+        app, containerEl as any, inputEl,
+        createMockCallbacks({ excludedTags: ['private'] })
+      );
+
+      manager.autoAttachActiveFile();
+      expect(manager.getCurrentNotePath()).toBeNull();
+
+      fileCacheByPath.set('notes/startup.md', { tags: [] });
+      manager.handleActiveFileMetadataChanged(createMockTFile('notes/startup.md'));
+      expect(manager.getCurrentNotePath()).toBe('notes/startup.md');
+
+      manager.destroy();
+    });
+
+    it('does not link the active note on open while its metadata is unresolved', () => {
+      const fileCacheByPath = new Map<string, any>();
+      const app = createMockApp({
+        files: ['notes/startup.md'],
+        activeFilePath: 'notes/startup.md',
+        fileCacheByPath,
+      });
+      const manager = new FileContextManager(
+        app, containerEl as any, inputEl,
+        createMockCallbacks({ excludedTags: ['private'] })
+      );
+
+      manager.handleFileOpen(createMockTFile('notes/startup.md'));
+      expect(manager.getCurrentNotePath()).toBeNull();
+
+      fileCacheByPath.set('notes/startup.md', { tags: [] });
+      manager.handleActiveFileMetadataChanged(createMockTFile('notes/startup.md'));
+      expect(manager.getCurrentNotePath()).toBe('notes/startup.md');
+
+      manager.destroy();
+    });
+
+    it('unloads the auto-linked current note when its metadata gains an excluded tag', () => {
+      const fileCacheByPath = new Map<string, any>([
+        ['notes/public.md', { tags: [] }],
+      ]);
+      const app = createMockApp({
+        files: ['notes/public.md'],
+        activeFilePath: 'notes/public.md',
+        fileCacheByPath,
+      });
+      const manager = new FileContextManager(
+        app, containerEl as any, inputEl,
+        createMockCallbacks({ excludedTags: ['private'] })
+      );
+
+      manager.autoAttachActiveFile();
+      expect(manager.getCurrentNotePath()).toBe('notes/public.md');
+
+      fileCacheByPath.set('notes/public.md', { tags: [{ tag: '#private' }] });
+      manager.handleActiveFileMetadataChanged(createMockTFile('notes/public.md'));
+      expect(manager.getCurrentNotePath()).toBeNull();
+
+      manager.destroy();
+    });
+
+    it('unloads the linked current note mid-session when its metadata gains an excluded tag', () => {
+      const fileCacheByPath = new Map<string, any>([
+        ['notes/public.md', { tags: [] }],
+      ]);
+      const app = createMockApp({
+        files: ['notes/public.md'],
+        activeFilePath: 'notes/public.md',
+        fileCacheByPath,
+      });
+      const manager = new FileContextManager(
+        app, containerEl as any, inputEl,
+        createMockCallbacks({ excludedTags: ['private'] })
+      );
+
+      manager.autoAttachActiveFile();
+      manager.startSession();
+      manager.markCurrentNoteSent();
+      expect(manager.getAttachedFiles().has('notes/public.md')).toBe(true);
+
+      fileCacheByPath.set('notes/public.md', { tags: [{ tag: '#private' }] });
+      manager.handleActiveFileMetadataChanged(createMockTFile('notes/public.md'));
+      expect(manager.getCurrentNotePath()).toBeNull();
+      expect(manager.getAttachedFiles().has('notes/public.md')).toBe(false);
+
+      manager.destroy();
+    });
+
+    it('ignores metadata changes for files that are not the active note', () => {
+      const fileCacheByPath = new Map<string, any>([
+        ['notes/public.md', { tags: [] }],
+        ['notes/other.md', { tags: [{ tag: '#private' }] }],
+      ]);
+      const app = createMockApp({
+        files: ['notes/public.md', 'notes/other.md'],
+        activeFilePath: 'notes/public.md',
+        fileCacheByPath,
+      });
+      const manager = new FileContextManager(
+        app, containerEl as any, inputEl,
+        createMockCallbacks({ excludedTags: ['private'] })
+      );
+
+      manager.autoAttachActiveFile();
+      expect(manager.getCurrentNotePath()).toBe('notes/public.md');
+
+      manager.handleActiveFileMetadataChanged(createMockTFile('notes/other.md'));
+      expect(manager.getCurrentNotePath()).toBe('notes/public.md');
+
+      manager.destroy();
+    });
+
+    it('matches excluded tag settings values with a # prefix', () => {
+      const fileCacheByPath = new Map<string, any>([
+        ['notes/tagged.md', { frontmatter: { tags: ['private'] } }],
+      ]);
+      const app = createMockApp({
+        files: ['notes/tagged.md'],
+        activeFilePath: 'notes/tagged.md',
+        fileCacheByPath,
+      });
+      const manager = new FileContextManager(
+        app, containerEl as any, inputEl,
+        createMockCallbacks({ excludedTags: ['#private'] })
+      );
+
+      manager.autoAttachActiveFile();
+      expect(manager.getCurrentNotePath()).toBeNull();
+
       manager.destroy();
     });
   });


### PR DESCRIPTION
## Summary

With excluded tags configured (e.g. `#private`), a note was auto-linked into the prompt **before** its metadata cache resolved, because an unresolved cache was treated as "no excluded tags" — a privacy leak. And once linked, adding an excluded tag to the active note never re-evaluated the link, so its content kept being sent.

An unresolved metadata cache is now an explicit `unknown` state (fail closed: not auto-linked), and the linked current note is re-evaluated when the cache `changed`, `resolve`, or `resolved` events fire, so notes that gain an excluded tag are unloaded. Excluded tag settings values are normalized to strip `#` prefixes, which previously never matched.


## Adaptation notes

- Upstream's `LinkedContentController` does not exist here; the reconcile logic lands in `FileContextManager`, shared by file-open and metadata events. Metadata reconciliation skips redundant publishes to avoid chip re-render churn on cache-wide `resolved` events.
- View wiring mirrors the existing `file-open` routing (active tab, same linked-note navigation guard).
- Deliberate improvement over upstream: `#`-prefixed settings values now match cache tags.

## Testing

- Six new `FileContextManager` tests (delayed auto-attach, open-time fail-closed, unload on excluded tag pre- and mid-session, non-active-file filtering, `#` normalization); one view routing test.
- One pre-existing test needed its fixture updated: it attached a file with no cache entry, which the new fail-closed semantics intentionally reject.
- Full suite: 407 suites / 7,034 tests green; typecheck, lint, and production build clean.