### PR TITLE
fix: restore inline mention text

### DIFF
--- a/src/features/chat/ui/FileContext.ts
+++ b/src/features/chat/ui/FileContext.ts
@@ -116,10 +116,6 @@ export class FileContextManager {
       this.dropdownContainerEl,
       this.inputEl,
       {
-        onAttachFile: (filePath) => {
-          this.state.attachFile(filePath);
-          this.renderAttachedFiles();
-        },
         onMcpMentionChange: (servers) => this.onMcpMentionChange?.(servers),
         onAgentMentionSelect: (agentId) => this.callbacks.onAgentMentionSelect?.(agentId),
         getMentionedMcpServers: () => this.state.getMentionedMcpServers(),

--- a/src/features/inline-edit/ui/InlineEditModal.ts
+++ b/src/features/inline-edit/ui/InlineEditModal.ts
@@ -574,7 +574,6 @@ export class InlineEditSession {
       inputEl,
       {
         // Inline-edit resolves @mentions at send time from input text.
-        onAttachFile: () => {},
         onMcpMentionChange: () => {},
         getMentionedMcpServers: () => new Set(),
         setMentionedMcpServers: () => false,

--- a/src/shared/mention/MentionDropdownController.ts
+++ b/src/shared/mention/MentionDropdownController.ts
@@ -6,6 +6,7 @@ import { type ExternalContextFile, externalContextScanner } from '../../utils/ex
 import { extractMcpMentions } from '../../utils/mcp';
 import { SelectableDropdown } from '../components/SelectableDropdown';
 import { appendMcpIcon } from '../icons';
+import { formatVaultFileMention } from './formatMention';
 import {
   type AgentMentionProvider,
   type FolderMentionItem,
@@ -19,7 +20,6 @@ export interface MentionDropdownOptions {
 }
 
 export interface MentionDropdownCallbacks {
-  onAttachFile: (path: string) => void;
   onMcpMentionChange?: (servers: Set<string>) => void;
   onAgentMentionSelect?: (agentId: string) => void;
   getMentionedMcpServers: () => Set<string>;
@@ -685,30 +685,26 @@ export class MentionDropdownController {
         return;
       }
       case 'context-file': {
-        // External file references become context chips; keep the prompt text clean.
-        if (selectedItem.absolutePath) {
-          this.callbacks.onAttachFile(selectedItem.absolutePath);
-        }
-        this.insertReplacement(beforeAt, '', afterCursor);
+        // Keep the resolvable mention in the input; send-time resolution maps it to the absolute path.
+        const mentionPath = selectedItem.folderName
+          ? `${selectedItem.folderName}/${selectedItem.name}`
+          : selectedItem.name;
+        this.insertReplacement(beforeAt, `@${mentionPath} `, afterCursor);
         break;
       }
       case 'folder': {
         const normalizedPath = this.callbacks.normalizePathForVault(selectedItem.path);
-        if (normalizedPath) {
-          this.callbacks.onAttachFile(
-            normalizedPath.endsWith('/') ? normalizedPath : `${normalizedPath}/`,
-          );
-        }
-        this.insertReplacement(beforeAt, '', afterCursor);
+        this.insertReplacement(beforeAt, `@${normalizedPath ?? selectedItem.path}/ `, afterCursor);
         break;
       }
       default: {
         const rawPath = selectedItem.file?.path ?? selectedItem.path;
         const normalizedPath = this.callbacks.normalizePathForVault(rawPath);
-        if (normalizedPath) {
-          this.callbacks.onAttachFile(normalizedPath);
-        }
-        this.insertReplacement(beforeAt, '', afterCursor);
+        this.insertReplacement(
+          beforeAt,
+          formatVaultFileMention(normalizedPath ?? selectedItem.name),
+          afterCursor,
+        );
         break;
       }
     }

--- a/tests/unit/features/chat/ui/FileContextManager.test.ts
+++ b/tests/unit/features/chat/ui/FileContextManager.test.ts
@@ -248,7 +248,7 @@ describe('FileContextManager', () => {
     manager.destroy();
   });
 
-  it('shows vault-relative path in @ dropdown and turns selection into a context chip', () => {
+  it('shows vault-relative path in @ dropdown and inserts full path on selection', () => {
     const app = createMockApp({
       files: ['clipping/file.md'],
     });
@@ -270,10 +270,8 @@ describe('FileContextManager', () => {
 
     manager.handleMentionKeydown({ key: 'Enter', preventDefault: jest.fn() } as any);
 
-    // File references are represented by a removable chip, not prompt text.
-    expect(inputEl.value).toBe('');
-    const attached = manager.getAttachedFiles();
-    expect(attached.has('clipping/file.md')).toBe(true);
+    expect(inputEl.value).toBe('@clipping/file.md ');
+    expect(manager.getAttachedFiles()).toEqual(new Set());
 
     manager.destroy();
   });
@@ -305,7 +303,7 @@ describe('FileContextManager', () => {
     getFoldersSpy.mockRestore();
   });
 
-  it('filters context files and attaches absolute path', () => {
+  it('filters external context files and resolves their mention on send', () => {
     const app = createMockApp();
     const manager = new FileContextManager(
       app,
@@ -336,10 +334,8 @@ describe('FileContextManager', () => {
 
     manager.handleMentionKeydown({ key: 'Enter', preventDefault: jest.fn() } as any);
 
-    // External file references are represented by a removable chip.
-    expect(inputEl.value).toBe('');
-    const attached = manager.getAttachedFiles();
-    expect(attached.has('/external/src/app.md')).toBe(true);
+    expect(inputEl.value).toBe('@external/src/app.md ');
+    expect(manager.getAttachedFiles()).toEqual(new Set());
     // Check transformation works
     const transformed = manager.transformContextMentions('@external/src/app.md');
     expect(transformed).toBe('/external/src/app.md');

--- a/tests/unit/shared/mention/MentionDropdownController.test.ts
+++ b/tests/unit/shared/mention/MentionDropdownController.test.ts
@@ -47,7 +47,6 @@ function createMockInput() {
 function createMockCallbacks(overrides: Partial<MentionDropdownCallbacks> = {}): MentionDropdownCallbacks {
   const mentionedServers = new Set<string>();
   return {
-    onAttachFile: jest.fn(),
     onMcpMentionChange: jest.fn(),
     onAgentMentionSelect: jest.fn(),
     getMentionedMcpServers: jest.fn().mockReturnValue(mentionedServers),
@@ -731,10 +730,8 @@ describe('MentionDropdownController', () => {
       localController.destroy();
     });
 
-    it('turns a vault file mention into a removable context attachment', () => {
-      const onAttachFile = jest.fn();
+    it('inserts the vault file mention text', () => {
       const localCallbacks = createMockCallbacks({
-        onAttachFile,
         getCachedVaultFiles: jest.fn().mockReturnValue([
           { name: 'note.md', path: 'note.md', stat: { mtime: 1000 } } as any,
         ]),
@@ -751,16 +748,13 @@ describe('MentionDropdownController', () => {
       const enterEvent = { key: 'Enter', preventDefault: jest.fn(), isComposing: false } as any;
       localController.handleKeydown(enterEvent);
 
-      expect(localInput.value).toBe('');
-      expect(onAttachFile).toHaveBeenCalledWith('note.md');
+      expect(localInput.value).toBe('@note.md ');
 
       localController.destroy();
     });
 
-    it('turns a folder mention into a removable context attachment', () => {
-      const onAttachFile = jest.fn();
+    it('inserts folder mention as plain text', () => {
       const localCallbacks = createMockCallbacks({
-        onAttachFile,
         getCachedVaultFolders: jest.fn().mockReturnValue([
           { name: 'src', path: 'src' },
         ]),
@@ -777,8 +771,7 @@ describe('MentionDropdownController', () => {
       const enterEvent = { key: 'Enter', preventDefault: jest.fn(), isComposing: false } as any;
       localController.handleKeydown(enterEvent);
 
-      expect(localInput.value).toBe('');
-      expect(onAttachFile).toHaveBeenCalledWith('src/');
+      expect(localInput.value).toBe('@src/ ');
 
       localController.destroy();
     });


### PR DESCRIPTION
## Summary
- restore selected vault, folder, and external references as @ text in the composer
- stop creating duplicate context chips for mention-dropdown selections
- retain send-time resolution for external context references

## Verification
- pnpm run typecheck
- pnpm run lint (9 existing warnings, no errors)
- pnpm run test
- pnpm run build