### PR TITLE
fix: accept quoted CLI paths in provider settings and resolution

### DIFF
--- a/src/providers/claude/runtime/ClaudeCliResolver.ts
+++ b/src/providers/claude/runtime/ClaudeCliResolver.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
 import type { HostnameCliPaths } from '../../../core/types/settings';
 import { getHostnameKey, parseEnvironmentVariables } from '../../../utils/env';
-import { expandHomePath } from '../../../utils/path';
+import { normalizeConfiguredCliPath } from '../../../utils/path';
 import { findClaudeCLIPath } from '../cli/findClaudeCLIPath';
 import { getClaudeProviderSettings } from '../settings';
 
@@ -68,10 +68,9 @@ export class ClaudeCliResolver {
 }
 
 function resolveConfiguredPath(rawPath: string | undefined): string | null {
-  const trimmed = (rawPath ?? '').trim();
-  if (!trimmed) return null;
   try {
-    const expanded = expandHomePath(trimmed);
+    const expanded = normalizeConfiguredCliPath(rawPath);
+    if (!expanded) return null;
     if (fs.existsSync(expanded) && fs.statSync(expanded).isFile()) {
       return expanded;
     }

--- a/src/providers/claude/ui/ClaudeSettingsTab.ts
+++ b/src/providers/claude/ui/ClaudeSettingsTab.ts
@@ -12,7 +12,7 @@ import { renderProviderEnablementSetting } from '../../../shared/settings/Provid
 import { renderLastEnabledProviderWarning } from '../../../shared/settings/ProviderModelEnablementWarning';
 import { renderProviderReadinessPanel } from '../../../shared/settings/ProviderReadinessPanel';
 import { getHostnameKey } from '../../../utils/env';
-import { expandHomePath } from '../../../utils/path';
+import { normalizeConfiguredCliPath } from '../../../utils/path';
 import { getClaudeWorkspaceServices } from '../app/ClaudeWorkspaceServices';
 import {
   getClaudeModelOptions,
@@ -129,7 +129,7 @@ export const claudeSettingsTabRenderer: ProviderSettingsTabRenderer = {
       const trimmed = value.trim();
       if (!trimmed) return null;
 
-      const expandedPath = expandHomePath(trimmed);
+      const expandedPath = normalizeConfiguredCliPath(trimmed);
 
       if (!fs.existsSync(expandedPath)) {
         return t('settings.cliPath.validation.notExist');

--- a/src/providers/codex/runtime/CodexBinaryLocator.ts
+++ b/src/providers/codex/runtime/CodexBinaryLocator.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 
 import { findCliBinaryPath, resolveConfiguredCliPath } from '../../../utils/cliBinaryLocator';
 import { parseEnvironmentVariables } from '../../../utils/env';
-import { expandHomePath } from '../../../utils/path';
+import { expandHomePath, stripSurroundingQuotes } from '../../../utils/path';
 import type { CodexInstallationMethod } from '../settings';
 import type { CodexExecutionTarget } from './codexLaunchTypes';
 
@@ -138,16 +138,6 @@ function parsePathEntriesForPlatform(pathValue: string | undefined, platform: No
     .map(segment => expandHomePath(segment));
 }
 
-function stripSurroundingQuotes(value: string): string {
-  if (
-    (value.startsWith('"') && value.endsWith('"')) ||
-    (value.startsWith("'") && value.endsWith("'"))
-  ) {
-    return value.slice(1, -1);
-  }
-  return value;
-}
-
 export function resolveCodexCliPath(
   hostnamePath: string | undefined,
   legacyPath: string | undefined,
@@ -165,7 +155,7 @@ export function resolveCodexCliPath(
 
   if (isWslTarget) {
     const configuredCommand = [hostnamePath, legacyPath]
-      .map(value => (value ?? '').trim())
+      .map(value => stripSurroundingQuotes((value ?? '').trim()))
       .find(value => value.length > 0 && !isWindowsStyleCliReference(value));
     return configuredCommand || 'codex';
   }

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../shared/settings/ProviderModelEnablementWarning';
 import { renderProviderReadinessPanel } from '../../../shared/settings/ProviderReadinessPanel';
 import { getHostnameKey } from '../../../utils/env';
-import { expandHomePath } from '../../../utils/path';
+import { normalizeConfiguredCliPath, stripSurroundingQuotes } from '../../../utils/path';
 import { getCodexWorkspaceServices } from '../app/CodexWorkspaceServices';
 import { getCodexModelOptions } from '../modelOptions';
 import { getDefaultCodexModel } from '../models';
@@ -159,13 +159,13 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
       if (!trimmed) return null;
 
       if (!shouldValidateCliPathAsFile()) {
-        if (isWindowsStyleCliReference(trimmed)) {
+        if (isWindowsStyleCliReference(stripSurroundingQuotes(trimmed))) {
           return t('settings.codex.cliPath.validation.wslWindowsPath');
         }
         return null;
       }
 
-      const expandedPath = expandHomePath(trimmed);
+      const expandedPath = normalizeConfiguredCliPath(trimmed);
 
       if (!fs.existsSync(expandedPath)) {
         return t('settings.cliPath.validation.notExist');

--- a/src/providers/cursor/ui/CursorSettingsTab.ts
+++ b/src/providers/cursor/ui/CursorSettingsTab.ts
@@ -17,7 +17,7 @@ import {
 } from '../../../shared/settings/ProviderModelPicker';
 import { renderProviderReadinessPanel } from '../../../shared/settings/ProviderReadinessPanel';
 import { getHostnameKey } from '../../../utils/env';
-import { expandHomePath } from '../../../utils/path';
+import { normalizeConfiguredCliPath } from '../../../utils/path';
 import { maybeGetCursorWorkspaceServices } from '../app/CursorWorkspaceServices';
 import { normalizeCursorVisibleModels } from '../models';
 import {
@@ -151,7 +151,7 @@ function renderCursorModelPicker(
 function validateCliPath(value: string): string | null {
   const trimmed = value.trim();
   if (!trimmed) return null;
-  const expandedPath = expandHomePath(trimmed);
+  const expandedPath = normalizeConfiguredCliPath(trimmed);
   if (!fs.existsSync(expandedPath)) return 'Path does not exist';
   return fs.statSync(expandedPath).isFile() ? null : 'Path must point to a file';
 }

--- a/src/providers/grok/ui/GrokSettingsTab.ts
+++ b/src/providers/grok/ui/GrokSettingsTab.ts
@@ -27,7 +27,7 @@ import {
 } from '../../../shared/settings/ProviderModelPicker';
 import { renderProviderReadinessPanel } from '../../../shared/settings/ProviderReadinessPanel';
 import { getHostnameKey } from '../../../utils/env';
-import { expandHomePath } from '../../../utils/path';
+import { normalizeConfiguredCliPath } from '../../../utils/path';
 import type { GrokWorkspaceServices } from '../app/GrokWorkspaceServices';
 import type { GrokDiscoveredModel } from '../models';
 import {
@@ -292,7 +292,7 @@ function validateCliPath(value: string): string | null {
   if (!trimmed) {
     return null;
   }
-  const expandedPath = expandHomePath(trimmed);
+  const expandedPath = normalizeConfiguredCliPath(trimmed);
   if (!path.posix.isAbsolute(expandedPath) && !path.win32.isAbsolute(expandedPath)) {
     return 'Path must be absolute';
   }

--- a/src/providers/omp/ui/OmpSettingsTab.ts
+++ b/src/providers/omp/ui/OmpSettingsTab.ts
@@ -17,7 +17,7 @@ import {
 } from '../../../shared/settings/ProviderModelPicker';
 import { renderProviderReadinessPanel } from '../../../shared/settings/ProviderReadinessPanel';
 import { getHostnameKey } from '../../../utils/env';
-import { expandHomePath } from '../../../utils/path';
+import { normalizeConfiguredCliPath } from '../../../utils/path';
 import { maybeGetOmpWorkspaceServices } from '../app/OmpWorkspaceServices';
 import { normalizeOmpVisibleModels } from '../models';
 import {
@@ -151,7 +151,7 @@ function renderOmpModelPicker(
 function validateCliPath(value: string): string | null {
   const trimmed = value.trim();
   if (!trimmed) return null;
-  const expandedPath = expandHomePath(trimmed);
+  const expandedPath = normalizeConfiguredCliPath(trimmed);
   if (!fs.existsSync(expandedPath)) return 'Path does not exist';
   return fs.statSync(expandedPath).isFile() ? null : 'Path must point to a file';
 }

--- a/src/providers/opencode/ui/OpencodeSettingsTab.ts
+++ b/src/providers/opencode/ui/OpencodeSettingsTab.ts
@@ -23,7 +23,7 @@ import {
 } from '../../../shared/settings/ProviderModelPicker';
 import { renderProviderReadinessPanel } from '../../../shared/settings/ProviderReadinessPanel';
 import { getHostnameKey } from '../../../utils/env';
-import { expandHomePath } from '../../../utils/path';
+import { normalizeConfiguredCliPath } from '../../../utils/path';
 import { maybeGetOpencodeWorkspaceServices } from '../app/OpencodeWorkspaceServices';
 import { clearOpencodeDiscoveryState } from '../discoveryState';
 import { sameStringList } from '../internal/compareCollections';
@@ -298,7 +298,7 @@ function validateCliPath(value: string): string | null {
     return null;
   }
 
-  const expandedPath = expandHomePath(trimmed);
+  const expandedPath = normalizeConfiguredCliPath(trimmed);
   if (!fs.existsSync(expandedPath)) {
     return 'Path does not exist';
   }

--- a/src/providers/pi/ui/PiSettingsTab.ts
+++ b/src/providers/pi/ui/PiSettingsTab.ts
@@ -23,7 +23,7 @@ import {
 } from '../../../shared/settings/ProviderModelPicker';
 import { renderProviderReadinessPanel } from '../../../shared/settings/ProviderReadinessPanel';
 import { getHostnameKey } from '../../../utils/env';
-import { expandHomePath } from '../../../utils/path';
+import { normalizeConfiguredCliPath } from '../../../utils/path';
 import { maybeGetPiWorkspaceServices } from '../app/PiWorkspaceServices';
 import { sameDiscoveredModels, sameStringList } from '../internal/compareCollections';
 import { decodePiModelId, type PiDiscoveredModel } from '../models';
@@ -252,7 +252,7 @@ function validateCliPath(value: string): string | null {
     return null;
   }
 
-  const expandedPath = expandHomePath(trimmed);
+  const expandedPath = normalizeConfiguredCliPath(trimmed);
   if (!fs.existsSync(expandedPath)) {
     return 'Path does not exist';
   }

--- a/src/utils/cliBinaryLocator.ts
+++ b/src/utils/cliBinaryLocator.ts
@@ -2,7 +2,12 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { getEnhancedPath } from './env';
-import { expandHomePath, parsePathEntries } from './path';
+import {
+  expandHomePath,
+  normalizeConfiguredCliPath,
+  parsePathEntries,
+  stripSurroundingQuotes,
+} from './path';
 
 export function isExistingFile(filePath: string): boolean {
   try {
@@ -13,13 +18,11 @@ export function isExistingFile(filePath: string): boolean {
 }
 
 export function resolveConfiguredCliPath(configuredPath: string | undefined): string | null {
-  const trimmed = (configuredPath ?? '').trim();
-  if (!trimmed) {
-    return null;
-  }
-
   try {
-    const expandedPath = expandHomePath(trimmed);
+    const expandedPath = normalizeConfiguredCliPath(configuredPath);
+    if (!expandedPath) {
+      return null;
+    }
     return isExistingFile(expandedPath) ? expandedPath : null;
   } catch {
     return null;
@@ -67,16 +70,6 @@ function parsePathEntriesForPlatform(pathValue: string | undefined, platform: No
       return upper !== '$PATH' && upper !== '${PATH}' && upper !== '%PATH%';
     })
     .map(segment => translateMsysPathForPlatform(expandHomePath(segment), platform));
-}
-
-function stripSurroundingQuotes(value: string): string {
-  if (
-    (value.startsWith('"') && value.endsWith('"')) ||
-    (value.startsWith("'") && value.endsWith("'"))
-  ) {
-    return value.slice(1, -1);
-  }
-  return value;
 }
 
 function translateMsysPathForPlatform(value: string, platform: NodeJS.Platform): string {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -83,7 +83,7 @@ export function expandHomePath(p: string): string {
   return expanded;
 }
 
-function stripSurroundingQuotes(value: string): string {
+export function stripSurroundingQuotes(value: string): string {
   if (
     (value.startsWith('"') && value.endsWith('"')) ||
     (value.startsWith("'") && value.endsWith("'"))
@@ -91,6 +91,20 @@ function stripSurroundingQuotes(value: string): string {
     return value.slice(1, -1);
   }
   return value;
+}
+
+/**
+ * Normalizes a user-configured CLI path. Windows Explorer's "Copy as path" wraps the
+ * path in double quotes exactly when it contains a space, so a configured path field
+ * receives a quoted value far more often than a PATH segment does. Unquoting before
+ * expansion mirrors `parsePathEntries`, so `"%APPDATA%\..."` still expands.
+ *
+ * Returns an empty string when nothing is configured; callers treat that as "unset".
+ */
+export function normalizeConfiguredCliPath(rawPath: string | undefined): string {
+  const trimmed = (rawPath ?? '').trim();
+  if (!trimmed) return '';
+  return expandHomePath(stripSurroundingQuotes(trimmed));
 }
 
 export function parsePathEntries(pathValue?: string): string[] {

--- a/tests/unit/providers/claude/runtime/ClaudeCliResolver.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudeCliResolver.test.ts
@@ -1,0 +1,50 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { resolveClaudeCliPath } from '@/providers/claude/runtime/ClaudeCliResolver';
+
+describe('resolveClaudeCliPath', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-cli-resolver-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const createExecutable = (...segments: string[]): string => {
+    const filePath = path.join(tempDir, ...segments);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, '');
+    return filePath;
+  };
+
+  it('resolves a configured CLI path that was pasted with surrounding quotes', () => {
+    const cliPath = createExecutable('my tools', 'claude');
+
+    expect(resolveClaudeCliPath(`"${cliPath}"`, '', '')).toBe(cliPath);
+  });
+
+  it('does not fall back to PATH discovery when the configured path is quoted', () => {
+    const configured = createExecutable('configured dir', 'claude');
+    const discoverable = createExecutable('path dir', 'claude');
+    const envText = `PATH=${path.dirname(discoverable)}`;
+
+    expect(resolveClaudeCliPath(`"${configured}"`, '', envText)).toBe(configured);
+  });
+
+  it('resolves a quoted legacy CLI path when no host-scoped path is set', () => {
+    const cliPath = createExecutable('legacy dir', 'claude');
+
+    expect(resolveClaudeCliPath('', `"${cliPath}"`, '')).toBe(cliPath);
+  });
+
+  it('still resolves an unquoted configured path', () => {
+    const cliPath = createExecutable('plain', 'claude');
+
+    expect(resolveClaudeCliPath(cliPath, '', '')).toBe(cliPath);
+  });
+});

--- a/tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts
+++ b/tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts
@@ -432,6 +432,33 @@ describe('ClaudeSettingsTab', () => {
     expect(mockCliResolverReset).toHaveBeenCalledTimes(1);
   });
 
+  it('persists a CLI path pasted with surrounding quotes', async () => {
+    mockedExistsSync.mockImplementation((filePath: fs.PathLike) => (
+      String(filePath) === '/custom dir/claude'
+    ));
+    const plugin = createPlugin();
+    plugin.mutateSettings.mockImplementation(async (
+      mutation: (settings: any) => void | Promise<void>,
+    ) => {
+      await mutation(plugin.settings);
+      await plugin.saveSettings();
+    });
+    plugin.runProviderExecutionTransition.mockImplementation(async (
+      _providerIds: string[],
+      mutation: () => Promise<unknown>,
+    ) => mutation());
+    mockCliResolverReset.mockImplementation(() => undefined);
+
+    claudeSettingsTabRenderer.render(createContainer(), createContext(plugin));
+    await findSetting('settings.cliPath.name')
+      .textComponents[0]
+      .onChangeCallback?.('"/custom dir/claude"');
+
+    expect(plugin.settings.providerConfigs.claude.cliPathsByHost).toEqual({
+      'host-a': '"/custom dir/claude"',
+    });
+  });
+
   it('reloads Claude MCP state inside the execution transition', async () => {
     let transitionActive = false;
     const plugin = createPlugin();

--- a/tests/unit/providers/codex/runtime/CodexBinaryLocator.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexBinaryLocator.test.ts
@@ -138,4 +138,62 @@ describe('CodexBinaryLocator', () => {
       { installationMethod: 'wsl', hostPlatform: 'win32' },
     )).toBe('codex');
   });
+
+  it('strips matching surrounding quotes from configured Linux commands in WSL mode', () => {
+    expect(resolveCodexCliPath(
+      '"/home/user/my tools/codex"',
+      '',
+      '',
+      { installationMethod: 'wsl', hostPlatform: 'win32' },
+    )).toBe('/home/user/my tools/codex');
+    expect(resolveCodexCliPath(
+      "'/home/user/codex'",
+      '',
+      '',
+      { installationMethod: 'wsl', hostPlatform: 'win32' },
+    )).toBe('/home/user/codex');
+  });
+
+  it('keeps Linux-side home and environment references literal in WSL mode', () => {
+    const originalRoot = process.env.TEST_WSL_CODEX_ROOT;
+    process.env.TEST_WSL_CODEX_ROOT = 'C:\\host-tools';
+    try {
+      expect(resolveCodexCliPath(
+        '"~/tools/codex"',
+        '',
+        '',
+        { installationMethod: 'wsl', hostPlatform: 'win32' },
+      )).toBe('~/tools/codex');
+      expect(resolveCodexCliPath(
+        '"$TEST_WSL_CODEX_ROOT/bin/codex"',
+        '',
+        '',
+        { installationMethod: 'wsl', hostPlatform: 'win32' },
+      )).toBe('$TEST_WSL_CODEX_ROOT/bin/codex');
+    } finally {
+      if (originalRoot === undefined) {
+        delete process.env.TEST_WSL_CODEX_ROOT;
+      } else {
+        process.env.TEST_WSL_CODEX_ROOT = originalRoot;
+      }
+    }
+  });
+
+  it('ignores a quoted Windows path and selects a quoted legacy Linux command in WSL mode', () => {
+    expect(resolveCodexCliPath(
+      '"C:\\Users\\user\\AppData\\Roaming\\npm\\codex.exe"',
+      '"/home/user/legacy tools/codex"',
+      '',
+      { installationMethod: 'wsl', hostPlatform: 'win32' },
+    )).toBe('/home/user/legacy tools/codex');
+  });
+
+  it('ignores a quoted Windows-native CLI path in WSL mode and uses the default command', () => {
+    expect(resolveCodexCliPath(
+      '"C:\\Users\\user\\AppData\\Roaming\\npm\\codex.exe"',
+      '',
+      '',
+      { installationMethod: 'wsl', hostPlatform: 'win32' },
+    )).toBe('codex');
+  });
 });

--- a/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
+++ b/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
@@ -672,6 +672,65 @@ describe('CodexSettingsTab', () => {
     );
   });
 
+  it('accepts a CLI path pasted with surrounding quotes', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    mockedExistsSync.mockImplementation((filePath: fs.PathLike) => String(filePath) === '/my tools/codex');
+    const plugin = createPlugin();
+    plugin.runProviderExecutionTransition.mockImplementation(async (
+      _providerIds: string[],
+      mutation: () => Promise<unknown>,
+    ) => mutation());
+    plugin.mutateSettings.mockImplementation(async (
+      mutation: (settings: any) => void | Promise<void>,
+    ) => {
+      await mutation(plugin.settings);
+      await plugin.saveSettings();
+    });
+
+    codexSettingsTabRenderer.render(createContainer(), createContext(plugin));
+    await findSetting('Codex CLI path').textComponents[0].onChangeCallback?.('"/my tools/codex"');
+
+    expect(plugin.settings.providerConfigs.codex.cliPathsByHost['host-a']).toBe('"/my tools/codex"');
+  });
+
+  it('accepts a quoted Linux-side CLI path when installation method is WSL', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const plugin = createPlugin();
+
+    codexSettingsTabRenderer.render(createContainer(), createContext(plugin));
+
+    const installationMethodSetting = findSetting('Installation method');
+    await installationMethodSetting.dropdownComponents[0].onChangeCallback?.('wsl');
+    mockSaveSettings.mockClear();
+
+    const cliPathSetting = findSetting('Codex CLI path');
+    await cliPathSetting.textComponents[0].onChangeCallback?.('"/home/user/my tools/codex"');
+
+    expect(plugin.settings.providerConfigs.codex.cliPathsByHost['host-a']).toBe(
+      '"/home/user/my tools/codex"',
+    );
+    expect(mockSaveSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a quoted Windows-native CLI path when installation method is WSL', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const plugin = createPlugin();
+
+    codexSettingsTabRenderer.render(createContainer(), createContext(plugin));
+
+    const installationMethodSetting = findSetting('Installation method');
+    await installationMethodSetting.dropdownComponents[0].onChangeCallback?.('wsl');
+    mockSaveSettings.mockClear();
+
+    const cliPathSetting = findSetting('Codex CLI path');
+    await cliPathSetting.textComponents[0].onChangeCallback?.(
+      '"C:\\Users\\me\\AppData\\Roaming\\npm\\codex.exe"',
+    );
+
+    expect(plugin.settings.providerConfigs.codex.cliPathsByHost['host-a']).toBeUndefined();
+    expect(mockSaveSettings).not.toHaveBeenCalled();
+  });
+
   it('does not render the legacy custom models textarea', () => {
     Object.defineProperty(process, 'platform', { value: 'darwin' });
     const plugin = createPlugin();

--- a/tests/unit/providers/grok/ui/GrokSettingsTab.test.ts
+++ b/tests/unit/providers/grok/ui/GrokSettingsTab.test.ts
@@ -361,6 +361,19 @@ describe('GrokSettingsTab', () => {
     });
   });
 
+  it('accepts a CLI path pasted with surrounding quotes', async () => {
+    const plugin = createPlugin();
+    grokSettingsTabRenderer.render(createContainer(), createContext(plugin));
+
+    mockedAccessSync.mockImplementation(() => undefined);
+    mockedExistsSync.mockImplementation((filePath: fs.PathLike) => String(filePath) === '/my tools/grok');
+    await findSetting('CLI path').textComponents[0].onChangeCallback?.('"/my tools/grok"');
+
+    expect(getGrokProviderSettings(plugin.settings).cliPathsByHost).toEqual({
+      'device:current': '"/my tools/grok"',
+    });
+  });
+
   it('restores CLI path closure and input state after a pre-commit write failure', async () => {
     const plugin = createPlugin();
     const writeError = new Error('write failed');

--- a/tests/unit/providers/opencode/OpencodeSettingsTab.test.ts
+++ b/tests/unit/providers/opencode/OpencodeSettingsTab.test.ts
@@ -489,6 +489,28 @@ describe('OpencodeSettingsTab', () => {
     },
   );
 
+  it('accepts a CLI path pasted with surrounding quotes', async () => {
+    mockedExistsSync.mockImplementation((filePath: fs.PathLike) => String(filePath) === '/my tools/opencode');
+    const plugin = createPlugin();
+    plugin.runProviderExecutionTransition.mockImplementation(async (
+      _providerIds: string[],
+      mutation: () => Promise<unknown>,
+    ) => mutation());
+    plugin.mutateSettings.mockImplementation(async (
+      mutation: (settings: any) => void | Promise<void>,
+    ) => {
+      await mutation(plugin.settings);
+      await plugin.saveSettings();
+    });
+
+    opencodeSettingsTabRenderer.render(createContainer(), createContext(plugin));
+    await findSetting('CLI path').textComponents[0].onChangeCallback?.('"/my tools/opencode"');
+
+    expect(plugin.settings.providerConfigs.opencode.cliPathsByHost).toEqual({
+      'host-a': '"/my tools/opencode"',
+    });
+  });
+
   it('stores the CLI path and resets provider state inside an execution transition', async () => {
     mockedExistsSync.mockImplementation((filePath: fs.PathLike) => String(filePath) === '/custom/opencode');
     let transitionActive = false;

--- a/tests/unit/providers/pi/ui/PiSettingsTab.test.ts
+++ b/tests/unit/providers/pi/ui/PiSettingsTab.test.ts
@@ -559,6 +559,20 @@ describe('PiSettingsTab', () => {
     );
   });
 
+  it('accepts a CLI path pasted with surrounding quotes', async () => {
+    const settings: Record<string, unknown> = { providerConfigs: { pi: {} } };
+    render(settings);
+    const cliInput = findSetting('CLI path').textComponents[0];
+
+    mockedExists.mockImplementation((filePath: unknown) => String(filePath) === '/my tools/pi');
+    mockedStat.mockReturnValue({ isFile: () => true });
+    await cliInput.onChangeCallback?.('"/my tools/pi"');
+
+    expect(getPiProviderSettings(settings).cliPathsByHost).toEqual({
+      'current-host': '"/my tools/pi"',
+    });
+  });
+
   it('resynchronizes the Pi CLI input when transition setup fails before mutation', async () => {
     const settings: Record<string, unknown> = {
       providerConfigs: {

--- a/tests/unit/utils/cliBinaryLocator.test.ts
+++ b/tests/unit/utils/cliBinaryLocator.test.ts
@@ -22,6 +22,15 @@ describe('cliBinaryLocator', () => {
     expect(resolveConfiguredCliPath(cliPath)).toBe(cliPath);
   });
 
+  it('resolves a configured CLI path that was pasted with surrounding quotes', () => {
+    const binDir = path.join(tempDir, 'my tools');
+    const cliPath = path.join(binDir, 'pi');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(cliPath, '');
+
+    expect(resolveConfiguredCliPath(`"${cliPath}"`)).toBe(cliPath);
+  });
+
   it('finds Windows npm .cmd shims on a PATH entry', () => {
     const binDir = path.join(tempDir, 'bin');
     const shimPath = path.join(binDir, 'pi.cmd');

--- a/tests/unit/utils/path.test.ts
+++ b/tests/unit/utils/path.test.ts
@@ -12,6 +12,7 @@ import {
   getVaultPath,
   isPathWithinDirectory,
   isPathWithinVault,
+  normalizeConfiguredCliPath,
   normalizePathForComparison,
   normalizePathForFilesystem,
   normalizePathForVault,
@@ -673,5 +674,47 @@ describe('expandHomePath - Windows environment variable formats', () => {
       if (original === undefined) delete process.env.MY_CI_VAR;
       else process.env.MY_CI_VAR = original;
     }
+  });
+});
+
+describe('normalizeConfiguredCliPath', () => {
+  it('strips surrounding double quotes from a path containing a space', () => {
+    expect(normalizeConfiguredCliPath('"/opt/my cli/claude"')).toBe('/opt/my cli/claude');
+  });
+
+  it('strips surrounding single quotes', () => {
+    expect(normalizeConfiguredCliPath("'/opt/claude'")).toBe('/opt/claude');
+  });
+
+  it('leaves an unquoted path unchanged', () => {
+    expect(normalizeConfiguredCliPath('/opt/my cli/claude')).toBe('/opt/my cli/claude');
+  });
+
+  it('leaves a path with only a leading quote unchanged', () => {
+    expect(normalizeConfiguredCliPath('"/opt/claude')).toBe('"/opt/claude');
+  });
+
+  it('trims surrounding whitespace before unquoting', () => {
+    expect(normalizeConfiguredCliPath('  "/opt/claude"  ')).toBe('/opt/claude');
+  });
+
+  it('expands environment variables after unquoting', () => {
+    const original = process.env.TEST_QUOTED_CLI_DIR;
+    process.env.TEST_QUOTED_CLI_DIR = '/opt/tools';
+    try {
+      expect(normalizeConfiguredCliPath('"$TEST_QUOTED_CLI_DIR/my cli"')).toBe('/opt/tools/my cli');
+    } finally {
+      if (original === undefined) delete process.env.TEST_QUOTED_CLI_DIR;
+      else process.env.TEST_QUOTED_CLI_DIR = original;
+    }
+  });
+
+  it('expands a home-relative path after unquoting', () => {
+    expect(normalizeConfiguredCliPath('"~/bin/my cli"')).toBe(path.join(os.homedir(), 'bin/my cli'));
+  });
+
+  it('returns an empty string for blank or missing input', () => {
+    expect(normalizeConfiguredCliPath('   ')).toBe('');
+    expect(normalizeConfiguredCliPath(undefined)).toBe('');
   });
 });


### PR DESCRIPTION
## Summary

Windows Explorer's "Copy as path" wraps paths containing spaces in double quotes. Both settings validation (`fs.existsSync('"…"')` → "does not exist") and launch resolution (configured path never matched → silent fallback to PATH discovery) rejected such values in every provider, so a pasted quoted path could not be saved or used.

Adds `normalizeConfiguredCliPath` (trim → strip surrounding quotes → expand home/env, empty means unset) in `src/utils/path.ts` and applies it in every provider CLI path validator and resolver. The Codex WSL branch strips quotes from configured commands before the Windows-path rejection check, so a quoted Linux command is accepted while a quoted Windows path is still rejected. Persisted settings keep the raw string; unquoting happens at read time, so the fail-closed settings decode rules are untouched.


## Adaptation notes

- One shared change in `resolveConfiguredCliPath` covers pi, omp, cursor, grok, and opencode via `CachedProviderCliResolver`; Claude and Codex have provider-specific resolvers patched separately. The private `stripSurroundingQuotes` duplicates in `cliBinaryLocator` and `CodexBinaryLocator` are deduplicated into `utils/path`.
- Deliberate improvement over upstream: the Cursor and OMP settings tabs are covered too — upstream skipped them, but their resolvers share the identical bug, and validation-only parity would let users save paths that cannot launch.
- The Cursor/OMP tabs have no test harness in this fork; their fix is covered through the shared `normalizeConfiguredCliPath` contract tests. Noted in the commit message.

## Testing

- New `normalizeConfiguredCliPath` unit tests; quoted-path resolution tests for `cliBinaryLocator` and a new `ClaudeCliResolver` test file; Codex WSL quote handling (quoted Linux command accepted, quoted Windows path rejected, `~`/`$` kept literal); quoted-path acceptance tests for all five tested provider settings tabs.
- Utility/resolver tests fail on the pre-fix code.
- Full suite: 408 suites / 7,051 tests green; typecheck, lint, and production build clean.