### PR TITLE
fix: restore and highlight inline file mentions

### DIFF
--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -65,6 +65,7 @@ import { FileContextManager } from '../ui/FileContext';
 import { ImageContextManager } from '../ui/ImageContext';
 import { createInputToolbar } from '../ui/InputToolbar';
 import { InstructionModeManager as InstructionModeManagerClass } from '../ui/InstructionModeManager';
+import { MentionTextHighlighter } from '../ui/MentionTextHighlighter';
 import { NavigationSidebar } from '../ui/NavigationSidebar';
 import { renderProviderDiagnosticCard } from '../ui/ProviderDiagnosticCard';
 import { ScopePreview } from '../ui/ScopePreview';
@@ -1470,6 +1471,11 @@ export function initializeTabUI(
       tab.renderer?.scrollToBottomIfNeeded();
     },
   });
+  const mentionTextHighlighter = new MentionTextHighlighter(
+    dom.inputEl,
+    dom.inputMentionHighlightsEl,
+  );
+  dom.eventCleanups.push(() => mentionTextHighlighter.destroy());
   tab.ui.scopePreview = new ScopePreview(dom.scopePreviewEl);
   initializeContextManagers(tab, plugin, onUserModified);
 

--- a/src/features/chat/tabs/TabRuntimeFactory.ts
+++ b/src/features/chat/tabs/TabRuntimeFactory.ts
@@ -146,7 +146,12 @@ function buildTabDOM(contentEl: HTMLElement): TabDOMElements {
   const inputWrapper = inputContainerEl.createDiv({ cls: 'claudian-input-wrapper' });
   const contextRowEl = inputWrapper.createDiv({ cls: 'claudian-context-row' });
   const scopePreviewEl = inputWrapper.createDiv({ cls: 'claudian-scope-preview' });
-  const inputEl = inputWrapper.createEl('textarea', {
+  const inputEditorEl = inputWrapper.createDiv({ cls: 'claudian-input-editor' });
+  const inputMentionHighlightsEl = inputEditorEl.createDiv({
+    cls: 'claudian-input-mention-highlights claudian-input-mention-highlights--empty',
+    attr: { 'aria-hidden': 'true' },
+  });
+  const inputEl = inputEditorEl.createEl('textarea', {
     cls: 'claudian-input',
     attr: {
       placeholder: 'Ask to make changes, @mention files, run /commands',
@@ -173,6 +178,7 @@ function buildTabDOM(contentEl: HTMLElement): TabDOMElements {
     inputContainerEl,
     queueIndicatorEl,
     inputWrapper,
+    inputMentionHighlightsEl,
     inputEl,
     sendButtonEl,
     navRowEl,

--- a/src/features/chat/tabs/types.ts
+++ b/src/features/chat/tabs/types.ts
@@ -168,6 +168,8 @@ export interface TabDOMElements {
   inputContainerEl: HTMLElement;
   queueIndicatorEl: HTMLElement;
   inputWrapper: HTMLElement;
+  /** Read-only mirror beneath the textarea that highlights file @mentions. */
+  inputMentionHighlightsEl: HTMLElement;
   inputEl: HTMLTextAreaElement;
   sendButtonEl: HTMLButtonElement;
 

--- a/src/features/chat/ui/MentionTextHighlighter.ts
+++ b/src/features/chat/ui/MentionTextHighlighter.ts
@@ -1,0 +1,49 @@
+const FILE_MENTION_PATTERN = /@(?:[^\s@]+\.[^\s@]+|[^\s@/]+(?:\/[^\s@]+)*\/)/g;
+
+/** Mirrors composer text beneath its textarea and emphasizes file-like @mentions. */
+export class MentionTextHighlighter {
+  private readonly contentEl: HTMLElement;
+  private readonly syncHandler = () => this.sync();
+  private readonly scrollHandler = () => this.syncScroll();
+
+  constructor(
+    private readonly inputEl: HTMLTextAreaElement,
+    private readonly highlightEl: HTMLElement,
+  ) {
+    this.contentEl = this.highlightEl.createDiv({ cls: 'claudian-input-mention-highlights-content' });
+    this.inputEl.addEventListener('input', this.syncHandler);
+    this.inputEl.addEventListener('scroll', this.scrollHandler);
+    this.inputEl.addEventListener('claudian:mention-inserted', this.syncHandler);
+    this.sync();
+  }
+
+  destroy(): void {
+    this.inputEl.removeEventListener('input', this.syncHandler);
+    this.inputEl.removeEventListener('scroll', this.scrollHandler);
+    this.inputEl.removeEventListener('claudian:mention-inserted', this.syncHandler);
+    this.highlightEl.remove();
+  }
+
+  private sync(): void {
+    const text = this.inputEl.value;
+    this.highlightEl.classList.toggle('claudian-input-mention-highlights--empty', text.length === 0);
+    this.contentEl.textContent = '';
+
+    let cursor = 0;
+    for (const match of text.matchAll(FILE_MENTION_PATTERN)) {
+      const start = match.index ?? 0;
+      if (start > cursor) this.contentEl.createSpan({ text: text.slice(cursor, start) });
+      this.contentEl.createSpan({
+        cls: 'claudian-input-mention-highlight',
+        text: match[0],
+      });
+      cursor = start + match[0].length;
+    }
+    if (cursor < text.length) this.contentEl.createSpan({ text: text.slice(cursor) });
+    this.syncScroll();
+  }
+
+  private syncScroll(): void {
+    this.contentEl.style.transform = `translate(${-this.inputEl.scrollLeft}px, ${-this.inputEl.scrollTop}px)`;
+  }
+}

--- a/src/shared/mention/MentionDropdownController.ts
+++ b/src/shared/mention/MentionDropdownController.ts
@@ -710,6 +710,7 @@ export class MentionDropdownController {
     }
 
     this.hide();
+    this.inputEl.dispatchEvent(new Event('claudian:mention-inserted'));
     this.inputEl.focus();
   }
 }

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -164,10 +164,11 @@
 }
 
 .claudian-input-mention-highlight {
-  padding: 1px 4px;
+  padding: 0;
   border-radius: 4px;
   background: color-mix(in srgb, var(--interactive-accent) 14%, transparent);
   color: var(--interactive-accent);
+  line-height: inherit;
 }
 
 .claudian-input-send-button {

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -98,7 +98,16 @@
   height: 16.8px;
 }
 
+.claudian-input-editor {
+  position: relative;
+  display: flex;
+  flex: 1 1 0;
+  min-height: 0;
+}
+
 .claudian-input-wrapper textarea.claudian-input {
+  position: relative;
+  z-index: 1;
   width: 100%;
   flex: 1 1 0;
   min-height: var(--claudian-textarea-min-height, 64px);
@@ -108,7 +117,8 @@
   border: none;
   border-radius: 15px;
   background: transparent;
-  color: var(--text-normal);
+  color: transparent;
+  caret-color: var(--text-normal);
   font-family: inherit;
   font-size: 14px;
   line-height: 1.4;
@@ -127,6 +137,37 @@
 
 .claudian-input-wrapper textarea.claudian-input::placeholder {
   color: var(--text-muted);
+}
+
+.claudian-input-mention-highlights {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  color: var(--text-normal);
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.claudian-input-mention-highlights--empty {
+  display: none;
+}
+
+.claudian-input-mention-highlights-content {
+  box-sizing: border-box;
+  min-height: 100%;
+  padding: 13px 15px 48px;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  will-change: transform;
+}
+
+.claudian-input-mention-highlight {
+  padding: 1px 4px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--interactive-accent) 14%, transparent);
+  color: var(--interactive-accent);
 }
 
 .claudian-input-send-button {

--- a/tests/unit/features/chat/ui/FileContextManager.test.ts
+++ b/tests/unit/features/chat/ui/FileContextManager.test.ts
@@ -126,6 +126,7 @@ describe('FileContextManager', () => {
       selectionStart: 0,
       selectionEnd: 0,
       focus: jest.fn(),
+      dispatchEvent: jest.fn(),
     } as unknown as HTMLTextAreaElement;
   });
 

--- a/tests/unit/features/chat/ui/MentionTextHighlighter.test.ts
+++ b/tests/unit/features/chat/ui/MentionTextHighlighter.test.ts
@@ -1,0 +1,55 @@
+/** @jest-environment jsdom */
+
+import { MentionTextHighlighter } from '@/features/chat/ui/MentionTextHighlighter';
+
+describe('MentionTextHighlighter', () => {
+  function createFixture() {
+    const wrapper = document.createElement('div');
+    const highlights = document.createElement('div');
+    const input = document.createElement('textarea');
+    wrapper.append(highlights, input);
+    document.body.appendChild(wrapper);
+    return { highlights, input, wrapper };
+  }
+
+  it('emphasizes file and folder mentions while preserving the full input text', () => {
+    const { highlights, input, wrapper } = createFixture();
+    input.value = 'Review @notes/plan.md and @src/ before sending.';
+    const highlighter = new MentionTextHighlighter(input, highlights);
+
+    expect(highlights.textContent).toBe(input.value);
+    expect([...highlights.querySelectorAll('.claudian-input-mention-highlight')]
+      .map(element => element.textContent)).toEqual(['@notes/plan.md', '@src/']);
+
+    highlighter.destroy();
+    wrapper.remove();
+  });
+
+  it('refreshes after a mention is selected from the dropdown', () => {
+    const { highlights, input, wrapper } = createFixture();
+    const highlighter = new MentionTextHighlighter(input, highlights);
+
+    input.value = '@notes/plan.md ';
+    input.dispatchEvent(new Event('claudian:mention-inserted'));
+
+    expect(highlights.querySelector('.claudian-input-mention-highlight')?.textContent)
+      .toBe('@notes/plan.md');
+
+    highlighter.destroy();
+    wrapper.remove();
+  });
+
+  it('keeps its mirrored text aligned with textarea scrolling', () => {
+    const { highlights, input, wrapper } = createFixture();
+    const highlighter = new MentionTextHighlighter(input, highlights);
+    input.scrollLeft = 12;
+    input.scrollTop = 24;
+    input.dispatchEvent(new Event('scroll'));
+
+    expect((highlights.firstElementChild as HTMLElement).style.transform)
+      .toBe('translate(-12px, -24px)');
+
+    highlighter.destroy();
+    wrapper.remove();
+  });
+});

--- a/tests/unit/shared/mention/MentionDropdownController.test.ts
+++ b/tests/unit/shared/mention/MentionDropdownController.test.ts
@@ -41,6 +41,7 @@ function createMockInput() {
     focus: jest.fn(),
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
   } as any;
 }
 

--- a/tests/unit/style/components/input.test.ts
+++ b/tests/unit/style/components/input.test.ts
@@ -43,4 +43,16 @@ describe('Chat input toolbar styles', () => {
       /\.oh-my-claudian-root \.claudian-input-send-button:hover:not\(:disabled\)\s*\{[\s\S]*?background:\s*color-mix\(in srgb, var\(--oh-my-claudian-brand\)/,
     );
   });
+
+  it('does not let inline mention highlighting change textarea text metrics', () => {
+    expect(css).toMatch(
+      /\.claudian-input-mention-highlight\s*\{[^}]*padding:\s*0;/,
+    );
+    expect(css).toMatch(
+      /\.claudian-input-wrapper textarea\.claudian-input\s*\{[\s\S]*?line-height:\s*1\.4;/,
+    );
+    expect(css).toMatch(
+      /\.claudian-input-mention-highlights\s*\{[\s\S]*?line-height:\s*1\.4;/,
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- restore selected file and folder references as editable @ text in the composer
- highlight inline file mentions without creating context chips
- preserve textarea cursor alignment by keeping highlights metric-neutral

## Verification
- pnpm run typecheck
- pnpm run lint (existing warnings only)
- pnpm run test
- pnpm run build