### PR TITLE
fix: expose resume dropdown selection to assistive tech

### DIFF
--- a/src/shared/components/ResumeSessionDropdown.ts
+++ b/src/shared/components/ResumeSessionDropdown.ts
@@ -14,6 +14,15 @@ export interface ResumeSessionDropdownCallbacks {
   onDismiss: () => void;
 }
 
+const INPUT_ACCESSIBILITY_ATTRIBUTES = [
+  'aria-haspopup',
+  'aria-controls',
+  'aria-expanded',
+  'aria-activedescendant',
+] as const;
+
+let nextListboxId = 0;
+
 export class ResumeSessionDropdown {
   private containerEl: HTMLElement;
   private inputEl: HTMLTextAreaElement;
@@ -23,6 +32,8 @@ export class ResumeSessionDropdown {
   private currentConversationId: string | null;
   private selectedIndex = 0;
   private onInput: () => void;
+  private listboxId: string;
+  private previousInputAttributes: Map<string, string | null>;
 
   constructor(
     containerEl: HTMLElement,
@@ -36,8 +47,16 @@ export class ResumeSessionDropdown {
     this.conversations = this.sortConversations(conversations);
     this.currentConversationId = currentConversationId;
     this.callbacks = callbacks;
+    this.listboxId = `claudian-resume-listbox-${++nextListboxId}`;
+    this.previousInputAttributes = new Map(
+      INPUT_ACCESSIBILITY_ATTRIBUTES.map(attribute => [
+        attribute,
+        this.inputEl.getAttribute(attribute),
+      ])
+    );
 
     this.dropdownEl = this.containerEl.createDiv({ cls: 'claudian-resume-dropdown' });
+    this.configureInputAccessibility();
     this.render();
     this.dropdownEl.addClass('visible');
 
@@ -80,11 +99,13 @@ export class ResumeSessionDropdown {
 
   destroy(): void {
     this.inputEl.removeEventListener('input', this.onInput);
+    this.restoreInputAccessibility();
     this.dropdownEl?.remove();
   }
 
   private dismiss(): void {
     this.dropdownEl.removeClass('visible');
+    this.inputEl.removeAttribute('aria-activedescendant');
     this.callbacks.onDismiss();
   }
 
@@ -108,16 +129,28 @@ export class ResumeSessionDropdown {
     this.updateSelection();
   }
 
-  private updateSelection(): void {
+  private updateSelection(scrollSelectedIntoView = true): void {
     const items = this.dropdownEl.querySelectorAll('.claudian-resume-item');
+    let activeOptionId: string | null = null;
     items?.forEach((item, index) => {
       if (index === this.selectedIndex) {
         item.addClass('selected');
-        (item as HTMLElement).scrollIntoView({ block: 'nearest' });
+        item.setAttribute('aria-selected', 'true');
+        activeOptionId = item.getAttribute('id');
+        if (scrollSelectedIntoView) {
+          (item as HTMLElement).scrollIntoView({ block: 'nearest' });
+        }
       } else {
         item.removeClass('selected');
+        item.setAttribute('aria-selected', 'false');
       }
     });
+
+    if (activeOptionId) {
+      this.inputEl.setAttribute('aria-activedescendant', activeOptionId);
+    } else {
+      this.inputEl.removeAttribute('aria-activedescendant');
+    }
   }
 
   private sortConversations(conversations: ConversationMeta[]): ConversationMeta[] {
@@ -132,18 +165,24 @@ export class ResumeSessionDropdown {
     const header = this.dropdownEl.createDiv({ cls: 'claudian-resume-header' });
     header.createSpan({ text: 'Resume conversation' });
 
+    const list = this.dropdownEl.createDiv({ cls: 'claudian-resume-list' });
+    list.setAttribute('id', this.listboxId);
+    list.setAttribute('role', 'listbox');
+    list.setAttribute('aria-label', 'Resume conversation');
+
     if (this.conversations.length === 0) {
-      this.dropdownEl.createDiv({ cls: 'claudian-resume-empty', text: 'No conversations' });
+      list.createDiv({ cls: 'claudian-resume-empty', text: 'No conversations' });
+      this.inputEl.removeAttribute('aria-activedescendant');
       return;
     }
-
-    const list = this.dropdownEl.createDiv({ cls: 'claudian-resume-list' });
 
     for (let i = 0; i < this.conversations.length; i++) {
       const conv = this.conversations[i];
       const isCurrent = conv.id === this.currentConversationId;
 
       const item = list.createDiv({ cls: 'claudian-resume-item' });
+      item.setAttribute('id', `${this.listboxId}-option-${i}`);
+      item.setAttribute('role', 'option');
       if (isCurrent) item.addClass('current');
       if (i === this.selectedIndex) item.addClass('selected');
 
@@ -170,6 +209,26 @@ export class ResumeSessionDropdown {
         this.selectedIndex = i;
         this.updateSelection();
       });
+    }
+
+    this.updateSelection(false);
+  }
+
+  private configureInputAccessibility(): void {
+    // Preserve the textarea's native multiline textbox semantics.
+    this.inputEl.setAttribute('aria-haspopup', 'listbox');
+    this.inputEl.setAttribute('aria-controls', this.listboxId);
+    this.inputEl.removeAttribute('aria-expanded');
+  }
+
+  private restoreInputAccessibility(): void {
+    for (const attribute of INPUT_ACCESSIBILITY_ATTRIBUTES) {
+      const previousValue = this.previousInputAttributes.get(attribute) ?? null;
+      if (previousValue === null) {
+        this.inputEl.removeAttribute(attribute);
+      } else {
+        this.inputEl.setAttribute(attribute, previousValue);
+      }
     }
   }
 

--- a/tests/unit/shared/components/ResumeSessionDropdown.test.ts
+++ b/tests/unit/shared/components/ResumeSessionDropdown.test.ts
@@ -1,3 +1,5 @@
+/** @jest-environment jsdom */
+
 import { createMockEl } from '@test/helpers/MockElement';
 
 import type { ConversationMeta } from '@/core/types';
@@ -6,15 +8,12 @@ import {
   type ResumeSessionDropdownCallbacks,
 } from '@/shared/components/ResumeSessionDropdown';
 
-function createMockInput(): any {
-  return {
-    value: '',
-    selectionStart: 0,
-    selectionEnd: 0,
-    focus: jest.fn(),
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-  };
+function createInput(): HTMLTextAreaElement {
+  const input = document.createElement('textarea');
+  jest.spyOn(input, 'focus');
+  jest.spyOn(input, 'addEventListener');
+  jest.spyOn(input, 'removeEventListener');
+  return input;
 }
 
 function createMockCallbacks(
@@ -70,7 +69,7 @@ function getRenderedItems(containerEl: any): { title: string; isCurrent: boolean
 
 describe('ResumeSessionDropdown', () => {
   let containerEl: any;
-  let inputEl: any;
+  let inputEl: HTMLTextAreaElement;
   let callbacks: ResumeSessionDropdownCallbacks;
 
   const conversations: ConversationMeta[] = [
@@ -81,7 +80,7 @@ describe('ResumeSessionDropdown', () => {
 
   beforeEach(() => {
     containerEl = createMockEl();
-    inputEl = createMockInput();
+    inputEl = createInput();
     callbacks = createMockCallbacks();
   });
 
@@ -152,6 +151,39 @@ describe('ResumeSessionDropdown', () => {
 
       dropdown.destroy();
     });
+
+    it('exposes the popup while preserving native textarea semantics', () => {
+      const dropdown = new ResumeSessionDropdown(
+        containerEl, inputEl, conversations, null, callbacks
+      );
+
+      const listbox = containerEl.querySelector('.claudian-resume-list');
+      const items = listbox?.querySelectorAll('.claudian-resume-item') ?? [];
+      const listboxId = listbox?.getAttribute('id');
+      const activeOptionId = items[0]?.getAttribute('id');
+
+      expect(listbox?.getAttribute('role')).toBe('listbox');
+      expect(listbox?.getAttribute('aria-label')).toBe('Resume conversation');
+      expect(listboxId).toBeTruthy();
+      expect(items.map((item: any) => item.getAttribute('role'))).toEqual([
+        'option',
+        'option',
+        'option',
+      ]);
+      expect(items.map((item: any) => item.getAttribute('aria-selected'))).toEqual([
+        'true',
+        'false',
+        'false',
+      ]);
+      expect(inputEl).toBeInstanceOf(HTMLTextAreaElement);
+      expect(inputEl.getAttribute('role')).toBeNull();
+      expect(inputEl.getAttribute('aria-haspopup')).toBe('listbox');
+      expect(inputEl.getAttribute('aria-expanded')).toBeNull();
+      expect(inputEl.getAttribute('aria-controls')).toBe(listboxId);
+      expect(inputEl.getAttribute('aria-activedescendant')).toBe(activeOptionId);
+
+      dropdown.destroy();
+    });
   });
 
   describe('handleKeydown', () => {
@@ -183,6 +215,24 @@ describe('ResumeSessionDropdown', () => {
 
       expect(result).toBe(true);
       expect(event.preventDefault).toHaveBeenCalled();
+
+      dropdown.destroy();
+    });
+
+    it('keeps the active descendant and option selection in sync while navigating', () => {
+      const dropdown = new ResumeSessionDropdown(
+        containerEl, inputEl, conversations, null, callbacks
+      );
+      const listbox = containerEl.querySelector('.claudian-resume-list');
+      const items = listbox?.querySelectorAll('.claudian-resume-item') ?? [];
+
+      dropdown.handleKeydown({ key: 'ArrowDown', preventDefault: jest.fn() } as any);
+
+      expect(items[0]?.getAttribute('aria-selected')).toBe('false');
+      expect(items[1]?.getAttribute('aria-selected')).toBe('true');
+      expect(inputEl.getAttribute('aria-activedescendant')).toBe(
+        items[1]?.getAttribute('id')
+      );
 
       dropdown.destroy();
     });
@@ -312,6 +362,26 @@ describe('ResumeSessionDropdown', () => {
       dropdown.destroy();
 
       expect(inputEl.removeEventListener).toHaveBeenCalledWith('input', expect.any(Function));
+    });
+
+    it('restores the input accessibility attributes it temporarily owns', () => {
+      inputEl.setAttribute('role', 'textbox');
+      inputEl.setAttribute('aria-controls', 'existing-popup');
+      inputEl.setAttribute('aria-expanded', 'false');
+      const dropdown = new ResumeSessionDropdown(
+        containerEl, inputEl, conversations, null, callbacks
+      );
+
+      expect(inputEl.getAttribute('role')).toBe('textbox');
+      expect(inputEl.getAttribute('aria-expanded')).toBeNull();
+
+      dropdown.destroy();
+
+      expect(inputEl.getAttribute('role')).toBe('textbox');
+      expect(inputEl.getAttribute('aria-controls')).toBe('existing-popup');
+      expect(inputEl.getAttribute('aria-haspopup')).toBeNull();
+      expect(inputEl.getAttribute('aria-expanded')).toBe('false');
+      expect(inputEl.getAttribute('aria-activedescendant')).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

The `/resume` dropdown was invisible to screen readers: its list had no listbox semantics, items no selection state, and the composer textarea no relationship to the popup. Keyboard users got visual-only selection feedback.

The dropdown is now an accessible combobox popup: the list gets `role=listbox` with a stable id and label, items get `role=option` with `aria-selected`, and the textarea keeps its native multiline textbox semantics while pointing at the popup through `aria-haspopup`, `aria-controls`, and a synced `aria-activedescendant`. Attributes the dropdown temporarily owns on the input are restored on destroy.

## Testing

- Ported upstream's rewritten test file (jsdom real `<textarea>`): popup semantics, selection sync while navigating, attribute restoration on destroy.
- Full suite: 407 suites / 7,030 tests green; typecheck, lint, and production build clean.