### PR TITLE
fix: make image previews keyboard accessible and leak-free

### DIFF
--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -35,6 +35,7 @@ import {
 import { openVaultFile } from '../../../utils/obsidianCompat';
 import type { FeatureHost } from '../../FeatureHost';
 import { findRewindContext } from '../rewind';
+import { ImagePreviewModal } from '../ui/ImagePreviewModal';
 import { formatConversationDirectoryTitle } from '../utils/conversationDirectoryTitle';
 import { renderCitationGroup as renderCitationBlock } from './CitationRenderer';
 import {
@@ -81,6 +82,8 @@ export class MessageRenderer {
   private getCapabilities: () => ProviderCapabilities;
   private forkCallback?: (messageId: string) => Promise<void>;
   private liveMessageEls = new Map<string, HTMLElement>();
+  private readonly imagePreviewModal = new ImagePreviewModal();
+  private isDisposed = false;
 
   constructor(
     plugin: FeatureHost,
@@ -117,6 +120,14 @@ export class MessageRenderer {
   /** Sets the messages container element. */
   setMessagesEl(el: HTMLElement): void {
     this.messagesEl = el;
+  }
+
+  /** Releases renderer-owned resources (call on tab teardown). */
+  dispose(): void {
+    if (this.isDisposed) return;
+    this.isDisposed = true;
+    this.imagePreviewModal.close();
+    this.liveMessageEls.clear();
   }
 
   private getSubagentAdapter(toolName?: string) {
@@ -712,7 +723,13 @@ export class MessageRenderer {
     const imagesEl = containerEl.createDiv({ cls: 'claudian-message-images' });
 
     for (const image of images) {
-      const imageWrapper = imagesEl.createDiv({ cls: 'claudian-message-image' });
+      const imageWrapper = imagesEl.createEl('button', {
+        cls: 'claudian-message-image',
+        attr: {
+          'aria-label': `Preview ${image.name}`,
+          type: 'button',
+        },
+      });
       const imgEl = imageWrapper.createEl('img', {
         attr: {
           alt: image.name,
@@ -721,8 +738,7 @@ export class MessageRenderer {
 
       void this.setImageSrc(imgEl, image);
 
-      // Click to view full size
-      imgEl.addEventListener('click', () => {
+      imageWrapper.addEventListener('click', () => {
         void this.showFullImage(image);
       });
     }
@@ -732,38 +748,9 @@ export class MessageRenderer {
    * Shows full-size image in modal overlay.
    */
   showFullImage(image: ImageAttachment): void {
-    const dataUri = `data:${image.mediaType};base64,${image.data}`;
-
+    if (this.isDisposed) return;
     const ownerDocument = this.messagesEl.ownerDocument ?? window.document;
-    const overlay = ownerDocument.body.createDiv({ cls: 'claudian-image-modal-overlay' });
-    const modal = overlay.createDiv({ cls: 'claudian-image-modal' });
-
-    modal.createEl('img', {
-      attr: {
-        src: dataUri,
-        alt: image.name,
-      },
-    });
-
-    const closeBtn = modal.createDiv({ cls: 'claudian-image-modal-close' });
-    closeBtn.setText('\u00D7');
-
-    const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        close();
-      }
-    };
-
-    const close = () => {
-      ownerDocument.removeEventListener('keydown', handleEsc);
-      overlay.remove();
-    };
-
-    closeBtn.addEventListener('click', close);
-    overlay.addEventListener('click', (e) => {
-      if (e.target === overlay) close();
-    });
-    ownerDocument.addEventListener('keydown', handleEsc);
+    this.imagePreviewModal.open(ownerDocument, image);
   }
 
   /**

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -2129,6 +2129,7 @@ export async function destroyTab(tab: TabData): Promise<void> {
     tab.dom.eventCleanups.length = 0;
   });
   cleanup.register('tab stream controller', () => tab.controllers.streamController?.dispose());
+  cleanup.register('tab message renderer', () => tab.renderer?.dispose());
   cleanup.register('tab navigation sidebar', () => {
     tab.ui.navigationSidebar?.destroy();
     tab.ui.navigationSidebar = null;

--- a/src/features/chat/ui/ImageContext.ts
+++ b/src/features/chat/ui/ImageContext.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 
 import type { ImageAttachment, ImageMediaType } from '../../../core/types';
 import { ComposerContextTray } from './ComposerContextTray';
+import { ImagePreviewModal } from './ImagePreviewModal';
 
 const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
 
@@ -27,6 +28,8 @@ export class ImageContextManager {
   private inputEl: HTMLTextAreaElement;
   private dropOverlay: HTMLElement | null = null;
   private attachedImages: Map<string, ImageAttachment> = new Map();
+  private readonly imagePreviewModal = new ImagePreviewModal();
+  private destroyed = false;
   private enabled = true;
 
   constructor(
@@ -83,6 +86,8 @@ export class ImageContextManager {
   }
 
   destroy(): void {
+    this.destroyed = true;
+    this.imagePreviewModal.close();
     this.contextTray.clearItems('images');
     this.ownedContextTray?.destroy();
     this.ownedContextTray = null;
@@ -277,36 +282,9 @@ export class ImageContextManager {
   }
 
   private showFullImage(image: ImageAttachment) {
+    if (this.destroyed) return;
     const ownerDocument = this.containerEl.ownerDocument ?? window.document;
-    const overlay = ownerDocument.body.createDiv({ cls: 'claudian-image-modal-overlay' });
-    const modal = overlay.createDiv({ cls: 'claudian-image-modal' });
-
-    modal.createEl('img', {
-      attr: {
-        src: `data:${image.mediaType};base64,${image.data}`,
-        alt: image.name,
-      },
-    });
-
-    const closeBtn = modal.createDiv({ cls: 'claudian-image-modal-close' });
-    closeBtn.setText('\u00D7');
-
-    const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        close();
-      }
-    };
-
-    const close = () => {
-      ownerDocument.removeEventListener('keydown', handleEsc);
-      overlay.remove();
-    };
-
-    closeBtn.addEventListener('click', close);
-    overlay.addEventListener('click', (e) => {
-      if (e.target === overlay) close();
-    });
-    ownerDocument.addEventListener('keydown', handleEsc);
+    this.imagePreviewModal.open(ownerDocument, image);
   }
 
   private generateId(): string {

--- a/src/features/chat/ui/ImagePreviewModal.ts
+++ b/src/features/chat/ui/ImagePreviewModal.ts
@@ -1,0 +1,75 @@
+import type { ImageAttachment } from '../../../core/types';
+
+function getFocusableActiveElement(ownerDocument: Document): HTMLElement | null {
+  const activeElement = ownerDocument.activeElement;
+  if (!activeElement || typeof (activeElement as HTMLElement).focus !== 'function') {
+    return null;
+  }
+  return activeElement as HTMLElement;
+}
+
+/** Owns the DOM and focus lifecycle of one open image preview. */
+export class ImagePreviewModal {
+  private closeCurrent: (() => void) | null = null;
+
+  open(ownerDocument: Document, image: ImageAttachment): void {
+    this.close();
+
+    const previouslyFocusedElement = getFocusableActiveElement(ownerDocument);
+    const overlay = ownerDocument.body.createDiv({ cls: 'claudian-image-modal-overlay' });
+    const modal = overlay.createDiv({ cls: 'claudian-image-modal' });
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-modal', 'true');
+    modal.setAttribute('aria-label', `Image preview: ${image.name}`);
+
+    modal.createEl('img', {
+      attr: {
+        src: `data:${image.mediaType};base64,${image.data}`,
+        alt: image.name,
+      },
+    });
+
+    const closeButton = modal.createEl('button', {
+      cls: 'claudian-image-modal-close',
+      attr: {
+        'aria-label': 'Close image preview',
+        type: 'button',
+      },
+    });
+    closeButton.setText('\u00D7');
+
+    let isClosed = false;
+    const close = () => {
+      if (isClosed) return;
+      isClosed = true;
+      ownerDocument.removeEventListener('keydown', handleKeyDown);
+      overlay.remove();
+      if (this.closeCurrent === close) {
+        this.closeCurrent = null;
+      }
+      if (previouslyFocusedElement?.isConnected) {
+        previouslyFocusedElement.focus();
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        close();
+      } else if (event.key === 'Tab') {
+        event.preventDefault();
+        closeButton.focus();
+      }
+    };
+
+    closeButton.addEventListener('click', close);
+    overlay.addEventListener('click', (event) => {
+      if (event.target === overlay) close();
+    });
+    ownerDocument.addEventListener('keydown', handleKeyDown);
+    this.closeCurrent = close;
+    closeButton.focus();
+  }
+
+  close(): void {
+    this.closeCurrent?.();
+  }
+}

--- a/src/style/features/image-context.css
+++ b/src/style/features/image-context.css
@@ -49,23 +49,40 @@
 }
 
 /* Individual image in message - standardized size */
-.claudian-message-image {
+button.claudian-message-image,
+button.claudian-message-image:active {
+  appearance: none;
   width: 120px;
   height: 120px;
+  margin: 0;
+  padding: 0;
   border-radius: 8px;
   overflow: hidden;
   cursor: pointer;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
   background: var(--background-secondary);
+  background-image: none;
   border: 1px solid var(--background-modifier-border);
+  color: var(--text-muted);
+  box-shadow: none;
 }
 
-.claudian-message-image:hover {
+button.claudian-message-image:hover,
+button.claudian-message-image:focus-visible {
+  border: 1px solid var(--background-modifier-border);
+  background: var(--background-secondary);
+  background-image: none;
+  color: var(--text-normal);
   transform: scale(1.03);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
-.claudian-message-image img {
+button.claudian-message-image:focus-visible {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: 2px;
+}
+
+button.claudian-message-image img {
   width: 100%;
   height: 100%;
   object-fit: cover;

--- a/src/style/features/image-modal.css
+++ b/src/style/features/image-modal.css
@@ -28,16 +28,23 @@
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 }
 
-.claudian-image-modal-close {
+button.claudian-image-modal-close,
+button.claudian-image-modal-close:focus,
+button.claudian-image-modal-close:active {
+  appearance: none;
   position: absolute;
   top: -12px;
   right: -12px;
   width: 32px;
   height: 32px;
+  margin: 0;
+  padding: 0;
+  border: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   background: var(--background-secondary);
+  background-image: none;
   border-radius: 50%;
   cursor: pointer;
   font-size: 20px;
@@ -46,7 +53,10 @@
   transition: background 0.15s ease, color 0.15s ease;
 }
 
-.claudian-image-modal-close:hover {
+button.claudian-image-modal-close:hover {
+  border: 0;
   background: var(--background-modifier-error);
+  background-image: none;
   color: var(--text-on-accent);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -1372,7 +1372,7 @@ describe('MessageRenderer', () => {
     expect(imgEl.getAttribute('src')).toBe('data:image/png;base64,abc123');
   });
 
-  it('showFullImage creates overlay with image', () => {
+  it('showFullImage opens a preview that disposal closes without allowing another', () => {
     const { renderer } = createRenderer();
     const image: ImageAttachment = {
       id: 'img-1',
@@ -1383,8 +1383,8 @@ describe('MessageRenderer', () => {
       source: 'file',
     };
 
-    // Mock document.body.createDiv (document may not exist in node env)
     const overlayEl = createMockEl();
+    const removeOverlay = jest.spyOn(overlayEl, 'remove');
     const mockBody = { createDiv: jest.fn().mockReturnValue(overlayEl) };
     const origDocument = globalThis.document;
     (globalThis as any).document = { body: mockBody, addEventListener: jest.fn(), removeEventListener: jest.fn() };
@@ -1392,6 +1392,12 @@ describe('MessageRenderer', () => {
     try {
       renderer.showFullImage(image);
       expect(mockBody.createDiv).toHaveBeenCalledWith({ cls: 'claudian-image-modal-overlay' });
+
+      renderer.dispose();
+      renderer.showFullImage(image);
+
+      expect(removeOverlay).toHaveBeenCalledTimes(1);
+      expect(mockBody.createDiv).toHaveBeenCalledTimes(1);
     } finally {
       (globalThis as any).document = origDocument;
     }
@@ -1988,110 +1994,6 @@ describe('MessageRenderer', () => {
   });
 
   // ============================================
-  // showFullImage - close behaviors
-  // ============================================
-
-  describe('showFullImage - close behaviors', () => {
-    const image: ImageAttachment = {
-      id: 'img-1',
-      name: 'test.png',
-      mediaType: 'image/png',
-      data: 'abc123',
-      size: 100,
-      source: 'file',
-    };
-
-    function setupDocumentMock() {
-      const overlayEl = createMockEl();
-      const mockBody = { createDiv: jest.fn().mockReturnValue(overlayEl) };
-      const docListeners = new Map<string, ((...args: any[]) => void)[]>();
-      const origDocument = globalThis.document;
-
-      (globalThis as any).document = {
-        body: mockBody,
-        addEventListener: jest.fn((event: string, handler: (...args: any[]) => void) => {
-          if (!docListeners.has(event)) docListeners.set(event, []);
-          docListeners.get(event)!.push(handler);
-        }),
-        removeEventListener: jest.fn((event: string, handler: (...args: any[]) => void) => {
-          const handlers = docListeners.get(event);
-          if (handlers) {
-            const idx = handlers.indexOf(handler);
-            if (idx !== -1) handlers.splice(idx, 1);
-          }
-        }),
-      };
-
-      return { overlayEl, docListeners, origDocument };
-    }
-
-    it('closeBtn click removes overlay', () => {
-      const { renderer } = createRenderer();
-      const { overlayEl, origDocument } = setupDocumentMock();
-
-      try {
-        renderer.showFullImage(image);
-
-        // The overlay has a modal child, which has a close button child
-        const modalEl = overlayEl.children[0]; // claudian-image-modal
-        // Children: img (index 0), closeBtn (index 1)
-        const closeBtn = modalEl.children[1];
-        expect(closeBtn.hasClass('claudian-image-modal-close')).toBe(true);
-
-        const removeSpy = jest.spyOn(overlayEl, 'remove');
-        closeBtn.click();
-
-        expect(removeSpy).toHaveBeenCalled();
-      } finally {
-        (globalThis as any).document = origDocument;
-      }
-    });
-
-    it('clicking overlay background removes overlay', () => {
-      const { renderer } = createRenderer();
-      const { overlayEl, origDocument } = setupDocumentMock();
-
-      try {
-        renderer.showFullImage(image);
-
-        const removeSpy = jest.spyOn(overlayEl, 'remove');
-
-        // Simulate click on the overlay itself (e.target === overlay)
-        const clickHandlers = overlayEl._eventListeners.get('click');
-        expect(clickHandlers).toBeDefined();
-        clickHandlers![0]({ target: overlayEl });
-
-        expect(removeSpy).toHaveBeenCalled();
-      } finally {
-        (globalThis as any).document = origDocument;
-      }
-    });
-
-    it('ESC key removes overlay', () => {
-      const { renderer } = createRenderer();
-      const { overlayEl, docListeners, origDocument } = setupDocumentMock();
-
-      try {
-        renderer.showFullImage(image);
-
-        const removeSpy = jest.spyOn(overlayEl, 'remove');
-
-        // Simulate ESC key press via the document keydown listener
-        const keydownHandlers = docListeners.get('keydown');
-        expect(keydownHandlers).toBeDefined();
-        expect(keydownHandlers!.length).toBeGreaterThan(0);
-        keydownHandlers![0]({ key: 'Escape' });
-
-        expect(removeSpy).toHaveBeenCalled();
-        // After close, the keydown handler should be removed
-        expect(document.removeEventListener).toHaveBeenCalledWith('keydown', expect.any(Function));
-      } finally {
-        (globalThis as any).document = origDocument;
-      }
-    });
-  });
-
-  // ============================================
   // renderContent - code block wrapping (error path)
   // ============================================
 
@@ -2264,11 +2166,11 @@ describe('MessageRenderer', () => {
   });
 
   // ============================================
-  // renderMessageImages - click handler
+  // renderMessageImages - preview control
   // ============================================
 
-  describe('renderMessageImages - click handler', () => {
-    it('should add click handler on image elements', () => {
+  describe('renderMessageImages - preview control', () => {
+    it('opens the preview from a native named button', () => {
       const containerEl = createMockEl();
       const { renderer } = createRenderer();
       const showFullImageSpy = jest.spyOn(renderer, 'showFullImage').mockImplementation(() => {});
@@ -2280,17 +2182,20 @@ describe('MessageRenderer', () => {
 
       renderer.renderMessageImages(containerEl, images);
 
-      // Find the img element and check for click handler
       const imagesContainer = containerEl.children[0];
-      const wrapper = imagesContainer.children[0];
-      const imgEl = wrapper.children[0]; // The img element
+      const previewButton = imagesContainer.children[0];
+      const imgEl = previewButton.children[0];
 
-      // Check click handler is registered
-      const clickHandlers = imgEl._eventListeners?.get('click');
+      expect(previewButton.tagName).toBe('BUTTON');
+      expect(previewButton.getAttribute('type')).toBe('button');
+      expect(previewButton.getAttribute('aria-label')).toBe('Preview photo.png');
+      expect(imgEl.tagName).toBe('IMG');
+      expect(imgEl.getAttribute('alt')).toBe('photo.png');
+
+      const clickHandlers = previewButton._eventListeners?.get('click');
       expect(clickHandlers).toBeDefined();
       expect(clickHandlers!.length).toBe(1);
 
-      // Trigger click and verify showFullImage is called
       clickHandlers![0]();
       expect(showFullImageSpy).toHaveBeenCalledWith(images[0]);
     });

--- a/tests/unit/features/chat/ui/ImageContext.test.ts
+++ b/tests/unit/features/chat/ui/ImageContext.test.ts
@@ -686,62 +686,35 @@ describe('ImageContextManager - Private Helpers', () => {
       expect(mgr.getAttachedImages()[0].id).toBe('img-2');
       expect(cb.onImagesChanged).toHaveBeenCalled();
     });
-  });
 
-  describe('showFullImage', () => {
-    let origDocument: typeof globalThis.document;
-    let overlayEl: any;
-    let mockBody: any;
-    let addEventSpy: jest.Mock;
-    let removeEventSpy: jest.Mock;
-
-    beforeEach(() => {
-      overlayEl = createMockEl();
-      addEventSpy = jest.fn();
-      removeEventSpy = jest.fn();
-      mockBody = { createDiv: jest.fn().mockReturnValue(overlayEl) };
-      origDocument = globalThis.document;
+    it('opens an image preview from the rendered attachment control and closes it on destroy', () => {
+      const overlayEl = createMockEl();
+      const removeOverlay = jest.spyOn(overlayEl, 'remove');
+      const mockBody = { createDiv: jest.fn().mockReturnValue(overlayEl) };
+      const originalDocument = globalThis.document;
       (globalThis as any).document = {
+        activeElement: null,
         body: mockBody,
-        addEventListener: addEventSpy,
-        removeEventListener: removeEventSpy,
-        createElementNS: jest.fn(() => mockSvgElement()),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
       };
-    });
 
-    afterEach(() => {
-      (globalThis as any).document = origDocument;
-    });
+      try {
+        manager.setImages([createImageAttachment({ name: 'photo.png' })]);
+        const previewButton = manager['contextTray']['containerEl']
+          .querySelector('.claudian-context-chip-main');
 
-    it('should create modal overlay with image', () => {
-      const image = createImageAttachment({ name: 'test.png', mediaType: 'image/png', data: 'abc123' });
-      manager['showFullImage'](image);
+        expect(previewButton.tagName).toBe('BUTTON');
+        previewButton.click();
+        expect(mockBody.createDiv).toHaveBeenCalledWith({
+          cls: 'claudian-image-modal-overlay',
+        });
 
-      expect(mockBody.createDiv).toHaveBeenCalledWith({ cls: 'claudian-image-modal-overlay' });
-    });
-
-    it('should register Escape key handler and close button', () => {
-      const image = createImageAttachment();
-      manager['showFullImage'](image);
-
-      expect(addEventSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
-
-      const escHandler = addEventSpy.mock.calls[0][1];
-      escHandler({ key: 'Escape' });
-
-      expect(removeEventSpy).toHaveBeenCalledWith('keydown', escHandler);
-    });
-
-    it('should close modal when clicking on overlay background', () => {
-      const image = createImageAttachment();
-      manager['showFullImage'](image);
-
-      const clickHandler = overlayEl._eventListeners.get('click')?.[0];
-      expect(clickHandler).toBeDefined();
-
-      clickHandler({ target: overlayEl });
-
-      expect(removeEventSpy).toHaveBeenCalled();
+        manager.destroy();
+        expect(removeOverlay).toHaveBeenCalledTimes(1);
+      } finally {
+        (globalThis as any).document = originalDocument;
+      }
     });
   });
 

--- a/tests/unit/features/chat/ui/ImagePreviewModal.test.ts
+++ b/tests/unit/features/chat/ui/ImagePreviewModal.test.ts
@@ -1,0 +1,172 @@
+import { createMockEl } from '@test/helpers/MockElement';
+
+import type { ImageAttachment } from '@/core/types';
+import { ImagePreviewModal } from '@/features/chat/ui/ImagePreviewModal';
+
+const IMAGE: ImageAttachment = {
+  id: 'image-1',
+  name: 'diagram.png',
+  mediaType: 'image/png',
+  data: 'abc123',
+  size: 128,
+  source: 'file',
+};
+
+function createDocumentHarness(previouslyFocusedElement: unknown = {
+  focus: jest.fn(),
+  isConnected: true,
+}) {
+  const overlayEl = createMockEl();
+  const closeButtonFocus = jest.fn();
+  const createModal = overlayEl.createDiv.bind(overlayEl);
+  overlayEl.createDiv = jest.fn((options: { cls?: string }) => {
+    const modalEl = createModal(options);
+    const createModalChild = modalEl.createEl.bind(modalEl);
+    modalEl.createEl = jest.fn((tag: string, childOptions?: unknown) => {
+      const child = createModalChild(tag, childOptions);
+      if (tag === 'button') child.focus = closeButtonFocus;
+      return child;
+    });
+    return modalEl;
+  });
+
+  const listeners = new Map<string, Array<(event: any) => void>>();
+  const ownerDocument = {
+    activeElement: previouslyFocusedElement,
+    body: {
+      createDiv: jest.fn().mockReturnValue(overlayEl),
+    },
+    addEventListener: jest.fn((event: string, handler: (event: any) => void) => {
+      const handlers = listeners.get(event) ?? [];
+      handlers.push(handler);
+      listeners.set(event, handlers);
+    }),
+    removeEventListener: jest.fn((event: string, handler: (event: any) => void) => {
+      const handlers = listeners.get(event) ?? [];
+      listeners.set(event, handlers.filter(candidate => candidate !== handler));
+    }),
+  } as unknown as Document;
+
+  return {
+    closeButtonFocus,
+    listeners,
+    overlayEl,
+    ownerDocument,
+    previouslyFocusedElement,
+  };
+}
+
+describe('ImagePreviewModal', () => {
+  it('opens a named dialog with a focused native close button', () => {
+    const harness = createDocumentHarness();
+    const modal = new ImagePreviewModal();
+
+    modal.open(harness.ownerDocument, IMAGE);
+
+    const modalEl = harness.overlayEl.children[0];
+    const imageEl = modalEl.children[0];
+    const closeButton = modalEl.children[1];
+    expect(modalEl.getAttribute('role')).toBe('dialog');
+    expect(modalEl.getAttribute('aria-modal')).toBe('true');
+    expect(modalEl.getAttribute('aria-label')).toBe('Image preview: diagram.png');
+    expect(imageEl.getAttribute('src')).toBe('data:image/png;base64,abc123');
+    expect(imageEl.getAttribute('alt')).toBe('diagram.png');
+    expect(closeButton.tagName).toBe('BUTTON');
+    expect(closeButton.getAttribute('type')).toBe('button');
+    expect(closeButton.getAttribute('aria-label')).toBe('Close image preview');
+    expect(harness.closeButtonFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { shiftKey: false },
+    { shiftKey: true },
+  ])('contains $shiftKey Tab navigation on its only control', ({ shiftKey }) => {
+    const harness = createDocumentHarness();
+    const modal = new ImagePreviewModal();
+    modal.open(harness.ownerDocument, IMAGE);
+    const event = {
+      key: 'Tab',
+      shiftKey,
+      preventDefault: jest.fn(),
+    };
+
+    harness.listeners.get('keydown')?.[0](event);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(harness.closeButtonFocus).toHaveBeenCalledTimes(2);
+  });
+
+  it('closes idempotently, removes its listener, and restores connected focus', () => {
+    const harness = createDocumentHarness();
+    const previousFocus = (harness.previouslyFocusedElement as { focus: jest.Mock }).focus;
+    const modal = new ImagePreviewModal();
+    modal.open(harness.ownerDocument, IMAGE);
+    const removeOverlay = jest.spyOn(harness.overlayEl, 'remove');
+
+    modal.close();
+    modal.close();
+
+    expect(removeOverlay).toHaveBeenCalledTimes(1);
+    expect(harness.listeners.get('keydown')).toEqual([]);
+    expect(previousFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the current preview before opening its replacement', () => {
+    const firstHarness = createDocumentHarness();
+    const secondHarness = createDocumentHarness();
+    const modal = new ImagePreviewModal();
+    const removeFirstOverlay = jest.spyOn(firstHarness.overlayEl, 'remove');
+
+    modal.open(firstHarness.ownerDocument, IMAGE);
+    modal.open(secondHarness.ownerDocument, { ...IMAGE, name: 'replacement.png' });
+
+    expect(removeFirstOverlay).toHaveBeenCalledTimes(1);
+    expect(firstHarness.listeners.get('keydown')).toEqual([]);
+    expect(secondHarness.overlayEl.children[0].getAttribute('aria-label'))
+      .toBe('Image preview: replacement.png');
+  });
+
+  it('supports Escape, close-button, and overlay-background dismissal', () => {
+    const escapeHarness = createDocumentHarness();
+    const escapeModal = new ImagePreviewModal();
+    escapeModal.open(escapeHarness.ownerDocument, IMAGE);
+    const removeEscapeOverlay = jest.spyOn(escapeHarness.overlayEl, 'remove');
+    escapeHarness.listeners.get('keydown')?.[0]({ key: 'Escape' });
+    expect(removeEscapeOverlay).toHaveBeenCalledTimes(1);
+
+    const buttonHarness = createDocumentHarness();
+    const buttonModal = new ImagePreviewModal();
+    buttonModal.open(buttonHarness.ownerDocument, IMAGE);
+    const removeButtonOverlay = jest.spyOn(buttonHarness.overlayEl, 'remove');
+    buttonHarness.overlayEl.children[0].children[1].click();
+    expect(removeButtonOverlay).toHaveBeenCalledTimes(1);
+
+    const overlayHarness = createDocumentHarness();
+    const overlayModal = new ImagePreviewModal();
+    overlayModal.open(overlayHarness.ownerDocument, IMAGE);
+    const removeBackgroundOverlay = jest.spyOn(overlayHarness.overlayEl, 'remove');
+    const overlayClick = overlayHarness.overlayEl._eventListeners.get('click')?.[0];
+    overlayClick?.({ target: overlayHarness.overlayEl.children[0] });
+    expect(removeBackgroundOverlay).not.toHaveBeenCalled();
+    overlayClick?.({ target: overlayHarness.overlayEl });
+    expect(removeBackgroundOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not restore a disconnected prior focus target', () => {
+    const priorFocusTarget = { focus: jest.fn(), isConnected: false };
+    const harness = createDocumentHarness(priorFocusTarget);
+    const modal = new ImagePreviewModal();
+    modal.open(harness.ownerDocument, IMAGE);
+
+    expect(() => modal.close()).not.toThrow();
+    expect(priorFocusTarget.focus).not.toHaveBeenCalled();
+  });
+
+  it('ignores an active element without a focus operation', () => {
+    const harness = createDocumentHarness({ isConnected: true });
+    const modal = new ImagePreviewModal();
+    modal.open(harness.ownerDocument, IMAGE);
+
+    expect(() => modal.close()).not.toThrow();
+  });
+});

--- a/tests/unit/style/features/image-preview.test.ts
+++ b/tests/unit/style/features/image-preview.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+describe('Image preview button styles', () => {
+  const contextCss = readFileSync(
+    path.resolve('src/style/features/image-context.css'),
+    'utf8',
+  );
+  const modalCss = readFileSync(
+    path.resolve('src/style/features/image-modal.css'),
+    'utf8',
+  );
+
+  it('keeps the native thumbnail button on the existing image surface in every state', () => {
+    const baseRule = contextCss.match(
+      /button\.claudian-message-image,\s*button\.claudian-message-image:active\s*{[^}]*}/,
+    )?.[0];
+    expect(baseRule).toContain('padding: 0;');
+    expect(baseRule).toContain('border: 1px solid var(--background-modifier-border);');
+    expect(baseRule).toContain('background: var(--background-secondary);');
+    expect(baseRule).toContain('background-image: none;');
+    expect(baseRule).toContain('box-shadow: none;');
+
+    const interactionRule = contextCss.match(
+      /button\.claudian-message-image:hover,\s*button\.claudian-message-image:focus-visible\s*{[^}]*}/,
+    )?.[0];
+    expect(interactionRule).toContain('border: 1px solid var(--background-modifier-border);');
+    expect(interactionRule).toContain('background: var(--background-secondary);');
+    expect(interactionRule).toContain('background-image: none;');
+    expect(interactionRule).toContain('box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);');
+  });
+
+  it('keeps the native close button on the existing circular surface in every state', () => {
+    const baseRule = modalCss.match(
+      /button\.claudian-image-modal-close,\s*button\.claudian-image-modal-close:focus,\s*button\.claudian-image-modal-close:active\s*{[^}]*}/,
+    )?.[0];
+    expect(baseRule).toContain('padding: 0;');
+    expect(baseRule).toContain('border: 0;');
+    expect(baseRule).toContain('background: var(--background-secondary);');
+    expect(baseRule).toContain('background-image: none;');
+    expect(baseRule).toContain('box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);');
+
+    const hoverRule = modalCss.match(
+      /button\.claudian-image-modal-close:hover\s*{[^}]*}/,
+    )?.[0];
+    expect(hoverRule).toContain('border: 0;');
+    expect(hoverRule).toContain('background: var(--background-modifier-error);');
+    expect(hoverRule).toContain('background-image: none;');
+    expect(hoverRule).toContain('box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);');
+  });
+});


### PR DESCRIPTION
## Summary

Image preview thumbnails were click-only `div`s — invisible and unusable from a keyboard or screen reader — and the inline modal was duplicated in `MessageRenderer` and `ImageContextManager` with no lifecycle ownership: opening a preview, then closing the view or tab, leaked the document-level `keydown` listener and left the overlay on screen.

The duplicated inline modal is extracted into a shared `ImagePreviewModal` that owns the dialog role (`role=dialog`, `aria-modal`, labelled), a focused native close button, Tab containment, focus restoration, and idempotent teardown. Message image thumbnails are now named native buttons (`type=button`, `aria-label`). `MessageRenderer` gains a `dispose()` that closes an open preview and refuses new ones after disposal, and `ImageContextManager.destroy()` closes its preview. The affected controls are restyled for button semantics (appearance reset, focus-visible outline) while keeping the existing surfaces.


## Adaptation notes

- Upstream's fix assumed a `MessageRenderer.dispose()`/`isDisposed` scaffolding this fork lacked; disposal hooks into the tab runtime cleanup (`destroyTab`), which is where this fork retires renderers, and the local inline modals (which predated upstream's close-tracking) needed the full lifecycle added, not just delegation.
- Upstream also fixed a `dismissed`-state guard in its own modal variant that does not exist here.

## Testing

- New `ImagePreviewModal` test file (dialog semantics, Tab containment, idempotent close, replacement, Escape/button/background dismissal, disconnected-focus safety) and a new style test for the button restyling.
- Renderer tests updated: preview opens from a named native button; disposal closes the open preview and blocks new ones. ImageContext tests: preview opens from the rendered chip control and closes on destroy. The superseded inline-modal behavior tests were removed with the inline modal.
- Full suite: 409 suites / 7,032 tests green; typecheck, lint, and production build clean.