### PR TITLE
fix: isolate offscreen assistant message layout

### DIFF
--- a/src/style/components/messages.css
+++ b/src/style/components/messages.css
@@ -77,6 +77,9 @@
 }
 
 .claudian-message-assistant {
+  flex-shrink: 0;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 23.5rem;
   background: transparent;
   align-self: stretch;
   width: min(100%, 72ch);

--- a/tests/unit/style/components/messages.test.ts
+++ b/tests/unit/style/components/messages.test.ts
@@ -17,4 +17,20 @@ describe('Message styles', () => {
       /\.oh-my-claudian-root \.claudian-message-user\s*\{[\s\S]*?background:\s*rgba\(var\(--oh-my-claudian-brand-rgb\), 0\.16\);/,
     );
   });
+
+  it('isolates assistant layout without containing user message actions', () => {
+    const css = readFileSync(path.resolve('src/style/components/messages.css'), 'utf8');
+
+    const messageRule = css.match(/\.claudian-message\s*{[^}]*}/)?.[0];
+    expect(messageRule).not.toContain('content-visibility: auto;');
+
+    const userRule = css.match(/\.claudian-message-user\s*{[^}]*}/)?.[0];
+    expect(userRule).not.toContain('content-visibility: auto;');
+    expect(userRule).not.toContain('contain-intrinsic-size:');
+
+    const assistantRule = css.match(/\.claudian-message-assistant\s*{[^}]*}/)?.[0];
+    expect(assistantRule).toContain('flex-shrink: 0;');
+    expect(assistantRule).toContain('content-visibility: auto;');
+    expect(assistantRule).toContain('contain-intrinsic-size: auto 23.5rem;');
+  });
 });


### PR DESCRIPTION
## Summary

In long conversations, assistant messages could get squished inside the constrained message flex column (no `flex-shrink`), and every message paid full layout cost even when offscreen.

`.claudian-message-assistant` now sets `flex-shrink: 0` and skips layout for offscreen messages via `content-visibility: auto` with `contain-intrinsic-size: auto 23.5rem`, which retains last-rendered sizes so scrollbars stay stable.


## Review note

Our `NavigationSidebar` locates messages via `offsetTop`; under `content-visibility: auto`, offscreen offsets are intrinsic-size estimates, so message navigation precision can degrade in very long conversations. Worth a manual pass in a long conversation after merging — if navigation regresses, dropping the two `content-visibility`/`contain-intrinsic-size` lines and keeping `flex-shrink: 0` is the fallback.

## Testing

- Style assertions extended in the local `messages.test.ts` (assistant rule has the three properties; user messages and the shared message rule must not).
- Full suite: 407 suites / 7,028 tests green; typecheck, lint, and production build clean.