### PR TITLE
refactor: split input turn submission

### DIFF
--- a/src/features/chat/controllers/BuiltInCommandController.ts
+++ b/src/features/chat/controllers/BuiltInCommandController.ts
@@ -1,0 +1,79 @@
+import { Notice } from 'obsidian';
+
+import {
+  type BuiltInCommand,
+  isBuiltInCommandSupported,
+} from '../../../core/commands/builtInCommands';
+import type { ProviderCapabilities } from '../../../core/providers/types';
+import type { AddExternalContextResult } from '../ui/InputToolbar';
+
+export interface BuiltInCommandControllerDeps {
+  getCapabilities: () => ProviderCapabilities;
+  createNewConversation: () => Promise<void>;
+  handleNewConversationCommand?: () => Promise<boolean>;
+  getExternalContextSelector: () => {
+    addExternalContext: (path: string) => AddExternalContextResult;
+  } | null;
+  showResumeDropdown: () => void;
+  onForkAll?: () => Promise<void>;
+  toggleFastMode?: () => Promise<boolean>;
+}
+
+/** Routes provider-neutral slash commands to the feature-owned capabilities. */
+export class BuiltInCommandController {
+  constructor(private readonly deps: BuiltInCommandControllerDeps) {}
+
+  async execute(command: BuiltInCommand, args: string): Promise<void> {
+    const capabilities = this.deps.getCapabilities();
+    if (!isBuiltInCommandSupported(command, capabilities)) {
+      new Notice(`/${command.name} is not supported by this provider.`);
+      return;
+    }
+
+    switch (command.action) {
+      case 'clear': {
+        const handled = await this.deps.handleNewConversationCommand?.() ?? false;
+        if (!handled) await this.deps.createNewConversation();
+        return;
+      }
+      case 'add-dir': {
+        const selector = this.deps.getExternalContextSelector();
+        if (!selector) {
+          new Notice('External context selector not available.');
+          return;
+        }
+        const result = selector.addExternalContext(args);
+        new Notice(result.success ? `Added external context: ${result.normalizedPath}` : result.error);
+        return;
+      }
+      case 'resume':
+        this.deps.showResumeDropdown();
+        return;
+      case 'fork':
+        if (!capabilities.supportsFork) {
+          new Notice('Fork is not supported by this provider.');
+        } else if (!this.deps.onForkAll) {
+          new Notice('Fork not available.');
+        } else {
+          await this.deps.onForkAll();
+        }
+        return;
+      case 'fast':
+        try {
+          const toggled = await this.deps.toggleFastMode?.() ?? false;
+          if (!toggled) {
+            new Notice('Fast mode is not available for this model.');
+          }
+        } catch {
+          new Notice('Failed to toggle fast mode.');
+        }
+        return;
+      default: {
+        const action = typeof (command as { action?: unknown }).action === 'string'
+          ? (command as { action: string }).action
+          : 'unknown';
+        new Notice(`Unknown command: ${action}`);
+      }
+    }
+  }
+}

--- a/src/features/chat/controllers/ComposerAutoScroll.ts
+++ b/src/features/chat/controllers/ComposerAutoScroll.ts
@@ -1,0 +1,13 @@
+/** Schedules a guarded composer-driven scroll after render updates. */
+export function syncComposerAutoScroll(
+  isEnabled: () => boolean,
+  isAutoScrollActive: () => boolean,
+  getMessagesEl: () => HTMLElement,
+): void {
+  if (!isEnabled() || !isAutoScrollActive()) return;
+  window.requestAnimationFrame(() => {
+    if (!isEnabled() || !isAutoScrollActive()) return;
+    const messagesEl = getMessagesEl();
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+  });
+}

--- a/src/features/chat/controllers/ComposerDraft.ts
+++ b/src/features/chat/controllers/ComposerDraft.ts
@@ -1,0 +1,10 @@
+import type { QueuedMessage } from '../state/types';
+import { createQueuedMessage } from './QueuedTurn';
+
+export function captureComposerDraft(
+  content: string,
+  images: QueuedMessage['images'],
+): QueuedMessage | null {
+  if (!content.trim() && !images?.length) return null;
+  return createQueuedMessage(content, { images, text: content });
+}

--- a/src/features/chat/controllers/DeferredReviewableSettlement.ts
+++ b/src/features/chat/controllers/DeferredReviewableSettlement.ts
@@ -1,0 +1,28 @@
+/** Defers review attention while a queued continuation starts in the same conversation. */
+export class DeferredReviewableSettlement {
+  private pending: { conversationId: string | null; report: () => void } | null = null;
+
+  defer(conversationId: string | null, report: (() => void) | null): void {
+    if (report) this.pending = { conversationId, report };
+  }
+
+  hasFor(conversationId: string | null): boolean {
+    this.discardForDifferentConversation(conversationId);
+    return this.pending !== null;
+  }
+
+  takeFor(conversationId: string | null): (() => void) | null {
+    if (!this.hasFor(conversationId)) return null;
+    const report = this.pending?.report ?? null;
+    this.clear();
+    return report;
+  }
+
+  discardForDifferentConversation(conversationId: string | null): void {
+    if (this.pending?.conversationId !== conversationId) this.clear();
+  }
+
+  clear(): void {
+    this.pending = null;
+  }
+}

--- a/src/features/chat/controllers/InputContainerVisibility.ts
+++ b/src/features/chat/controllers/InputContainerVisibility.ts
@@ -1,0 +1,23 @@
+/** Balances temporary composer hiding across overlapping inline interactions. */
+export class InputContainerVisibility {
+  private hideDepth = 0;
+
+  hide(inputContainerEl: HTMLElement): void {
+    this.hideDepth++;
+    inputContainerEl.addClass('claudian-hidden');
+  }
+
+  restore(inputContainerEl: HTMLElement): void {
+    if (this.hideDepth <= 0) return;
+    this.hideDepth--;
+    if (this.hideDepth === 0) {
+      inputContainerEl.removeClass('claudian-hidden');
+    }
+  }
+
+  reset(inputContainerEl: HTMLElement): void {
+    if (this.hideDepth <= 0) return;
+    this.hideDepth = 0;
+    inputContainerEl.removeClass('claudian-hidden');
+  }
+}

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -51,6 +51,7 @@ import type { StatusPanel } from '../ui/StatusPanel';
 import type { BrowserSelectionController } from './BrowserSelectionController';
 import { BuiltInCommandController } from './BuiltInCommandController';
 import type { CanvasSelectionController } from './CanvasSelectionController';
+import { captureComposerDraft } from './ComposerDraft';
 import type { ConversationController } from './ConversationController';
 import { DeferredReviewableSettlement } from './DeferredReviewableSettlement';
 import { InputContainerVisibility } from './InputContainerVisibility';
@@ -929,14 +930,7 @@ export class InputController {
     const content = this.deps.getInputEl().value;
     const attachedImages = this.deps.getImageContextManager()?.getAttachedImages() ?? [];
     const images = attachedImages.length > 0 ? [...attachedImages] : undefined;
-    if (!content.trim() && !images) {
-      return null;
-    }
-
-    return createQueuedMessage(content, {
-      text: content,
-      images,
-    });
+    return captureComposerDraft(content, images);
   }
 
   private restoreQueuedMessageToInput(): void {

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -594,7 +594,6 @@ export class InputController {
             }
           }
           this.finishStreamingState(streamController);
-
           // Capture response duration before resetting state (skip for interrupted responses and compaction)
           const hasCompactBoundary = finalAssistantMsg.contentBlocks?.some(b => b.type === 'context_compacted');
           if (!didCancelThisTurn && !hasCompactBoundary) {
@@ -617,20 +616,7 @@ export class InputController {
             }
           }
 
-          const finalMessageEl = state.currentContentEl?.closest<HTMLElement>('.claudian-message') ?? null;
-          state.currentContentEl = null;
-
-          await streamController.finalizeCurrentThinkingBlock(finalAssistantMsg);
-          await streamController.finalizeCurrentTextBlock(finalAssistantMsg);
-          renderer.renderFinalMessageTimestamp?.(finalMessageEl, finalAssistantMsg);
-          this.deps.getSubagentManager().resetStreamingState();
-
-          // Auto-hide completed todo panel on response end
-          // Panel reappears only when new TodoWrite tool is called
-          if (state.currentTodos && state.currentTodos.every(t => t.status === 'completed')) {
-            state.currentTodos = null;
-          }
-          this.syncScrollToBottomAfterRenderUpdates();
+          await this.finalizeRenderedTurn(finalAssistantMsg);
 
           // approve-new-session: the tool_result chunk is dropped because cancelRequested
           // was set before the stream loop could process it — manually set the result so
@@ -775,6 +761,18 @@ export class InputController {
     streamController.hideThinkingIndicator();
     this.deps.state.isStreaming = false;
     this.deps.state.cancelRequested = false;
+  }
+
+  private async finalizeRenderedTurn(message: ChatMessage): Promise<void> {
+    const { renderer, state, streamController } = this.deps;
+    const messageEl = state.currentContentEl?.closest<HTMLElement>('.claudian-message') ?? null;
+    state.currentContentEl = null;
+    await streamController.finalizeCurrentThinkingBlock(message);
+    await streamController.finalizeCurrentTextBlock(message);
+    renderer.renderFinalMessageTimestamp?.(messageEl, message);
+    this.deps.getSubagentManager().resetStreamingState();
+    if (state.currentTodos?.every(todo => todo.status === 'completed')) state.currentTodos = null;
+    this.syncScrollToBottomAfterRenderUpdates();
   }
 
   private queueStreamingMessage(

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -43,6 +43,7 @@ import type { SubagentManager } from '../services/SubagentManager';
 import type { ChatState } from '../state/ChatState';
 import type { QueuedMessage } from '../state/types';
 import type { ChatTurnRequest } from '../state/types';
+import { dispatchComposerInputEvent } from '../ui/ComposerInputEvents';
 import type { FileContextManager } from '../ui/FileContext';
 import type { ImageContextManager } from '../ui/ImageContext';
 import type { AddExternalContextResult, McpServerSelector } from '../ui/InputToolbar';
@@ -263,9 +264,15 @@ export class InputController {
           userMessageIndex >= 0 ? userMessageIndex : undefined,
         );
       },
-      setComposerText: (text) => { deps.getInputEl().value = text; },
+      setComposerText: (text) => {
+        const inputEl = deps.getInputEl();
+        inputEl.value = text;
+        dispatchComposerInputEvent(inputEl);
+      },
       scheduleCurrentControllerContinuation: (content, reporter) => {
-        deps.getInputEl().value = content;
+        const inputEl = deps.getInputEl();
+        inputEl.value = content;
+        dispatchComposerInputEvent(inputEl);
         this.deferReviewableSettlement(reporter);
         this.sendMessage().catch(() => this.reportDeferredReviewableSettlement());
       },
@@ -387,6 +394,7 @@ export class InputController {
       }
       if (shouldUseInput) {
         inputEl.value = '';
+        dispatchComposerInputEvent(inputEl);
         this.deps.resetInputHeight();
       }
       await this.builtInCommandController.execute(builtInCmd.command, builtInCmd.args);
@@ -691,7 +699,9 @@ export class InputController {
     const turnConversationId = state.currentConversationId;
     this.pendingSteersByConversation.delegateToHistory(turnConversationId);
     if (shouldUseInput) {
-      this.deps.getInputEl().value = '';
+      const inputEl = this.deps.getInputEl();
+      inputEl.value = '';
+      dispatchComposerInputEvent(inputEl);
       this.deps.resetInputHeight();
     }
     state.isStreaming = true;
@@ -778,7 +788,9 @@ export class InputController {
       createQueuedMessage(displayContent, turnRequest),
     );
     if (shouldUseInput) {
-      this.deps.getInputEl().value = '';
+      const inputEl = this.deps.getInputEl();
+      inputEl.value = '';
+      dispatchComposerInputEvent(inputEl);
       this.deps.resetInputHeight();
       imageContextManager?.clearImages();
     }
@@ -885,8 +897,7 @@ export class InputController {
       images: message.images,
     });
     const inputEl = this.deps.getInputEl();
-    const EventConstructor = inputEl.ownerDocument?.defaultView?.Event ?? Event;
-    inputEl.dispatchEvent(new EventConstructor('input', { bubbles: true }));
+    dispatchComposerInputEvent(inputEl);
   }
 
   private restoreMessageToInput(
@@ -901,6 +912,7 @@ export class InputController {
     inputEl.value = currentContent
       ? appendMarkdownSnippet(content, currentContent)
       : content;
+    dispatchComposerInputEvent(inputEl);
 
     const imageContextManager = this.deps.getImageContextManager();
     const currentImages = options.mergeWithComposer

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -1,9 +1,7 @@
 import { Notice, setIcon } from 'obsidian';
 
 import {
-  type BuiltInCommand,
   detectBuiltInCommand,
-  isBuiltInCommandSupported,
 } from '../../../core/commands/builtInCommands';
 import type { ProviderExecutionEvent } from '../../../core/execution';
 import { stringifyDiagnosticError } from '../../../core/providers/ProviderDiagnostics';
@@ -51,6 +49,7 @@ import type { AddExternalContextResult, McpServerSelector } from '../ui/InputToo
 import type { InstructionModeManager } from '../ui/InstructionModeManager';
 import type { StatusPanel } from '../ui/StatusPanel';
 import type { BrowserSelectionController } from './BrowserSelectionController';
+import { BuiltInCommandController } from './BuiltInCommandController';
 import type { CanvasSelectionController } from './CanvasSelectionController';
 import type { ConversationController } from './ConversationController';
 import { InputContainerVisibility } from './InputContainerVisibility';
@@ -194,6 +193,7 @@ export class InputController {
   private readonly turnCoordinator: TurnCoordinator<SendMessageOptions>;
   private readonly turnSubmissionBuilder: TurnSubmissionBuilder;
   private readonly instructionSubmissionController: InstructionSubmissionController;
+  private readonly builtInCommandController: BuiltInCommandController;
 
   constructor(deps: InputControllerDeps) {
     this.deps = deps;
@@ -234,6 +234,15 @@ export class InputController {
       getInputEl: deps.getInputEl,
       getCurrentConversationId: () => deps.state.currentConversationId,
       openConversation: deps.openConversation,
+    });
+    this.builtInCommandController = new BuiltInCommandController({
+      getCapabilities: () => this.getActiveCapabilities(),
+      createNewConversation: () => deps.conversationController.createNew(),
+      handleNewConversationCommand: deps.handleNewConversationCommand,
+      getExternalContextSelector: deps.getExternalContextSelector,
+      showResumeDropdown: () => this.resumeDropdownController.show(),
+      onForkAll: deps.onForkAll,
+      toggleFastMode: deps.toggleFastMode,
     });
   }
 
@@ -356,7 +365,7 @@ export class InputController {
         inputEl.value = '';
         this.deps.resetInputHeight();
       }
-      await this.executeBuiltInCommand(builtInCmd.command, builtInCmd.args);
+      await this.builtInCommandController.execute(builtInCmd.command, builtInCmd.args);
       return;
     }
 
@@ -1782,78 +1791,6 @@ export class InputController {
     }
     this.pendingPlanApproval.destroy();
     this.pendingPlanApproval = null;
-  }
-
-  // ============================================
-  // Built-in Commands
-  // ============================================
-
-  private async executeBuiltInCommand(command: BuiltInCommand, args: string): Promise<void> {
-    const { conversationController } = this.deps;
-    const capabilities = this.getActiveCapabilities();
-
-    if (!isBuiltInCommandSupported(command, capabilities)) {
-      new Notice(`/${command.name} is not supported by this provider.`);
-      return;
-    }
-
-    switch (command.action) {
-      case 'clear': {
-        const handledByLayout = await this.deps.handleNewConversationCommand?.() ?? false;
-        if (!handledByLayout) {
-          await conversationController.createNew();
-        }
-        break;
-      }
-      case 'add-dir': {
-        const externalContextSelector = this.deps.getExternalContextSelector();
-        if (!externalContextSelector) {
-          new Notice('External context selector not available.');
-          return;
-        }
-        const result = externalContextSelector.addExternalContext(args);
-        if (result.success) {
-          new Notice(`Added external context: ${result.normalizedPath}`);
-        } else {
-          new Notice(result.error);
-        }
-        break;
-      }
-      case 'resume':
-        this.resumeDropdownController.show();
-        break;
-      case 'fork': {
-        if (!this.getActiveCapabilities().supportsFork) {
-          new Notice('Fork is not supported by this provider.');
-          return;
-        }
-        if (!this.deps.onForkAll) {
-          new Notice('Fork not available.');
-          return;
-        }
-        await this.deps.onForkAll();
-        break;
-      }
-      case 'fast': {
-        try {
-          const toggled = await this.deps.toggleFastMode?.() ?? false;
-          if (!toggled) {
-            new Notice('Fast mode is not available for this model.');
-          }
-        } catch {
-          new Notice('Failed to toggle fast mode.');
-        }
-        break;
-      }
-      default: {
-        // Unknown command - notify user
-        const unknownAction = typeof (command as { action?: unknown }).action === 'string'
-          ? (command as { action: string }).action
-          : 'unknown';
-        new Notice(`Unknown command: ${unknownAction}`);
-        break;
-      }
-    }
   }
 
   // ============================================

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -61,6 +61,7 @@ import {
   type PendingSteerState,
 } from './PendingSteerRegistry';
 import {
+  cloneChatTurnRequest,
   cloneQueuedMessage,
   createQueuedMessage,
   getQueuedMessageDisplay,
@@ -1794,18 +1795,4 @@ export class InputController {
   destroyResumeDropdown(): void {
     this.resumeDropdownController.destroy();
   }
-}
-
-function cloneChatTurnRequest(request: ChatTurnRequest): ChatTurnRequest {
-  return {
-    ...request,
-    enabledMcpServers: request.enabledMcpServers
-      ? new Set(request.enabledMcpServers)
-      : undefined,
-    externalContextPaths: request.externalContextPaths
-      ? [...request.externalContextPaths]
-      : undefined,
-    contextFiles: request.contextFiles ? [...request.contextFiles] : undefined,
-    images: request.images ? [...request.images] : undefined,
-  };
 }

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -8,7 +8,6 @@ import {
 import type { ProviderExecutionEvent } from '../../../core/execution';
 import { stringifyDiagnosticError } from '../../../core/providers/ProviderDiagnostics';
 import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
-import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import {
   DEFAULT_CHAT_PROVIDER_ID,
   type InstructionRefineService,
@@ -22,7 +21,6 @@ import {
   type ChatMessage,
   type ExitPlanModeDecision,
   type ExitPlanModePresentationOptions,
-  isCanonicalUserMessage,
   type StreamChunk,
 } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
@@ -39,7 +37,6 @@ import { COMPLETION_FLAVOR_WORDS } from '../constants';
 import {
   type ChatExecutionCoordinator,
   ChatExecutionPreHandoffError,
-  type ChatTurnSubmission,
 } from '../execution/ChatExecutionCoordinator';
 import { type InlineAskQuestionConfig, InlineAskUserQuestion } from '../rendering/InlineAskUserQuestion';
 import { InlineExitPlanMode } from '../rendering/InlineExitPlanMode';
@@ -69,6 +66,7 @@ import {
 } from './suspiciousCommandText';
 import type { ActiveTurnOwner } from './TurnCoordinator';
 import { TurnCoordinator } from './TurnCoordinator';
+import { TurnSubmissionBuilder } from './TurnSubmissionBuilder';
 
 const APPROVAL_OPTION_MAP: Record<string, ApprovalDecision> = {
   'Deny': 'deny',
@@ -206,6 +204,7 @@ export class InputController {
     report: () => void;
   } | null = null;
   private readonly turnCoordinator: TurnCoordinator<SendMessageOptions>;
+  private readonly turnSubmissionBuilder: TurnSubmissionBuilder;
 
   constructor(deps: InputControllerDeps) {
     this.deps = deps;
@@ -213,6 +212,20 @@ export class InputController {
       (options) => this.executeSendMessage(options),
       deps.turnOwner,
     );
+    this.turnSubmissionBuilder = new TurnSubmissionBuilder({
+      plugin: deps.plugin,
+      state: deps.state,
+      selectionController: deps.selectionController,
+      browserSelectionController: deps.browserSelectionController,
+      canvasSelectionController: deps.canvasSelectionController,
+      getFileContextManager: deps.getFileContextManager,
+      getMcpServerSelector: deps.getMcpServerSelector,
+      getExternalContextSelector: deps.getExternalContextSelector,
+      getProviderId: () => this.getActiveProviderId(),
+      getProviderCapabilities: () => this.getActiveCapabilities(),
+      getAuxiliaryModel: () => this.getAuxiliaryModel(),
+      generateId: deps.generateId,
+    });
   }
 
   private getExecutionCoordinator(): ChatExecutionCoordinator | null {
@@ -361,7 +374,7 @@ export class InputController {
       const editorContext = selectionController.getContext();
       const browserContext = browserSelectionController?.getContext() ?? null;
       const canvasContext = canvasSelectionController.getContext();
-      const { displayContent, turnRequest } = this.buildTurnSubmission({
+    const { displayContent, turnRequest } = this.turnSubmissionBuilder.buildRequest({
         content,
         images,
         editorContextOverride: editorContext,
@@ -424,7 +437,7 @@ export class InputController {
         displayContent: content,
         turnRequest: cloneChatTurnRequest(options.turnRequestOverride),
       }
-      : this.buildTurnSubmission({
+      : this.turnSubmissionBuilder.buildRequest({
         content,
         images: imagesForMessage,
         editorContextOverride: options?.editorContextOverride,
@@ -522,7 +535,7 @@ export class InputController {
     try {
       userMsg.content = turnRequest.text;
       userMsg.currentNote = isCompact ? undefined : turnRequest.currentNotePath;
-      const result = await coordinator.execute(this.createExecutionSubmission(
+      const result = await coordinator.execute(this.turnSubmissionBuilder.buildExecutionSubmission(
         displayContent,
         turnRequest,
         userMsg,
@@ -991,150 +1004,6 @@ export class InputController {
     this.deferredReviewableSettlement = null;
   }
 
-  private buildTurnSubmission(options: {
-    content: string;
-    images?: ChatMessage['images'];
-    editorContextOverride?: EditorSelectionContext | null;
-    browserContextOverride?: BrowserSelectionContext | null;
-    canvasContextOverride?: CanvasSelectionContext | null;
-  }): {
-    displayContent: string;
-    turnRequest: ChatTurnRequest;
-  } {
-    const {
-      selectionController,
-      browserSelectionController,
-      canvasSelectionController,
-    } = this.deps;
-
-    const fileContextManager = this.deps.getFileContextManager();
-    const mcpServerSelector = this.deps.getMcpServerSelector();
-    const externalContextSelector = this.deps.getExternalContextSelector();
-
-    const currentNotePath = fileContextManager?.getCurrentNotePath() || null;
-    const shouldSendCurrentNote = fileContextManager?.shouldSendCurrentNote(currentNotePath) ?? false;
-
-    const editorContext = options.editorContextOverride !== undefined
-      ? options.editorContextOverride
-      : selectionController.getContext();
-    const browserContext = options.browserContextOverride !== undefined
-      ? options.browserContextOverride
-      : (browserSelectionController?.getContext() ?? null);
-    const canvasContext = options.canvasContextOverride !== undefined
-      ? options.canvasContextOverride
-      : canvasSelectionController.getContext();
-
-    const externalContextPaths = externalContextSelector?.getExternalContexts();
-    const isCompact = /^\/compact(\s|$)/i.test(options.content);
-    const transformedText = !isCompact && fileContextManager
-      ? fileContextManager.transformContextMentions(options.content)
-      : options.content;
-    const enabledMcpServers = mcpServerSelector?.getEnabledServers();
-    const contextFiles = fileContextManager?.getAttachedFiles?.();
-
-    return {
-      displayContent: options.content,
-      turnRequest: {
-        text: transformedText,
-        images: options.images,
-        currentNotePath: shouldSendCurrentNote && currentNotePath ? currentNotePath : undefined,
-        editorSelection: editorContext,
-        browserSelection: browserContext,
-        canvasSelection: canvasContext,
-        externalContextPaths: externalContextPaths && externalContextPaths.length > 0
-          ? externalContextPaths
-          : undefined,
-        contextFiles: contextFiles && contextFiles.size > 0 ? [...contextFiles] : undefined,
-        enabledMcpServers: enabledMcpServers && enabledMcpServers.size > 0
-          ? enabledMcpServers
-          : undefined,
-      },
-    };
-  }
-
-  private createExecutionSubmission(
-    displayContent: string,
-    request: ChatTurnRequest,
-    user?: ChatMessage,
-    assistant?: ChatMessage,
-  ): ChatTurnSubmission {
-    const providerId = this.getActiveProviderId();
-    const settings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
-      this.deps.plugin.settings,
-      providerId,
-    );
-    const reasoning = typeof settings.effortLevel === 'string'
-      ? settings.effortLevel
-      : typeof settings.thinkingBudget === 'string'
-        ? settings.thinkingBudget
-        : undefined;
-    const permissionMode = typeof settings.permissionMode === 'string'
-      ? settings.permissionMode
-      : undefined;
-    const serviceTier = typeof settings.serviceTier === 'string'
-      ? settings.serviceTier
-      : undefined;
-    const mode = permissionMode === 'plan' && this.getActiveCapabilities().supportsPlanMode
-      ? permissionMode
-      : undefined;
-    const customSystemPrompt = typeof this.deps.plugin.settings.systemPrompt === 'string'
-      ? this.deps.plugin.settings.systemPrompt.trim()
-      : '';
-    const images = [...(request.images ?? [])];
-    const existingUserTurns = this.deps.state.messages.filter(isCanonicalUserMessage).length;
-
-    return {
-      canonicalText: request.text,
-      configuration: {
-        ...(request.enabledMcpServers
-          ? { enabledMcpServers: [...request.enabledMcpServers] }
-          : {}),
-        ...(request.externalContextPaths
-          ? { externalWorkspaceRoots: [...request.externalContextPaths] }
-          : {}),
-        ...(this.getAuxiliaryModel()
-          ? { model: this.getAuxiliaryModel() ?? undefined }
-          : {}),
-        ...(permissionMode ? { permissionMode } : {}),
-        ...(mode ? { mode } : {}),
-        ...(reasoning ? { reasoning } : {}),
-        ...(serviceTier ? { serviceTier } : {}),
-        systemInstructions: customSystemPrompt
-          ? { kind: 'explicit', instructions: customSystemPrompt }
-          : { kind: 'none' },
-      },
-      context: {
-        ...(request.browserSelection
-          ? { browserSelection: request.browserSelection }
-          : {}),
-        ...(request.canvasSelection
-          ? { canvasSelection: request.canvasSelection }
-          : {}),
-        ...(request.currentNotePath
-          ? { currentNote: { path: request.currentNotePath } }
-          : {}),
-        ...(request.editorSelection
-          ? { editorSelection: request.editorSelection }
-          : {}),
-        ...(request.externalContextPaths
-          ? { externalContextPaths: [...request.externalContextPaths] }
-          : {}),
-        ...(request.contextFiles ? { contextFiles: [...request.contextFiles] } : {}),
-      },
-      conversationHistory: user && assistant
-        ? this.deps.state.messages.slice(0, -2)
-        : [...this.deps.state.messages],
-      images,
-      inputRecordId: this.deps.generateId(),
-      ...(user ? { localMessageId: user.id } : {}),
-      ...(user && assistant ? { messages: { assistant, user } } : {}),
-      rawDisplayText: displayContent,
-      timestamp: user?.timestamp ?? Date.now(),
-      toolPolicy: { kind: 'provider-default' },
-      userTurnOrdinal: user ? existingUserTurns : existingUserTurns + 1,
-    };
-  }
-
   private getQueuedMessageDisplay(message: QueuedMessage | null): string {
     if (!message) {
       return '';
@@ -1360,7 +1229,7 @@ export class InputController {
     const queuedMessage = this.cloneQueuedMessage(state.queuedMessage);
     state.queuedMessage = null;
     const { displayContent, request } = this.toQueuedChatTurn(queuedMessage);
-    const submission = this.createExecutionSubmission(displayContent, request);
+    const submission = this.turnSubmissionBuilder.buildExecutionSubmission(displayContent, request);
     const pending: PendingSteerState = {
       conversationId,
       coordinator,

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -55,6 +55,13 @@ import type { StatusPanel } from '../ui/StatusPanel';
 import type { BrowserSelectionController } from './BrowserSelectionController';
 import type { CanvasSelectionController } from './CanvasSelectionController';
 import type { ConversationController } from './ConversationController';
+import {
+  cloneQueuedMessage,
+  createQueuedMessage,
+  getQueuedMessageDisplay,
+  mergeQueuedMessages,
+  toQueuedChatTurn,
+} from './QueuedTurn';
 import type { SelectionController } from './SelectionController';
 import {
   providerOutputEventToStreamChunk,
@@ -381,9 +388,9 @@ export class InputController {
         browserContextOverride: browserContext,
         canvasContextOverride: canvasContext,
       });
-      state.queuedMessage = this.mergeQueuedMessages(
+      state.queuedMessage = mergeQueuedMessages(
         state.queuedMessage,
-        this.createQueuedMessage(displayContent, turnRequest),
+        createQueuedMessage(displayContent, turnRequest),
       );
 
       if (shouldUseInput) {
@@ -465,7 +472,7 @@ export class InputController {
     try {
       await this.triggerTitleGeneration();
     } catch (error) {
-      this.restoreMessageToInput(this.createQueuedMessage(displayContent, turnRequest));
+      this.restoreMessageToInput(createQueuedMessage(displayContent, turnRequest));
       this.rollbackFailedTurn(messagesBeforeTurn, hadPendingConversationSave);
       throw error;
     }
@@ -512,7 +519,7 @@ export class InputController {
       const ready = await this.deps.ensureExecutionInitialized();
       if (!ready) {
         new Notice('Failed to initialize agent execution. Please try again.');
-        this.restoreMessageToInput(this.createQueuedMessage(displayContent, turnRequest));
+        this.restoreMessageToInput(createQueuedMessage(displayContent, turnRequest));
         this.rollbackFailedTurn(messagesBeforeTurn, hadPendingConversationSave);
         this.activeStreamingAssistantMessage = null;
         this.resetProviderMessageBoundaryState();
@@ -524,7 +531,7 @@ export class InputController {
     const coordinator = this.getExecutionCoordinator();
     if (!coordinator) {
       new Notice('Agent execution is not available. Please reload the plugin.');
-      this.restoreMessageToInput(this.createQueuedMessage(displayContent, turnRequest));
+      this.restoreMessageToInput(createQueuedMessage(displayContent, turnRequest));
       this.rollbackFailedTurn(messagesBeforeTurn, hadPendingConversationSave);
       this.activeStreamingAssistantMessage = null;
       this.resetProviderMessageBoundaryState();
@@ -558,12 +565,12 @@ export class InputController {
       } else if (result.status === 'missing-session') {
         const retryMessage = result.accepted
           ? null
-          : this.createQueuedMessage(displayContent, {
+          : createQueuedMessage(displayContent, {
             ...turnRequest,
             images: imagesForMessage ?? turnRequest.images,
           });
         const pendingMessagesToRestore = state.queuedMessage
-          ? this.cloneQueuedMessage(state.queuedMessage)
+          ? cloneQueuedMessage(state.queuedMessage)
           : null;
         const composerDraftToRestore = this.captureComposerDraft();
         const resolution = result.missingSessionResolution ?? 'not_found';
@@ -593,7 +600,7 @@ export class InputController {
     } catch (error) {
       if (error instanceof ChatExecutionPreHandoffError) {
         this.restoreMessageToInput(
-          this.createQueuedMessage(displayContent, turnRequest),
+          createQueuedMessage(displayContent, turnRequest),
           { mergeWithComposer: true },
         );
         this.rollbackFailedTurn(messagesBeforeTurn, hadPendingConversationSave);
@@ -805,7 +812,7 @@ export class InputController {
       const isPendingSteerOnly = !state.queuedMessage && !!visiblePendingSteer;
       indicatorEl.createSpan({
         cls: 'claudian-queue-indicator-text',
-        text: `${isPendingSteerOnly ? '⌙ Steering: ' : '⌙ Queued: '}${this.getQueuedMessageDisplay(visibleQueuedMessage)}`,
+        text: `${isPendingSteerOnly ? '⌙ Steering: ' : '⌙ Queued: '}${getQueuedMessageDisplay(visibleQueuedMessage)}`,
       });
 
       if (state.queuedMessage) {
@@ -869,7 +876,7 @@ export class InputController {
     const { state } = this.deps;
     if (!state.queuedMessage) return;
 
-    const queuedMessage = this.cloneQueuedMessage(state.queuedMessage);
+    const queuedMessage = cloneQueuedMessage(state.queuedMessage);
     state.queuedMessage = null;
     this.restoreMessageToInput(queuedMessage, { mergeWithComposer: true });
     this.updateQueueIndicator();
@@ -922,7 +929,7 @@ export class InputController {
       return null;
     }
 
-    return this.createQueuedMessage(content, {
+    return createQueuedMessage(content, {
       text: content,
       images,
     });
@@ -931,7 +938,7 @@ export class InputController {
   private restoreQueuedMessageToInput(): void {
     const { state } = this.deps;
     const queuedMessage = state.queuedMessage
-      ? this.cloneQueuedMessage(state.queuedMessage)
+      ? cloneQueuedMessage(state.queuedMessage)
       : null;
     this.restoreMessageToInput(queuedMessage, { mergeWithComposer: true });
     state.queuedMessage = null;
@@ -942,7 +949,7 @@ export class InputController {
     const { state } = this.deps;
     if (!state.queuedMessage) return false;
 
-    const queuedMessage = this.cloneQueuedMessage(state.queuedMessage);
+    const queuedMessage = cloneQueuedMessage(state.queuedMessage);
     state.queuedMessage = null;
     this.updateQueueIndicator();
 
@@ -951,7 +958,7 @@ export class InputController {
         void this.sendMessage({
           content: queuedMessage.content,
           images: queuedMessage.images,
-          turnRequestOverride: this.toQueuedChatTurn(queuedMessage).request,
+          turnRequestOverride: toQueuedChatTurn(queuedMessage).request,
         }).catch(() => this.reportDeferredReviewableSettlement());
       },
       0
@@ -1004,24 +1011,6 @@ export class InputController {
     this.deferredReviewableSettlement = null;
   }
 
-  private getQueuedMessageDisplay(message: QueuedMessage | null): string {
-    if (!message) {
-      return '';
-    }
-
-    const rawContent = message.content.trim();
-    const preview = rawContent.length > 40
-      ? rawContent.slice(0, 40) + '...'
-      : rawContent;
-    const hasImages = (message.images?.length ?? 0) > 0;
-
-    if (hasImages) {
-      return preview ? `${preview} [images]` : '[images]';
-    }
-
-    return preview;
-  }
-
   private createQueueIconButton(
     parentEl: HTMLElement,
     icon: string,
@@ -1044,51 +1033,6 @@ export class InputController {
       && this.getCurrentPendingSteer() === null
       && this.getActiveCapabilities().supportsTurnSteer === true
       && this.getExecutionCoordinator() !== null;
-  }
-
-  private cloneQueuedMessage(message: QueuedMessage): QueuedMessage {
-    return {
-      ...message,
-      images: message.images ? [...message.images] : undefined,
-      turnRequest: message.turnRequest
-        ? cloneChatTurnRequest(message.turnRequest)
-        : undefined,
-    };
-  }
-
-  private createQueuedMessage(displayContent: string, turnRequest: ChatTurnRequest): QueuedMessage {
-    const request = cloneChatTurnRequest(turnRequest);
-    return {
-      content: displayContent,
-      images: request.images,
-      editorContext: request.editorSelection ?? null,
-      browserContext: request.browserSelection ?? null,
-      canvasContext: request.canvasSelection ?? null,
-      turnRequest: request,
-    };
-  }
-
-  private toQueuedChatTurn(message: QueuedMessage): {
-    displayContent: string;
-    request: ChatTurnRequest;
-  } {
-    if (message.turnRequest) {
-      return {
-        displayContent: message.content,
-        request: cloneChatTurnRequest(message.turnRequest),
-      };
-    }
-
-    return {
-      displayContent: message.content,
-      request: {
-        text: message.content,
-        images: message.images ? [...message.images] : undefined,
-        editorSelection: message.editorContext,
-        browserSelection: message.browserContext ?? null,
-        canvasSelection: message.canvasContext,
-      },
-    };
   }
 
   private getCurrentPendingSteer(): PendingSteerState | null {
@@ -1175,8 +1119,8 @@ export class InputController {
     const { state } = this.deps;
     if (state.isStreaming && !state.cancelRequested) {
       state.queuedMessage = state.queuedMessage
-        ? this.mergeQueuedMessages(pending.message, state.queuedMessage)
-        : this.cloneQueuedMessage(pending.message);
+        ? mergeQueuedMessages(pending.message, state.queuedMessage)
+        : cloneQueuedMessage(pending.message);
     } else {
       this.restoreMessageToInput(pending.message, { mergeWithComposer: true });
     }
@@ -1202,21 +1146,6 @@ export class InputController {
     this.updateQueueIndicator();
   }
 
-  private mergeQueuedMessages(
-    existing: QueuedMessage | null,
-    incoming: QueuedMessage,
-  ): QueuedMessage {
-    if (!existing) {
-      return this.cloneQueuedMessage(incoming);
-    }
-
-    const mergedTurn = mergeQueuedChatTurns(
-      this.toQueuedChatTurn(existing),
-      this.toQueuedChatTurn(incoming),
-    );
-    return this.createQueuedMessage(mergedTurn.displayContent, mergedTurn.request);
-  }
-
   private async steerQueuedMessage(): Promise<void> {
     const { state } = this.deps;
     const coordinator = this.getExecutionCoordinator();
@@ -1226,9 +1155,9 @@ export class InputController {
     }
     if (!conversationId) return;
 
-    const queuedMessage = this.cloneQueuedMessage(state.queuedMessage);
+    const queuedMessage = cloneQueuedMessage(state.queuedMessage);
     state.queuedMessage = null;
-    const { displayContent, request } = this.toQueuedChatTurn(queuedMessage);
+    const { displayContent, request } = toQueuedChatTurn(queuedMessage);
     const submission = this.turnSubmissionBuilder.buildExecutionSubmission(displayContent, request);
     const pending: PendingSteerState = {
       conversationId,
@@ -2172,45 +2101,5 @@ function cloneChatTurnRequest(request: ChatTurnRequest): ChatTurnRequest {
       : undefined,
     contextFiles: request.contextFiles ? [...request.contextFiles] : undefined,
     images: request.images ? [...request.images] : undefined,
-  };
-}
-
-function mergeQueuedChatTurns(
-  existing: { displayContent: string; request: ChatTurnRequest },
-  incoming: { displayContent: string; request: ChatTurnRequest },
-): { displayContent: string; request: ChatTurnRequest } {
-  const mergeText = (first: string, second: string) => (
-    [first, second].map(value => value.trim()).filter(Boolean).join('\n\n')
-  );
-  const externalContextPaths = Array.from(new Set([
-    ...(existing.request.externalContextPaths ?? []),
-    ...(incoming.request.externalContextPaths ?? []),
-  ]));
-  const contextFiles = Array.from(new Set([
-    ...(existing.request.contextFiles ?? []),
-    ...(incoming.request.contextFiles ?? []),
-  ]));
-  const enabledMcpServers = new Set([
-    ...(existing.request.enabledMcpServers ?? []),
-    ...(incoming.request.enabledMcpServers ?? []),
-  ]);
-  const images = [
-    ...(existing.request.images ?? []),
-    ...(incoming.request.images ?? []),
-  ];
-  return {
-    displayContent: mergeText(existing.displayContent, incoming.displayContent),
-    request: {
-      ...cloneChatTurnRequest(incoming.request),
-      currentNotePath:
-        incoming.request.currentNotePath ?? existing.request.currentNotePath,
-      enabledMcpServers:
-        enabledMcpServers.size > 0 ? enabledMcpServers : undefined,
-      externalContextPaths:
-        externalContextPaths.length > 0 ? externalContextPaths : undefined,
-      contextFiles: contextFiles.length > 0 ? contextFiles : undefined,
-      images: images.length > 0 ? images : undefined,
-      text: mergeText(existing.request.text, incoming.request.text),
-    },
   };
 }

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -52,6 +52,7 @@ import type { BrowserSelectionController } from './BrowserSelectionController';
 import { BuiltInCommandController } from './BuiltInCommandController';
 import type { CanvasSelectionController } from './CanvasSelectionController';
 import type { ConversationController } from './ConversationController';
+import { DeferredReviewableSettlement } from './DeferredReviewableSettlement';
 import { InputContainerVisibility } from './InputContainerVisibility';
 import { InstructionSubmissionController } from './InstructionSubmissionController';
 import {
@@ -186,10 +187,7 @@ export class InputController {
   private pendingProviderUserMessages: PendingProviderUserMessage[] = [];
   private sawInitialProviderUserMessage = false;
   private awaitingProviderAssistantStart = false;
-  private deferredReviewableSettlement: {
-    conversationId: string | null;
-    report: () => void;
-  } | null = null;
+  private readonly deferredReviewableSettlement = new DeferredReviewableSettlement();
   private readonly turnCoordinator: TurnCoordinator<SendMessageOptions>;
   private readonly turnSubmissionBuilder: TurnSubmissionBuilder;
   private readonly instructionSubmissionController: InstructionSubmissionController;
@@ -972,48 +970,36 @@ export class InputController {
   }
 
   private deferReviewableSettlement(report: (() => void) | null): void {
-    if (!report) return;
-    this.deferredReviewableSettlement = {
-      conversationId: this.deps.state.currentConversationId,
-      report,
-    };
+    this.deferredReviewableSettlement.defer(this.deps.state.currentConversationId, report);
   }
 
   private hasDeferredReviewableSettlement(): boolean {
     this.discardDeferredReviewForDifferentConversation();
-    return this.deferredReviewableSettlement !== null;
+    return this.deferredReviewableSettlement.hasFor(this.deps.state.currentConversationId);
   }
 
   private reportDeferredReviewableSettlement(): void {
     if (!this.hasDeferredReviewableSettlement()) return;
-    const deferred = this.deferredReviewableSettlement;
-    this.clearDeferredReviewableSettlement();
-    deferred?.report();
+    this.deferredReviewableSettlement.takeFor(this.deps.state.currentConversationId)?.();
   }
 
   private reportCurrentOrDeferredReviewableSettlement(
     currentReporter: (() => void) | null,
   ): void {
     const reporter = currentReporter
-      ?? (this.hasDeferredReviewableSettlement()
-        ? this.deferredReviewableSettlement?.report ?? null
-        : null);
+      ?? this.deferredReviewableSettlement.takeFor(this.deps.state.currentConversationId);
     this.clearDeferredReviewableSettlement();
     reporter?.();
   }
 
   private discardDeferredReviewForDifferentConversation(): void {
-    if (
-      this.deferredReviewableSettlement !== null
-      && this.deferredReviewableSettlement.conversationId
-        !== this.deps.state.currentConversationId
-    ) {
-      this.clearDeferredReviewableSettlement();
-    }
+    this.deferredReviewableSettlement.discardForDifferentConversation(
+      this.deps.state.currentConversationId,
+    );
   }
 
   private clearDeferredReviewableSettlement(): void {
-    this.deferredReviewableSettlement = null;
+    this.deferredReviewableSettlement.clear();
   }
 
   private createQueueIconButton(

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -24,7 +24,6 @@ import {
   type StreamChunk,
 } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
-import { ResumeSessionDropdown } from '../../../shared/components/ResumeSessionDropdown';
 import type { BrowserSelectionContext } from '../../../utils/browser';
 import type { CanvasSelectionContext } from '../../../utils/canvas';
 import { extractUserDisplayContent } from '../../../utils/context';
@@ -68,6 +67,7 @@ import {
   mergeQueuedMessages,
   toQueuedChatTurn,
 } from './QueuedTurn';
+import { ResumeDropdownController } from './ResumeDropdownController';
 import type { SelectionController } from './SelectionController';
 import {
   providerOutputEventToStreamChunk,
@@ -180,7 +180,7 @@ export class InputController {
   private pendingExitPlanModeInline: InlineExitPlanMode | null = null;
   private pendingPlanApproval: InlinePlanApproval | null = null;
   private pendingPlanApprovalInvalidated = false;
-  private activeResumeDropdown: ResumeSessionDropdown | null = null;
+  private readonly resumeDropdownController: ResumeDropdownController;
   private readonly inputContainerVisibility = new InputContainerVisibility();
   private readonly pendingSteersByConversation: PendingSteerRegistry;
   private activeStreamingAssistantMessage: ChatMessage | null = null;
@@ -226,6 +226,14 @@ export class InputController {
       getInstructionModeManager: deps.getInstructionModeManager,
       getModelOverride: () => this.getAuxiliaryModel(),
       ensureExecutionInitialized: deps.ensureExecutionInitialized,
+    });
+    this.resumeDropdownController = new ResumeDropdownController({
+      plugin: deps.plugin,
+      conversationController: deps.conversationController,
+      getInputContainerEl: deps.getInputContainerEl,
+      getInputEl: deps.getInputEl,
+      getCurrentConversationId: () => deps.state.currentConversationId,
+      openConversation: deps.openConversation,
     });
   }
 
@@ -1812,7 +1820,7 @@ export class InputController {
         break;
       }
       case 'resume':
-        this.showResumeDropdown();
+        this.resumeDropdownController.show();
         break;
       case 'fork': {
         if (!this.getActiveCapabilities().supportsFork) {
@@ -1853,54 +1861,15 @@ export class InputController {
   // ============================================
 
   handleResumeKeydown(e: KeyboardEvent): boolean {
-    if (!this.activeResumeDropdown?.isVisible()) return false;
-    return this.activeResumeDropdown.handleKeydown(e);
+    return this.resumeDropdownController.handleKeydown(e);
   }
 
   isResumeDropdownVisible(): boolean {
-    return this.activeResumeDropdown?.isVisible() ?? false;
+    return this.resumeDropdownController.isVisible();
   }
 
   destroyResumeDropdown(): void {
-    if (this.activeResumeDropdown) {
-      this.activeResumeDropdown.destroy();
-      this.activeResumeDropdown = null;
-    }
-  }
-
-  private showResumeDropdown(): void {
-    const { plugin, state, conversationController } = this.deps;
-
-    // Clean up any existing dropdown
-    this.destroyResumeDropdown();
-
-    const conversations = plugin.getConversationList();
-    if (conversations.length === 0) {
-      new Notice('No conversations to resume');
-      return;
-    }
-
-    const openConversation = this.deps.openConversation
-      ?? ((id: string) => conversationController.switchTo(id));
-
-    this.activeResumeDropdown = new ResumeSessionDropdown(
-      this.deps.getInputContainerEl(),
-      this.deps.getInputEl(),
-      conversations,
-      state.currentConversationId,
-      {
-        onSelect: (id) => {
-          this.destroyResumeDropdown();
-          openConversation(id).catch((err: unknown) => {
-            const msg = err instanceof Error ? err.message : String(err);
-            new Notice(`Failed to open conversation: ${msg}`);
-          });
-        },
-        onDismiss: () => {
-          this.destroyResumeDropdown();
-        },
-      }
-    );
+    this.resumeDropdownController.destroy();
   }
 }
 

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -25,7 +25,6 @@ import {
 } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
 import { ResumeSessionDropdown } from '../../../shared/components/ResumeSessionDropdown';
-import { InstructionModal } from '../../../shared/modals/InstructionConfirmModal';
 import type { BrowserSelectionContext } from '../../../utils/browser';
 import type { CanvasSelectionContext } from '../../../utils/canvas';
 import { extractUserDisplayContent } from '../../../utils/context';
@@ -55,6 +54,7 @@ import type { StatusPanel } from '../ui/StatusPanel';
 import type { BrowserSelectionController } from './BrowserSelectionController';
 import type { CanvasSelectionController } from './CanvasSelectionController';
 import type { ConversationController } from './ConversationController';
+import { InstructionSubmissionController } from './InstructionSubmissionController';
 import {
   type PendingProviderUserMessage,
   PendingSteerRegistry,
@@ -192,6 +192,7 @@ export class InputController {
   } | null = null;
   private readonly turnCoordinator: TurnCoordinator<SendMessageOptions>;
   private readonly turnSubmissionBuilder: TurnSubmissionBuilder;
+  private readonly instructionSubmissionController: InstructionSubmissionController;
 
   constructor(deps: InputControllerDeps) {
     this.deps = deps;
@@ -218,6 +219,13 @@ export class InputController {
       getAuxiliaryModel: () => this.getAuxiliaryModel(),
       generateId: deps.generateId,
     });
+    this.instructionSubmissionController = new InstructionSubmissionController({
+      plugin: deps.plugin,
+      getInstructionRefineService: deps.getInstructionRefineService,
+      getInstructionModeManager: deps.getInstructionModeManager,
+      getModelOverride: () => this.getAuxiliaryModel(),
+      ensureExecutionInitialized: deps.ensureExecutionInitialized,
+    });
   }
 
   private getExecutionCoordinator(): ChatExecutionCoordinator | null {
@@ -226,12 +234,6 @@ export class InputController {
 
   private getAuxiliaryModel(): string | null {
     return this.deps.getAuxiliaryModel?.() ?? null;
-  }
-
-  private syncInstructionRefineModelOverride(
-    instructionRefineService: InstructionRefineService,
-  ): void {
-    instructionRefineService.setModelOverride?.(this.getAuxiliaryModel() ?? undefined);
   }
 
   private getActiveProviderId(): ProviderId {
@@ -1477,111 +1479,7 @@ export class InputController {
   // ============================================
 
   async handleInstructionSubmit(rawInstruction: string): Promise<void> {
-    const { plugin } = this.deps;
-
-    if (this.deps.ensureExecutionInitialized) {
-      const ready = await this.deps.ensureExecutionInitialized();
-      if (!ready) {
-        new Notice('Failed to initialize instruction refinement. Please try again.');
-        return;
-      }
-    }
-    const instructionRefineService = this.deps.getInstructionRefineService();
-    const instructionModeManager = this.deps.getInstructionModeManager();
-
-    if (!instructionRefineService) return;
-
-    const existingPrompt = plugin.settings.systemPrompt;
-    let modal: InstructionModal | null = null;
-    let wasCancelled = false;
-
-    try {
-      modal = new InstructionModal(
-        plugin.app,
-        rawInstruction,
-        {
-          onAccept: (finalInstruction) => {
-            void (async (): Promise<void> => {
-              await plugin.mutateSettings((settings) => {
-                settings.systemPrompt = appendMarkdownSnippet(
-                  settings.systemPrompt,
-                  finalInstruction,
-                );
-              });
-
-              new Notice('Instruction added to custom system prompt');
-              instructionModeManager?.clear();
-            })();
-          },
-          onReject: () => {
-            wasCancelled = true;
-            instructionRefineService.cancel();
-            instructionModeManager?.clear();
-          },
-          onClarificationSubmit: async (response) => {
-            this.syncInstructionRefineModelOverride(instructionRefineService);
-            const result = await instructionRefineService.continueConversation(response);
-
-            if (wasCancelled) {
-              return;
-            }
-
-            if (!result.success) {
-              if (result.error === 'Cancelled') {
-                return;
-              }
-              new Notice(result.error || 'Failed to process response');
-              modal?.showError(result.error || 'Failed to process response');
-              return;
-            }
-
-            if (result.clarification) {
-              modal?.showClarification(result.clarification);
-            } else if (result.refinedInstruction) {
-              modal?.showConfirmation(result.refinedInstruction);
-            }
-          }
-        }
-      );
-      modal.open();
-
-      this.syncInstructionRefineModelOverride(instructionRefineService);
-      instructionRefineService.resetConversation();
-      const result = await instructionRefineService.refineInstruction(
-        rawInstruction,
-        existingPrompt
-      );
-
-      if (wasCancelled) {
-        return;
-      }
-
-      if (!result.success) {
-        if (result.error === 'Cancelled') {
-          instructionModeManager?.clear();
-          return;
-        }
-        new Notice(result.error || 'Failed to refine instruction');
-        modal.showError(result.error || 'Failed to refine instruction');
-        instructionModeManager?.clear();
-        return;
-      }
-
-      if (result.clarification) {
-        modal.showClarification(result.clarification);
-      } else if (result.refinedInstruction) {
-        modal.showConfirmation(result.refinedInstruction);
-      } else {
-        new Notice('No instruction received');
-        modal.showError('No instruction received');
-        instructionModeManager?.clear();
-      }
-    } catch (error) {
-      const errorMsg = stringifyDiagnosticError(error);
-      new Notice(`Error: ${errorMsg}`);
-      modal?.showError(errorMsg);
-      instructionModeManager?.clear();
-    }
+    await this.instructionSubmissionController.submit(rawInstruction);
   }
 
   // ============================================

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -36,7 +36,7 @@ import {
 } from '../execution/ChatExecutionCoordinator';
 import { type InlineAskQuestionConfig, InlineAskUserQuestion } from '../rendering/InlineAskUserQuestion';
 import { InlineExitPlanMode } from '../rendering/InlineExitPlanMode';
-import { InlinePlanApproval,type PlanApprovalDecision } from '../rendering/InlinePlanApproval';
+import { InlinePlanApproval, type PlanApprovalDecision } from '../rendering/InlinePlanApproval';
 import type { MessageRenderer } from '../rendering/MessageRenderer';
 import { setToolIcon, updateToolCallResult } from '../rendering/ToolCallRenderer';
 import type { SubagentManager } from '../services/SubagentManager';
@@ -80,6 +80,7 @@ import {
   hasSuspiciousCommandText,
   SUSPICIOUS_COMMAND_WARNING,
 } from './suspiciousCommandText';
+import { TurnCompletionCoordinator } from './TurnCompletionCoordinator';
 import type { ActiveTurnOwner } from './TurnCoordinator';
 import { TurnCoordinator } from './TurnCoordinator';
 import { TurnSubmissionBuilder } from './TurnSubmissionBuilder';
@@ -195,6 +196,7 @@ export class InputController {
   private readonly turnSubmissionBuilder: TurnSubmissionBuilder;
   private readonly instructionSubmissionController: InstructionSubmissionController;
   private readonly builtInCommandController: BuiltInCommandController;
+  private readonly turnCompletionCoordinator: TurnCompletionCoordinator;
 
   constructor(deps: InputControllerDeps) {
     this.deps = deps;
@@ -244,6 +246,32 @@ export class InputController {
       showResumeDropdown: () => this.resumeDropdownController.show(),
       onForkAll: deps.onForkAll,
       toggleFastMode: deps.toggleFastMode,
+    });
+    this.turnCompletionCoordinator = new TurnCompletionCoordinator({
+      state: deps.state,
+      requestPlanApproval: () => this.showPlanApproval(),
+      restorePrePlanPermissionModeIfNeeded: () => deps.restorePrePlanPermissionModeIfNeeded?.(),
+      saveConversation: async (didEnqueueToSdk) => {
+        const saveExtras = didEnqueueToSdk ? { resumeAtMessageId: undefined } : undefined;
+        await deps.conversationController.save(true, saveExtras);
+      },
+      refreshActionButtons: (userMessage) => {
+        const userMessageIndex = deps.state.messages.indexOf(userMessage);
+        deps.renderer.refreshActionButtons(
+          userMessage,
+          deps.state.messages,
+          userMessageIndex >= 0 ? userMessageIndex : undefined,
+        );
+      },
+      setComposerText: (text) => { deps.getInputEl().value = text; },
+      scheduleCurrentControllerContinuation: (content, reporter) => {
+        deps.getInputEl().value = content;
+        this.deferReviewableSettlement(reporter);
+        this.sendMessage().catch(() => this.reportDeferredReviewableSettlement());
+      },
+      startNewConversation: () => deps.conversationController.createNew(),
+      handleNewSessionPlan: async (content) => await deps.handleNewSessionPlan?.(content) ?? false,
+      processQueuedMessage: () => this.processQueuedMessage(),
     });
   }
 
@@ -318,7 +346,6 @@ export class InputController {
       state,
       renderer,
       streamController,
-      conversationController
     } = this.deps;
     this.discardDeferredReviewForDifferentConversation();
 
@@ -610,75 +637,17 @@ export class InputController {
             }
           }
 
-          // Provider-agnostic post-plan approval: show UI and await decision before save/auto-send
-          let planAutoSendContent: string | null = null;
-          let shouldProcessQueuedMessage = true;
-          if (planCompleted && !didCancelThisTurn) {
-            const planInteractionId = `local-plan-approval:${streamGeneration}`;
-            state.beginActionRequired(planInteractionId);
-            let decisionResult: { decision: PlanApprovalDecision | null; invalidated: boolean };
-            try {
-              decisionResult = await this.showPlanApproval();
-            } finally {
-              state.endActionRequired(planInteractionId);
-            }
-            const { decision, invalidated } = decisionResult;
-
-            // Re-check invalidation after async approval prompt
-            if (state.streamGeneration !== streamGeneration || invalidated) {
-              planApprovalInvalidated = true;
-            } else if (decision?.type === 'implement') {
-              await this.deps.restorePrePlanPermissionModeIfNeeded?.();
-              planAutoSendContent = 'Implement the plan.';
-            } else if (decision?.type === 'revise') {
-              // Keep plan mode active, populate input with feedback text
-              this.deps.getInputEl().value = decision.text;
-              shouldProcessQueuedMessage = false;
-            } else {
-              // cancel or null (dismissed)
-              await this.deps.restorePrePlanPermissionModeIfNeeded?.();
-            }
-          }
-
-          if (!planApprovalInvalidated) {
-            // Only clear resumeAtMessageId if enqueue succeeded; preserve checkpoint on failure for retry
-            const saveExtras = didEnqueueToSdk ? { resumeAtMessageId: undefined } : undefined;
-            await conversationController.save(true, saveExtras);
-
-            const userMsgIndex = state.messages.indexOf(userMsg);
-            renderer.refreshActionButtons(userMsg, state.messages, userMsgIndex >= 0 ? userMsgIndex : undefined);
-
-            // Auto-implement takes precedence over both approve-new-session and queued input
-            if (planAutoSendContent) {
-              scheduledContinuation = true;
-              continuationStaysInCurrentController = true;
-              this.deps.getInputEl().value = planAutoSendContent;
-              this.deferReviewableSettlement(currentReviewableSettlementReporter);
-              this.sendMessage().catch(() => this.reportDeferredReviewableSettlement());
-            } else {
-              // approve-new-session: create fresh conversation and send plan content
-              // Must be inside the invalidation guard — if the tab was closed or
-              // conversation switched, we must not create a new session on stale state.
-              const planContent = state.pendingNewSessionPlan;
-              if (planContent) {
-                state.pendingNewSessionPlan = null;
-                const handledByLayout = await this.deps.handleNewSessionPlan?.(planContent) ?? false;
-                if (handledByLayout) {
-                  scheduledContinuation = true;
-                } else {
-                  await conversationController.createNew();
-                  scheduledContinuation = true;
-                  continuationStaysInCurrentController = true;
-                  this.deps.getInputEl().value = planContent;
-                  this.deferReviewableSettlement(currentReviewableSettlementReporter);
-                  this.sendMessage().catch(() => this.reportDeferredReviewableSettlement());
-                }
-              } else if (shouldProcessQueuedMessage) {
-                scheduledContinuation = this.processQueuedMessage();
-                continuationStaysInCurrentController = scheduledContinuation;
-              }
-            }
-          }
+          const completion = await this.turnCompletionCoordinator.complete({
+            streamGeneration,
+            didEnqueueToSdk,
+            planCompleted,
+            didCancelThisTurn,
+            userMessage: userMsg,
+            reviewableSettlementReporter: currentReviewableSettlementReporter,
+          });
+          planApprovalInvalidated = completion.planApprovalInvalidated;
+          scheduledContinuation = completion.scheduledContinuation;
+          continuationStaysInCurrentController = completion.continuationStaysInCurrentController;
         }
 
         if (wasInvalidated) {

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -54,6 +54,7 @@ import type { StatusPanel } from '../ui/StatusPanel';
 import type { BrowserSelectionController } from './BrowserSelectionController';
 import type { CanvasSelectionController } from './CanvasSelectionController';
 import type { ConversationController } from './ConversationController';
+import { InputContainerVisibility } from './InputContainerVisibility';
 import { InstructionSubmissionController } from './InstructionSubmissionController';
 import {
   type PendingProviderUserMessage,
@@ -180,7 +181,7 @@ export class InputController {
   private pendingPlanApproval: InlinePlanApproval | null = null;
   private pendingPlanApprovalInvalidated = false;
   private activeResumeDropdown: ResumeSessionDropdown | null = null;
-  private inputContainerHideDepth = 0;
+  private readonly inputContainerVisibility = new InputContainerVisibility();
   private readonly pendingSteersByConversation: PendingSteerRegistry;
   private activeStreamingAssistantMessage: ChatMessage | null = null;
   private pendingProviderUserMessages: PendingProviderUserMessage[] = [];
@@ -1619,7 +1620,7 @@ export class InputController {
     config?: InlineAskQuestionConfig,
   ): Promise<Record<string, string | string[]> | null> {
     this.deps.streamController.hideThinkingIndicator();
-    this.hideInputContainer(inputContainerEl);
+    this.inputContainerVisibility.hide(inputContainerEl);
 
     return new Promise<Record<string, string | string[]> | null>((resolve, reject) => {
       const inline = new InlineAskUserQuestion(
@@ -1627,7 +1628,7 @@ export class InputController {
         input,
         (result: Record<string, string | string[]> | null) => {
           setPending(null);
-          this.restoreInputContainer(inputContainerEl);
+          this.inputContainerVisibility.restore(inputContainerEl);
           resolve(result);
         },
         signal,
@@ -1638,7 +1639,7 @@ export class InputController {
         inline.render();
       } catch (err) {
         setPending(null);
-        this.restoreInputContainer(inputContainerEl);
+        this.inputContainerVisibility.restore(inputContainerEl);
         reject(toError(err));
       }
     });
@@ -1657,7 +1658,7 @@ export class InputController {
     }
 
     streamController.hideThinkingIndicator();
-    this.hideInputContainer(inputContainerEl);
+    this.inputContainerVisibility.hide(inputContainerEl);
 
     const enrichedInput = state.planFilePath
       ? { ...input, planFilePath: state.planFilePath }
@@ -1674,7 +1675,7 @@ export class InputController {
         enrichedInput,
         (decision: ExitPlanModeDecision | null) => {
           this.pendingExitPlanModeInline = null;
-          this.restoreInputContainer(inputContainerEl);
+          this.inputContainerVisibility.restore(inputContainerEl);
           resolve(decision);
         },
         signal,
@@ -1687,7 +1688,7 @@ export class InputController {
         inline.render();
       } catch (err) {
         this.pendingExitPlanModeInline = null;
-        this.restoreInputContainer(inputContainerEl);
+        this.inputContainerVisibility.restore(inputContainerEl);
         reject(toError(err));
       }
     });
@@ -1727,7 +1728,7 @@ export class InputController {
       this.pendingExitPlanModeInline = null;
     }
     this.dismissPendingPlanApproval(true);
-    this.resetInputContainerVisibility();
+    this.inputContainerVisibility.reset(this.deps.getInputContainerEl());
   }
 
   private showPlanApproval(): Promise<{ decision: PlanApprovalDecision | null; invalidated: boolean }> {
@@ -1737,7 +1738,7 @@ export class InputController {
       return Promise.resolve({ decision: null, invalidated: false });
     }
 
-    this.hideInputContainer(inputContainerEl);
+    this.inputContainerVisibility.hide(inputContainerEl);
     this.pendingPlanApprovalInvalidated = false;
 
     return new Promise<{ decision: PlanApprovalDecision | null; invalidated: boolean }>((resolve, reject) => {
@@ -1747,7 +1748,7 @@ export class InputController {
           const invalidated = this.pendingPlanApprovalInvalidated;
           this.pendingPlanApprovalInvalidated = false;
           this.pendingPlanApproval = null;
-          this.restoreInputContainer(inputContainerEl);
+          this.inputContainerVisibility.restore(inputContainerEl);
           resolve({ decision, invalidated });
         },
       );
@@ -1757,7 +1758,7 @@ export class InputController {
       } catch (err) {
         this.pendingPlanApproval = null;
         this.pendingPlanApprovalInvalidated = false;
-        this.restoreInputContainer(inputContainerEl);
+        this.inputContainerVisibility.restore(inputContainerEl);
         reject(toError(err));
       }
     });
@@ -1773,26 +1774,6 @@ export class InputController {
     }
     this.pendingPlanApproval.destroy();
     this.pendingPlanApproval = null;
-  }
-
-  private hideInputContainer(inputContainerEl: HTMLElement): void {
-    this.inputContainerHideDepth++;
-    inputContainerEl.addClass('claudian-hidden');
-  }
-
-  private restoreInputContainer(inputContainerEl: HTMLElement): void {
-    if (this.inputContainerHideDepth <= 0) return;
-    this.inputContainerHideDepth--;
-    if (this.inputContainerHideDepth === 0) {
-      inputContainerEl.removeClass('claudian-hidden');
-    }
-  }
-
-  private resetInputContainerVisibility(): void {
-    if (this.inputContainerHideDepth > 0) {
-      this.inputContainerHideDepth = 0;
-      this.deps.getInputContainerEl().removeClass('claudian-hidden');
-    }
   }
 
   // ============================================

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -593,9 +593,7 @@ export class InputController {
               renderer.appendInterruptIndicator(state.currentContentEl);
             }
           }
-          streamController.hideThinkingIndicator();
-          state.isStreaming = false;
-          state.cancelRequested = false;
+          this.finishStreamingState(streamController);
 
           // Capture response duration before resetting state (skip for interrupted responses and compaction)
           const hasCompactBoundary = finalAssistantMsg.contentBlocks?.some(b => b.type === 'context_compacted');
@@ -771,6 +769,12 @@ export class InputController {
     this.deps.getWelcomeEl()?.addClass('claudian-hidden');
     fileContextManager?.startSession();
     return streamGeneration;
+  }
+
+  private finishStreamingState(streamController: StreamController): void {
+    streamController.hideThinkingIndicator();
+    this.deps.state.isStreaming = false;
+    this.deps.state.cancelRequested = false;
   }
 
   private queueStreamingMessage(

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -521,36 +521,15 @@ export class InputController {
       } else if (result.status === 'invalidated') {
         wasInvalidated = true;
       } else if (result.status === 'missing-session') {
-        const retryMessage = result.accepted
-          ? null
-          : createQueuedMessage(displayContent, {
-            ...turnRequest,
-            images: imagesForMessage ?? turnRequest.images,
-          });
-        const pendingMessagesToRestore = state.queuedMessage
-          ? cloneQueuedMessage(state.queuedMessage)
-          : null;
-        const composerDraftToRestore = this.captureComposerDraft();
-        const resolution = result.missingSessionResolution ?? 'not_found';
-        if (resolution === 'deleted') {
-          this.restoreMessageToInput(composerDraftToRestore, { mergeWithComposer: true });
-          this.restoreMessageToInput(pendingMessagesToRestore, { mergeWithComposer: true });
-          this.restoreMessageToInput(retryMessage, { mergeWithComposer: true });
-        } else if (retryMessage) {
-          this.restoreMessageToInput(retryMessage, { mergeWithComposer: true });
-          this.rollbackFailedTurn(messagesBeforeTurn, hadPendingConversationSave);
-        }
-        if (result.accepted) {
-          this.finishAcceptedMissingSession(streamGeneration);
-        }
-        const notice = resolution === 'deleted'
-            ? 'The provider session no longer exists. Its Oh My Claudian record was removed; send again to start a new session.'
-            : resolution === 'reset'
-              ? 'The provider session no longer exists. Oh My Claudian preserved the recoverable history; send again to rebuild the session.'
-              : resolution === 'preserved'
-                ? 'The provider session no longer exists. Oh My Claudian preserved its record because the remaining history could not be verified.'
-                : 'The provider session no longer exists. Send again to start a new session.';
-        new Notice(notice);
+        this.handleMissingSessionResult(
+          result,
+          displayContent,
+          turnRequest,
+          imagesForMessage,
+          messagesBeforeTurn,
+          hadPendingConversationSave,
+          streamGeneration,
+        );
         wasInvalidated = true;
       } else if (result.status === 'error' && result.error) {
         await streamController.appendText(`\n\n**Error:** ${result.error.message}`);
@@ -755,6 +734,38 @@ export class InputController {
     this.deps.getWelcomeEl()?.addClass('claudian-hidden');
     fileContextManager?.startSession();
     return streamGeneration;
+  }
+
+  private handleMissingSessionResult(
+    result: Awaited<ReturnType<ChatExecutionCoordinator['execute']>>,
+    displayContent: string,
+    turnRequest: ChatTurnRequest,
+    images: ChatMessage['images'] | undefined,
+    messagesBeforeTurn: ChatMessage[],
+    hadPendingConversationSave: boolean,
+    streamGeneration: number,
+  ): void {
+    const retryMessage = result.accepted
+      ? null
+      : createQueuedMessage(displayContent, { ...turnRequest, images: images ?? turnRequest.images });
+    const pending = this.deps.state.queuedMessage ? cloneQueuedMessage(this.deps.state.queuedMessage) : null;
+    const draft = this.captureComposerDraft();
+    const resolution = result.missingSessionResolution ?? 'not_found';
+    if (resolution === 'deleted') {
+      this.restoreMessageToInput(draft, { mergeWithComposer: true });
+      this.restoreMessageToInput(pending, { mergeWithComposer: true });
+      this.restoreMessageToInput(retryMessage, { mergeWithComposer: true });
+    } else if (retryMessage) {
+      this.restoreMessageToInput(retryMessage, { mergeWithComposer: true });
+      this.rollbackFailedTurn(messagesBeforeTurn, hadPendingConversationSave);
+    }
+    if (result.accepted) this.finishAcceptedMissingSession(streamGeneration);
+    const notices: Record<string, string> = {
+      deleted: 'The provider session no longer exists. Its Oh My Claudian record was removed; send again to start a new session.',
+      preserved: 'The provider session no longer exists. Oh My Claudian preserved its record because the remaining history could not be verified.',
+      reset: 'The provider session no longer exists. Oh My Claudian preserved the recoverable history; send again to rebuild the session.',
+    };
+    new Notice(notices[resolution] ?? 'The provider session no longer exists. Send again to start a new session.');
   }
 
   private finishStreamingState(streamController: StreamController): void {

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -315,7 +315,6 @@ export class InputController {
 
   private async executeSendMessage(options?: SendMessageOptions): Promise<void> {
     const {
-      plugin,
       state,
       renderer,
       streamController,
@@ -382,29 +381,10 @@ export class InputController {
       return;
     }
 
-    state.acknowledgeReview();
-
-    let turnConversationId = state.currentConversationId;
-      this.pendingSteersByConversation.delegateToHistory(turnConversationId);
-
-    if (shouldUseInput) {
-      inputEl.value = '';
-      this.deps.resetInputHeight();
-    }
-    state.isStreaming = true;
-    state.cancelRequested = false;
-    state.ignoreUsageUpdates = false; // Allow usage updates for new query
-    this.deps.getSubagentManager().resetSpawnedCount();
-    state.autoScrollEnabled = plugin.settings.enableAutoScroll ?? true; // Reset auto-scroll based on setting
-    const streamGeneration = state.bumpStreamGeneration();
-
-    // Hide welcome message when sending first message
-    const welcomeEl = this.deps.getWelcomeEl();
-    if (welcomeEl) {
-      welcomeEl.addClass('claudian-hidden');
-    }
-
-    fileContextManager?.startSession();
+    const streamGeneration = this.beginTurn(
+      shouldUseInput,
+      fileContextManager,
+    );
 
     // Slash commands are passed directly to SDK for handling
     // SDK handles expansion, $ARGUMENTS, @file references, and frontmatter options
@@ -454,7 +434,7 @@ export class InputController {
       this.rollbackFailedTurn(messagesBeforeTurn, hadPendingConversationSave);
       throw error;
     }
-    turnConversationId = state.currentConversationId;
+    const turnConversationId = state.currentConversationId;
 
     const assistantMsg: ChatMessage = {
       id: this.deps.generateId(),
@@ -768,6 +748,29 @@ export class InputController {
         this.resetProviderMessageBoundaryState();
       }
     }
+  }
+
+  private beginTurn(
+    shouldUseInput: boolean,
+    fileContextManager: FileContextManager | null,
+  ): number {
+    const { plugin, state } = this.deps;
+    state.acknowledgeReview();
+    const turnConversationId = state.currentConversationId;
+    this.pendingSteersByConversation.delegateToHistory(turnConversationId);
+    if (shouldUseInput) {
+      this.deps.getInputEl().value = '';
+      this.deps.resetInputHeight();
+    }
+    state.isStreaming = true;
+    state.cancelRequested = false;
+    state.ignoreUsageUpdates = false;
+    this.deps.getSubagentManager().resetSpawnedCount();
+    state.autoScrollEnabled = plugin.settings.enableAutoScroll ?? true;
+    const streamGeneration = state.bumpStreamGeneration();
+    this.deps.getWelcomeEl()?.addClass('claudian-hidden');
+    fileContextManager?.startSession();
+    return streamGeneration;
   }
 
   private queueStreamingMessage(

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -51,6 +51,7 @@ import type { StatusPanel } from '../ui/StatusPanel';
 import type { BrowserSelectionController } from './BrowserSelectionController';
 import { BuiltInCommandController } from './BuiltInCommandController';
 import type { CanvasSelectionController } from './CanvasSelectionController';
+import { syncComposerAutoScroll } from './ComposerAutoScroll';
 import { captureComposerDraft } from './ComposerDraft';
 import type { ConversationController } from './ConversationController';
 import { DeferredReviewableSettlement } from './DeferredReviewableSettlement';
@@ -1460,17 +1461,11 @@ export class InputController {
   }
 
   private syncScrollToBottomAfterRenderUpdates(): void {
-    const { plugin, state } = this.deps;
-    if (!(plugin.settings.enableAutoScroll ?? true)) return;
-    if (!state.autoScrollEnabled) return;
-
-    window.requestAnimationFrame(() => {
-      if (!(this.deps.plugin.settings.enableAutoScroll ?? true)) return;
-      if (!this.deps.state.autoScrollEnabled) return;
-
-      const messagesEl = this.deps.getMessagesEl();
-      messagesEl.scrollTop = messagesEl.scrollHeight;
-    });
+    syncComposerAutoScroll(
+      () => this.deps.plugin.settings.enableAutoScroll ?? true,
+      () => this.deps.state.autoScrollEnabled,
+      this.deps.getMessagesEl,
+    );
   }
 
   // ============================================

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -319,9 +319,6 @@ export class InputController {
       state,
       renderer,
       streamController,
-      selectionController,
-      browserSelectionController,
-      canvasSelectionController,
       conversationController
     } = this.deps;
     this.discardDeferredReviewForDifferentConversation();
@@ -381,32 +378,7 @@ export class InputController {
 
     // If agent is working, queue the message instead of dropping it
     if (state.isStreaming) {
-      const images = hasImages
-        ? [...(imageOverride ?? imageContextManager?.getAttachedImages() ?? [])]
-        : undefined;
-      const editorContext = selectionController.getContext();
-      const browserContext = browserSelectionController?.getContext() ?? null;
-      const canvasContext = canvasSelectionController.getContext();
-    const { displayContent, turnRequest } = this.turnSubmissionBuilder.buildRequest({
-        content,
-        images,
-        editorContextOverride: editorContext,
-        browserContextOverride: browserContext,
-        canvasContextOverride: canvasContext,
-      });
-      state.queuedMessage = mergeQueuedMessages(
-        state.queuedMessage,
-        createQueuedMessage(displayContent, turnRequest),
-      );
-
-      if (shouldUseInput) {
-        inputEl.value = '';
-        this.deps.resetInputHeight();
-      }
-      if (shouldUseInput) {
-        imageContextManager?.clearImages();
-      }
-      this.updateQueueIndicator();
+      this.queueStreamingMessage(content, imageOverride, hasImages, shouldUseInput);
       return;
     }
 
@@ -796,6 +768,36 @@ export class InputController {
         this.resetProviderMessageBoundaryState();
       }
     }
+  }
+
+  private queueStreamingMessage(
+    content: string,
+    imageOverride: ChatMessage['images'] | undefined,
+    hasImages: boolean,
+    shouldUseInput: boolean,
+  ): void {
+    const imageContextManager = this.deps.getImageContextManager();
+    const images = hasImages
+      ? [...(imageOverride ?? imageContextManager?.getAttachedImages() ?? [])]
+      : undefined;
+    const { displayContent, turnRequest } = this.turnSubmissionBuilder.buildRequest({
+      content,
+      images,
+      editorContextOverride: this.deps.selectionController.getContext(),
+      browserContextOverride: this.deps.browserSelectionController?.getContext() ?? null,
+      canvasContextOverride: this.deps.canvasSelectionController.getContext(),
+    });
+    const { state } = this.deps;
+    state.queuedMessage = mergeQueuedMessages(
+      state.queuedMessage,
+      createQueuedMessage(displayContent, turnRequest),
+    );
+    if (shouldUseInput) {
+      this.deps.getInputEl().value = '';
+      this.deps.resetInputHeight();
+      imageContextManager?.clearImages();
+    }
+    this.updateQueueIndicator();
   }
 
   // ============================================

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -56,6 +56,11 @@ import type { BrowserSelectionController } from './BrowserSelectionController';
 import type { CanvasSelectionController } from './CanvasSelectionController';
 import type { ConversationController } from './ConversationController';
 import {
+  type PendingProviderUserMessage,
+  PendingSteerRegistry,
+  type PendingSteerState,
+} from './PendingSteerRegistry';
+import {
   cloneQueuedMessage,
   createQueuedMessage,
   getQueuedMessageDisplay,
@@ -167,31 +172,6 @@ export interface SendMessageOptions {
   turnRequestOverride?: ChatTurnRequest;
 }
 
-interface PendingProviderUserMessage {
-  displayContent: string;
-  persistedContent?: string;
-  currentNote?: string;
-  images?: ChatMessage['images'];
-}
-
-type PendingSteerProviderDisposition =
-  | 'awaiting-result'
-  | 'definitely-unsent'
-  | 'accepted-awaiting-correlation'
-  | 'ambiguous-awaiting-reconciliation';
-
-interface PendingSteerState {
-  readonly conversationId: string;
-  readonly coordinator: ChatExecutionCoordinator;
-  readonly inputRecordId: string;
-  readonly message: QueuedMessage;
-  readonly expectedProviderMessage: PendingProviderUserMessage;
-  providerDisposition: PendingSteerProviderDisposition;
-  uiState: 'visible' | 'cleared';
-  correlationState: 'pending' | 'settled' | 'delegated-to-history';
-  retryState: 'blocked' | 'parked' | 'restored';
-}
-
 export class InputController {
   private deps: InputControllerDeps;
   private pendingApprovalInline: InlineAskUserQuestion | null = null;
@@ -201,7 +181,7 @@ export class InputController {
   private pendingPlanApprovalInvalidated = false;
   private activeResumeDropdown: ResumeSessionDropdown | null = null;
   private inputContainerHideDepth = 0;
-  private readonly pendingSteersByConversation = new Map<string, PendingSteerState>();
+  private readonly pendingSteersByConversation: PendingSteerRegistry;
   private activeStreamingAssistantMessage: ChatMessage | null = null;
   private pendingProviderUserMessages: PendingProviderUserMessage[] = [];
   private sawInitialProviderUserMessage = false;
@@ -219,6 +199,11 @@ export class InputController {
       (options) => this.executeSendMessage(options),
       deps.turnOwner,
     );
+    this.pendingSteersByConversation = new PendingSteerRegistry((conversationId) => {
+      if (conversationId === this.deps.state.currentConversationId) {
+        this.updateQueueIndicator();
+      }
+    });
     this.turnSubmissionBuilder = new TurnSubmissionBuilder({
       plugin: deps.plugin,
       state: deps.state,
@@ -407,7 +392,7 @@ export class InputController {
     state.acknowledgeReview();
 
     let turnConversationId = state.currentConversationId;
-    this.delegatePendingSteerCorrelationToHistory(turnConversationId);
+      this.pendingSteersByConversation.delegateToHistory(turnConversationId);
 
     if (shouldUseInput) {
       inputEl.value = '';
@@ -761,7 +746,7 @@ export class InputController {
         }
 
         if (wasInvalidated) {
-          this.clearCurrentPendingSteerUi();
+          this.pendingSteersByConversation.clearCurrentUi(state.currentConversationId);
           this.updateQueueIndicator();
         }
       } finally {
@@ -785,7 +770,7 @@ export class InputController {
           this.reportDeferredReviewableSettlement();
         }
 
-        this.delegatePendingSteerCorrelationToHistory(turnConversationId);
+        this.pendingSteersByConversation.delegateToHistory(turnConversationId);
         this.activeStreamingAssistantMessage = null;
         this.resetProviderMessageBoundaryState();
       }
@@ -803,7 +788,7 @@ export class InputController {
 
     indicatorEl.empty();
 
-    const pendingSteer = this.getCurrentPendingSteer();
+    const pendingSteer = this.pendingSteersByConversation.get(state.currentConversationId);
     const visiblePendingSteer = pendingSteer?.uiState === 'visible'
       ? pendingSteer.message
       : null;
@@ -1030,59 +1015,9 @@ export class InputController {
 
   private canSteerQueuedMessage(): boolean {
     return this.deps.state.isStreaming
-      && this.getCurrentPendingSteer() === null
+      && this.pendingSteersByConversation.get(this.deps.state.currentConversationId) === null
       && this.getActiveCapabilities().supportsTurnSteer === true
       && this.getExecutionCoordinator() !== null;
-  }
-
-  private getCurrentPendingSteer(): PendingSteerState | null {
-    const conversationId = this.deps.state.currentConversationId;
-    if (!conversationId) return null;
-    return this.pendingSteersByConversation.get(conversationId) ?? null;
-  }
-
-  private isPendingSteerRegistered(pending: PendingSteerState): boolean {
-    return this.pendingSteersByConversation.get(pending.conversationId) === pending;
-  }
-
-  private clearCurrentPendingSteerUi(): void {
-    const pending = this.getCurrentPendingSteer();
-    if (!pending) return;
-    pending.uiState = 'cleared';
-    this.updateQueueIndicator();
-  }
-
-  private clearPendingSteerUi(pending: PendingSteerState): void {
-    pending.uiState = 'cleared';
-    if (pending.conversationId === this.deps.state.currentConversationId) {
-      this.updateQueueIndicator();
-    }
-  }
-
-  private releasePendingSteer(pending: PendingSteerState): void {
-    if (this.isPendingSteerRegistered(pending)) {
-      this.pendingSteersByConversation.delete(pending.conversationId);
-      pending.coordinator.releaseSteerCorrelation(pending.inputRecordId);
-    }
-  }
-
-  private delegatePendingSteerCorrelationToHistory(
-    conversationId: string | null,
-  ): void {
-    if (!conversationId) return;
-    const pending = this.pendingSteersByConversation.get(conversationId);
-    if (!pending) return;
-
-    if (pending.correlationState === 'pending') {
-      pending.correlationState = 'delegated-to-history';
-    }
-    this.clearPendingSteerUi(pending);
-    if (
-      pending.providerDisposition !== 'awaiting-result'
-      || pending.correlationState === 'settled'
-    ) {
-      this.releasePendingSteer(pending);
-    }
   }
 
   private restoreDefinitelyUnsentSteer(pending: PendingSteerState): void {
@@ -1095,7 +1030,7 @@ export class InputController {
 
     pending.providerDisposition = 'definitely-unsent';
     pending.correlationState = 'settled';
-    this.clearPendingSteerUi(pending);
+    this.pendingSteersByConversation.clearUi(pending);
     if (
       pending.conversationId !== this.deps.state.currentConversationId
       || this.deps.state.isSwitchingConversation
@@ -1114,7 +1049,7 @@ export class InputController {
     if (pending.retryState === 'restored') return;
 
     pending.retryState = 'restored';
-    this.releasePendingSteer(pending);
+    this.pendingSteersByConversation.release(pending);
 
     const { state } = this.deps;
     if (state.isStreaming && !state.cancelRequested) {
@@ -1135,7 +1070,7 @@ export class InputController {
     ) {
       return;
     }
-    const pending = this.getCurrentPendingSteer();
+    const pending = this.pendingSteersByConversation.get(this.deps.state.currentConversationId);
     if (
       pending?.providerDisposition === 'definitely-unsent'
       && pending.retryState === 'parked'
@@ -1177,7 +1112,7 @@ export class InputController {
       retryState: 'blocked',
       uiState: 'visible',
     };
-    this.pendingSteersByConversation.set(conversationId, pending);
+    this.pendingSteersByConversation.register(pending);
     this.updateQueueIndicator();
 
     try {
@@ -1189,9 +1124,9 @@ export class InputController {
       }
 
       pending.providerDisposition = 'accepted-awaiting-correlation';
-      this.clearPendingSteerUi(pending);
+      this.pendingSteersByConversation.clearUi(pending);
       if (pending.correlationState !== 'pending') {
-        this.releasePendingSteer(pending);
+        this.pendingSteersByConversation.release(pending);
       }
       if (pending.conversationId === state.currentConversationId) {
         this.deps.getFileContextManager()?.markCurrentNoteSent();
@@ -1205,9 +1140,9 @@ export class InputController {
       }
 
       pending.providerDisposition = 'ambiguous-awaiting-reconciliation';
-      this.clearPendingSteerUi(pending);
+      this.pendingSteersByConversation.clearUi(pending);
       if (pending.correlationState !== 'pending') {
-        this.releasePendingSteer(pending);
+        this.pendingSteersByConversation.release(pending);
       }
       new Notice(
         'Steer delivery could not be confirmed. The message was not requeued to avoid sending it twice.',
@@ -1262,7 +1197,7 @@ export class InputController {
       return;
     }
 
-    const pendingSteer = this.getCurrentPendingSteer();
+    const pendingSteer = this.pendingSteersByConversation.get(this.deps.state.currentConversationId);
     const expected = pendingSteer?.correlationState === 'pending'
       ? pendingSteer.expectedProviderMessage
       : this.pendingProviderUserMessages.shift();
@@ -1270,7 +1205,7 @@ export class InputController {
     if (pendingSteer?.correlationState === 'pending') {
       pendingSteer.providerDisposition = 'accepted-awaiting-correlation';
       pendingSteer.correlationState = 'settled';
-      this.clearPendingSteerUi(pendingSteer);
+      this.pendingSteersByConversation.clearUi(pendingSteer);
       try {
         await pendingSteer.coordinator.acceptSteerFromProviderEvent(
           pendingSteer.inputRecordId,
@@ -1311,7 +1246,7 @@ export class InputController {
       this.deps.renderer.addMessage(userMessage);
     }
     if (pendingSteer?.correlationState === 'settled') {
-      this.releasePendingSteer(pendingSteer);
+      this.pendingSteersByConversation.release(pendingSteer);
     }
 
     const assistantMessage: ChatMessage = {
@@ -1511,7 +1446,7 @@ export class InputController {
     if (!state.isStreaming) return;
     state.cancelRequested = true;
     this.restoreQueuedMessageToInput();
-    this.clearCurrentPendingSteerUi();
+    this.pendingSteersByConversation.clearCurrentUi(this.deps.state.currentConversationId);
     this.getExecutionCoordinator()?.cancel();
     streamController.hideThinkingIndicator();
   }

--- a/src/features/chat/controllers/InstructionSubmissionController.ts
+++ b/src/features/chat/controllers/InstructionSubmissionController.ts
@@ -1,0 +1,108 @@
+import { Notice } from 'obsidian';
+
+import { stringifyDiagnosticError } from '../../../core/providers/ProviderDiagnostics';
+import type { InstructionRefineService } from '../../../core/providers/types';
+import { InstructionModal } from '../../../shared/modals/InstructionConfirmModal';
+import { appendMarkdownSnippet } from '../../../utils/markdown';
+import type { FeatureHost } from '../../FeatureHost';
+import type { InstructionModeManager } from '../ui/InstructionModeManager';
+
+export interface InstructionSubmissionControllerDeps {
+  plugin: FeatureHost;
+  getInstructionRefineService: () => InstructionRefineService | null;
+  getInstructionModeManager: () => InstructionModeManager | null;
+  getModelOverride: () => string | null;
+  ensureExecutionInitialized?: () => Promise<boolean>;
+}
+
+/** Coordinates the auxiliary instruction-refinement modal and settings update. */
+export class InstructionSubmissionController {
+  constructor(private readonly deps: InstructionSubmissionControllerDeps) {}
+
+  async submit(rawInstruction: string): Promise<void> {
+    const { plugin } = this.deps;
+    if (this.deps.ensureExecutionInitialized) {
+      const ready = await this.deps.ensureExecutionInitialized();
+      if (!ready) {
+        new Notice('Failed to initialize instruction refinement. Please try again.');
+        return;
+      }
+    }
+
+    const instructionRefineService = this.deps.getInstructionRefineService();
+    const instructionModeManager = this.deps.getInstructionModeManager();
+    if (!instructionRefineService) return;
+
+    const existingPrompt = plugin.settings.systemPrompt;
+    let modal: InstructionModal | null = null;
+    let wasCancelled = false;
+    try {
+      modal = new InstructionModal(plugin.app, rawInstruction, {
+        onAccept: (finalInstruction) => {
+          void (async (): Promise<void> => {
+            await plugin.mutateSettings((settings) => {
+              settings.systemPrompt = appendMarkdownSnippet(
+                settings.systemPrompt,
+                finalInstruction,
+              );
+            });
+            new Notice('Instruction added to custom system prompt');
+            instructionModeManager?.clear();
+          })();
+        },
+        onReject: () => {
+          wasCancelled = true;
+          instructionRefineService.cancel();
+          instructionModeManager?.clear();
+        },
+        onClarificationSubmit: async (response) => {
+          this.syncModelOverride(instructionRefineService);
+          const result = await instructionRefineService.continueConversation(response);
+          if (wasCancelled) return;
+          this.presentResult(result, modal, instructionModeManager, 'Failed to process response');
+        },
+      });
+      modal.open();
+
+      this.syncModelOverride(instructionRefineService);
+      instructionRefineService.resetConversation();
+      const result = await instructionRefineService.refineInstruction(rawInstruction, existingPrompt);
+      if (wasCancelled) return;
+      this.presentResult(result, modal, instructionModeManager, 'Failed to refine instruction');
+    } catch (error) {
+      const errorMessage = stringifyDiagnosticError(error);
+      new Notice(`Error: ${errorMessage}`);
+      modal?.showError(errorMessage);
+      instructionModeManager?.clear();
+    }
+  }
+
+  private syncModelOverride(instructionRefineService: InstructionRefineService): void {
+    instructionRefineService.setModelOverride?.(this.deps.getModelOverride() ?? undefined);
+  }
+
+  private presentResult(
+    result: Awaited<ReturnType<InstructionRefineService['refineInstruction']>>,
+    modal: InstructionModal | null,
+    instructionModeManager: InstructionModeManager | null,
+    fallbackError: string,
+  ): void {
+    if (!result.success) {
+      if (result.error === 'Cancelled') return;
+      const errorMessage = result.error || fallbackError;
+      new Notice(errorMessage);
+      modal?.showError(errorMessage);
+      instructionModeManager?.clear();
+      return;
+    }
+    if (result.clarification) {
+      modal?.showClarification(result.clarification);
+    } else if (result.refinedInstruction) {
+      modal?.showConfirmation(result.refinedInstruction);
+    } else {
+      new Notice('No instruction received');
+      modal?.showError('No instruction received');
+      instructionModeManager?.clear();
+    }
+  }
+}

--- a/src/features/chat/controllers/PendingSteerRegistry.ts
+++ b/src/features/chat/controllers/PendingSteerRegistry.ts
@@ -1,0 +1,88 @@
+import type { ChatMessage } from '../../../core/types';
+import type { ChatExecutionCoordinator } from '../execution/ChatExecutionCoordinator';
+import type { QueuedMessage } from '../state/types';
+
+export interface PendingProviderUserMessage {
+  displayContent: string;
+  persistedContent?: string;
+  currentNote?: string;
+  images?: ChatMessage['images'];
+}
+
+export type PendingSteerProviderDisposition =
+  | 'awaiting-result'
+  | 'definitely-unsent'
+  | 'accepted-awaiting-correlation'
+  | 'ambiguous-awaiting-reconciliation';
+
+export interface PendingSteerState {
+  readonly conversationId: string;
+  readonly coordinator: ChatExecutionCoordinator;
+  readonly inputRecordId: string;
+  readonly message: QueuedMessage;
+  readonly expectedProviderMessage: PendingProviderUserMessage;
+  providerDisposition: PendingSteerProviderDisposition;
+  uiState: 'visible' | 'cleared';
+  correlationState: 'pending' | 'settled' | 'delegated-to-history';
+  retryState: 'blocked' | 'parked' | 'restored';
+}
+
+/** Owns pending provider correlation and its visible queue state per conversation. */
+export class PendingSteerRegistry {
+  private readonly pendingByConversation = new Map<string, PendingSteerState>();
+
+  constructor(
+    private readonly onUiStateChanged: (conversationId: string) => void,
+  ) {}
+
+  get(conversationId: string | null): PendingSteerState | null {
+    if (!conversationId) return null;
+    return this.pendingByConversation.get(conversationId) ?? null;
+  }
+
+  has(conversationId: string): boolean {
+    return this.pendingByConversation.has(conversationId);
+  }
+
+  register(pending: PendingSteerState): void {
+    this.pendingByConversation.set(pending.conversationId, pending);
+    this.notifyUiChange(pending);
+  }
+
+  clearUi(pending: PendingSteerState): void {
+    pending.uiState = 'cleared';
+    this.notifyUiChange(pending);
+  }
+
+  clearCurrentUi(conversationId: string | null): void {
+    const pending = this.get(conversationId);
+    if (pending) this.clearUi(pending);
+  }
+
+  release(pending: PendingSteerState): void {
+    if (this.pendingByConversation.get(pending.conversationId) !== pending) return;
+    this.pendingByConversation.delete(pending.conversationId);
+    pending.coordinator.releaseSteerCorrelation(pending.inputRecordId);
+  }
+
+  delegateToHistory(conversationId: string | null): PendingSteerState | null {
+    const pending = this.get(conversationId);
+    if (!pending) return null;
+
+    if (pending.correlationState === 'pending') {
+      pending.correlationState = 'delegated-to-history';
+    }
+    this.clearUi(pending);
+    if (
+      pending.providerDisposition !== 'awaiting-result'
+      || pending.correlationState === 'settled'
+    ) {
+      this.release(pending);
+    }
+    return pending;
+  }
+
+  private notifyUiChange(pending: PendingSteerState): void {
+    this.onUiStateChanged(pending.conversationId);
+  }
+}

--- a/src/features/chat/controllers/QueuedTurn.ts
+++ b/src/features/chat/controllers/QueuedTurn.ts
@@ -82,7 +82,7 @@ export function mergeQueuedMessages(
   return createQueuedMessage(mergedTurn.displayContent, mergedTurn.request);
 }
 
-function cloneChatTurnRequest(request: ChatTurnRequest): ChatTurnRequest {
+export function cloneChatTurnRequest(request: ChatTurnRequest): ChatTurnRequest {
   return {
     ...request,
     contextFiles: request.contextFiles ? [...request.contextFiles] : undefined,

--- a/src/features/chat/controllers/QueuedTurn.ts
+++ b/src/features/chat/controllers/QueuedTurn.ts
@@ -1,0 +1,138 @@
+import type { ChatTurnRequest, QueuedMessage } from '../state/types';
+
+export interface QueuedChatTurn {
+  displayContent: string;
+  request: ChatTurnRequest;
+}
+
+export function getQueuedMessageDisplay(message: QueuedMessage | null): string {
+  if (!message) {
+    return '';
+  }
+
+  const rawContent = message.content.trim();
+  const preview = rawContent.length > 40
+    ? `${rawContent.slice(0, 40)}...`
+    : rawContent;
+
+  if ((message.images?.length ?? 0) > 0) {
+    return preview ? `${preview} [images]` : '[images]';
+  }
+
+  return preview;
+}
+
+export function cloneQueuedMessage(message: QueuedMessage): QueuedMessage {
+  return {
+    ...message,
+    images: message.images ? [...message.images] : undefined,
+    turnRequest: message.turnRequest
+      ? cloneChatTurnRequest(message.turnRequest)
+      : undefined,
+  };
+}
+
+export function createQueuedMessage(
+  displayContent: string,
+  turnRequest: ChatTurnRequest,
+): QueuedMessage {
+  const request = cloneChatTurnRequest(turnRequest);
+  return {
+    browserContext: request.browserSelection ?? null,
+    canvasContext: request.canvasSelection ?? null,
+    content: displayContent,
+    editorContext: request.editorSelection ?? null,
+    images: request.images,
+    turnRequest: request,
+  };
+}
+
+export function toQueuedChatTurn(message: QueuedMessage): QueuedChatTurn {
+  if (message.turnRequest) {
+    return {
+      displayContent: message.content,
+      request: cloneChatTurnRequest(message.turnRequest),
+    };
+  }
+
+  return {
+    displayContent: message.content,
+    request: {
+      browserSelection: message.browserContext ?? null,
+      canvasSelection: message.canvasContext,
+      editorSelection: message.editorContext,
+      images: message.images ? [...message.images] : undefined,
+      text: message.content,
+    },
+  };
+}
+
+export function mergeQueuedMessages(
+  existing: QueuedMessage | null,
+  incoming: QueuedMessage,
+): QueuedMessage {
+  if (!existing) {
+    return cloneQueuedMessage(incoming);
+  }
+
+  const mergedTurn = mergeQueuedChatTurns(
+    toQueuedChatTurn(existing),
+    toQueuedChatTurn(incoming),
+  );
+  return createQueuedMessage(mergedTurn.displayContent, mergedTurn.request);
+}
+
+function cloneChatTurnRequest(request: ChatTurnRequest): ChatTurnRequest {
+  return {
+    ...request,
+    contextFiles: request.contextFiles ? [...request.contextFiles] : undefined,
+    enabledMcpServers: request.enabledMcpServers
+      ? new Set(request.enabledMcpServers)
+      : undefined,
+    externalContextPaths: request.externalContextPaths
+      ? [...request.externalContextPaths]
+      : undefined,
+    images: request.images ? [...request.images] : undefined,
+  };
+}
+
+function mergeQueuedChatTurns(
+  existing: QueuedChatTurn,
+  incoming: QueuedChatTurn,
+): QueuedChatTurn {
+  const mergeText = (first: string, second: string) => (
+    [first, second].map(value => value.trim()).filter(Boolean).join('\n\n')
+  );
+  const externalContextPaths = Array.from(new Set([
+    ...(existing.request.externalContextPaths ?? []),
+    ...(incoming.request.externalContextPaths ?? []),
+  ]));
+  const contextFiles = Array.from(new Set([
+    ...(existing.request.contextFiles ?? []),
+    ...(incoming.request.contextFiles ?? []),
+  ]));
+  const enabledMcpServers = new Set([
+    ...(existing.request.enabledMcpServers ?? []),
+    ...(incoming.request.enabledMcpServers ?? []),
+  ]);
+  const images = [
+    ...(existing.request.images ?? []),
+    ...(incoming.request.images ?? []),
+  ];
+
+  return {
+    displayContent: mergeText(existing.displayContent, incoming.displayContent),
+    request: {
+      ...cloneChatTurnRequest(incoming.request),
+      contextFiles: contextFiles.length > 0 ? contextFiles : undefined,
+      currentNotePath:
+        incoming.request.currentNotePath ?? existing.request.currentNotePath,
+      enabledMcpServers:
+        enabledMcpServers.size > 0 ? enabledMcpServers : undefined,
+      externalContextPaths:
+        externalContextPaths.length > 0 ? externalContextPaths : undefined,
+      images: images.length > 0 ? images : undefined,
+      text: mergeText(existing.request.text, incoming.request.text),
+    },
+  };
+}

--- a/src/features/chat/controllers/ResumeDropdownController.ts
+++ b/src/features/chat/controllers/ResumeDropdownController.ts
@@ -1,0 +1,63 @@
+import { Notice } from 'obsidian';
+
+import { ResumeSessionDropdown } from '../../../shared/components/ResumeSessionDropdown';
+import type { FeatureHost } from '../../FeatureHost';
+import type { ConversationController } from './ConversationController';
+
+export interface ResumeDropdownControllerDeps {
+  plugin: FeatureHost;
+  conversationController: ConversationController;
+  getInputContainerEl: () => HTMLElement;
+  getInputEl: () => HTMLTextAreaElement;
+  getCurrentConversationId: () => string | null;
+  openConversation?: (conversationId: string) => Promise<void>;
+}
+
+/** Owns the ephemeral resume-session dropdown and its selection cleanup. */
+export class ResumeDropdownController {
+  private activeDropdown: ResumeSessionDropdown | null = null;
+
+  constructor(private readonly deps: ResumeDropdownControllerDeps) {}
+
+  handleKeydown(event: KeyboardEvent): boolean {
+    return this.activeDropdown?.isVisible() === true
+      ? this.activeDropdown.handleKeydown(event)
+      : false;
+  }
+
+  isVisible(): boolean {
+    return this.activeDropdown?.isVisible() ?? false;
+  }
+
+  destroy(): void {
+    this.activeDropdown?.destroy();
+    this.activeDropdown = null;
+  }
+
+  show(): void {
+    this.destroy();
+    const conversations = this.deps.plugin.getConversationList();
+    if (conversations.length === 0) {
+      new Notice('No conversations to resume');
+      return;
+    }
+    const openConversation = this.deps.openConversation
+      ?? ((id: string) => this.deps.conversationController.switchTo(id));
+    this.activeDropdown = new ResumeSessionDropdown(
+      this.deps.getInputContainerEl(),
+      this.deps.getInputEl(),
+      conversations,
+      this.deps.getCurrentConversationId(),
+      {
+        onDismiss: () => this.destroy(),
+        onSelect: (id) => {
+          this.destroy();
+          openConversation(id).catch((error: unknown) => {
+            const message = error instanceof Error ? error.message : String(error);
+            new Notice(`Failed to open conversation: ${message}`);
+          });
+        },
+      },
+    );
+  }
+}

--- a/src/features/chat/controllers/TurnCompletionCoordinator.ts
+++ b/src/features/chat/controllers/TurnCompletionCoordinator.ts
@@ -1,0 +1,123 @@
+import type { ChatMessage } from '../../../core/types';
+import type { PlanApprovalDecision } from '../rendering/InlinePlanApproval';
+import type { ChatState } from '../state/ChatState';
+
+export interface TurnCompletionCoordinatorDeps {
+  state: ChatState;
+  requestPlanApproval: () => Promise<{
+    decision: PlanApprovalDecision | null;
+    invalidated: boolean;
+  }>;
+  restorePrePlanPermissionModeIfNeeded: () => void | Promise<void>;
+  saveConversation: (didEnqueueToSdk: boolean) => Promise<void>;
+  refreshActionButtons: (userMessage: ChatMessage) => void;
+  setComposerText: (text: string) => void;
+  scheduleCurrentControllerContinuation: (content: string, reporter: (() => void) | null) => void;
+  startNewConversation: () => Promise<void>;
+  handleNewSessionPlan: (content: string) => Promise<boolean>;
+  processQueuedMessage: () => boolean;
+}
+
+export interface TurnCompletionOptions {
+  streamGeneration: number;
+  didEnqueueToSdk: boolean;
+  planCompleted: boolean;
+  didCancelThisTurn: boolean;
+  userMessage: ChatMessage;
+  reviewableSettlementReporter: (() => void) | null;
+}
+
+export interface TurnCompletionResult {
+  planApprovalInvalidated: boolean;
+  scheduledContinuation: boolean;
+  continuationStaysInCurrentController: boolean;
+}
+
+/** Coordinates terminal plan decisions, persistence, and follow-up turn scheduling. */
+export class TurnCompletionCoordinator {
+  constructor(private readonly deps: TurnCompletionCoordinatorDeps) {}
+
+  async complete(options: TurnCompletionOptions): Promise<TurnCompletionResult> {
+    const { state } = this.deps;
+    let planApprovalInvalidated = false;
+    let planAutoSendContent: string | null = null;
+    let shouldProcessQueuedMessage = true;
+
+    if (options.planCompleted && !options.didCancelThisTurn) {
+      const planInteractionId = `local-plan-approval:${options.streamGeneration}`;
+      state.beginActionRequired(planInteractionId);
+      let decisionResult: { decision: PlanApprovalDecision | null; invalidated: boolean };
+      try {
+        decisionResult = await this.deps.requestPlanApproval();
+      } finally {
+        state.endActionRequired(planInteractionId);
+      }
+
+      const { decision, invalidated } = decisionResult;
+      if (state.streamGeneration !== options.streamGeneration || invalidated) {
+        planApprovalInvalidated = true;
+      } else if (decision?.type === 'implement') {
+        await this.deps.restorePrePlanPermissionModeIfNeeded();
+        planAutoSendContent = 'Implement the plan.';
+      } else if (decision?.type === 'revise') {
+        this.deps.setComposerText(decision.text);
+        shouldProcessQueuedMessage = false;
+      } else {
+        await this.deps.restorePrePlanPermissionModeIfNeeded();
+      }
+    }
+
+    if (planApprovalInvalidated) {
+      return {
+        planApprovalInvalidated,
+        scheduledContinuation: false,
+        continuationStaysInCurrentController: false,
+      };
+    }
+
+    await this.deps.saveConversation(options.didEnqueueToSdk);
+    this.deps.refreshActionButtons(options.userMessage);
+
+    if (planAutoSendContent) {
+      this.deps.scheduleCurrentControllerContinuation(
+        planAutoSendContent,
+        options.reviewableSettlementReporter,
+      );
+      return {
+        planApprovalInvalidated: false,
+        scheduledContinuation: true,
+        continuationStaysInCurrentController: true,
+      };
+    }
+
+    const planContent = state.pendingNewSessionPlan;
+    if (planContent) {
+      state.pendingNewSessionPlan = null;
+      if (await this.deps.handleNewSessionPlan(planContent)) {
+        return {
+          planApprovalInvalidated: false,
+          scheduledContinuation: true,
+          continuationStaysInCurrentController: false,
+        };
+      }
+
+      await this.deps.startNewConversation();
+      this.deps.scheduleCurrentControllerContinuation(
+        planContent,
+        options.reviewableSettlementReporter,
+      );
+      return {
+        planApprovalInvalidated: false,
+        scheduledContinuation: true,
+        continuationStaysInCurrentController: true,
+      };
+    }
+
+    const scheduledContinuation = shouldProcessQueuedMessage && this.deps.processQueuedMessage();
+    return {
+      planApprovalInvalidated: false,
+      scheduledContinuation,
+      continuationStaysInCurrentController: scheduledContinuation,
+    };
+  }
+}

--- a/src/features/chat/controllers/TurnSubmissionBuilder.ts
+++ b/src/features/chat/controllers/TurnSubmissionBuilder.ts
@@ -1,0 +1,142 @@
+import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
+import type { ProviderCapabilities, ProviderId } from '../../../core/providers/types';
+import { type ChatMessage,isCanonicalUserMessage } from '../../../core/types';
+import type { BrowserSelectionContext } from '../../../utils/browser';
+import type { CanvasSelectionContext } from '../../../utils/canvas';
+import type { EditorSelectionContext } from '../../../utils/editor';
+import type { FeatureHost } from '../../FeatureHost';
+import type { ChatTurnSubmission } from '../execution/ChatExecutionCoordinator';
+import type { ChatState } from '../state/ChatState';
+import type { ChatTurnRequest } from '../state/types';
+import type { FileContextManager } from '../ui/FileContext';
+import type { McpServerSelector } from '../ui/InputToolbar';
+import type { BrowserSelectionController } from './BrowserSelectionController';
+import type { CanvasSelectionController } from './CanvasSelectionController';
+import type { SelectionController } from './SelectionController';
+
+export interface TurnSubmissionBuilderDeps {
+  plugin: FeatureHost;
+  state: ChatState;
+  selectionController: SelectionController;
+  browserSelectionController?: BrowserSelectionController;
+  canvasSelectionController: CanvasSelectionController;
+  getFileContextManager: () => FileContextManager | null;
+  getMcpServerSelector: () => McpServerSelector | null;
+  getExternalContextSelector: () => { getExternalContexts: () => string[] } | null;
+  getProviderId: () => ProviderId;
+  getProviderCapabilities: () => ProviderCapabilities;
+  getAuxiliaryModel: () => string | null;
+  generateId: () => string;
+}
+
+export interface BuildTurnRequestOptions {
+  content: string;
+  images?: ChatMessage['images'];
+  editorContextOverride?: EditorSelectionContext | null;
+  browserContextOverride?: BrowserSelectionContext | null;
+  canvasContextOverride?: CanvasSelectionContext | null;
+}
+
+/** Builds provider-neutral turn requests from the current composer state. */
+export class TurnSubmissionBuilder {
+  constructor(private readonly deps: TurnSubmissionBuilderDeps) {}
+
+  buildRequest(options: BuildTurnRequestOptions): {
+    displayContent: string;
+    turnRequest: ChatTurnRequest;
+  } {
+    const fileContextManager = this.deps.getFileContextManager();
+    const currentNotePath = fileContextManager?.getCurrentNotePath() || null;
+    const shouldSendCurrentNote = fileContextManager?.shouldSendCurrentNote(currentNotePath) ?? false;
+    const externalContextPaths = this.deps.getExternalContextSelector()?.getExternalContexts();
+    const isCompact = /^\/compact(\s|$)/i.test(options.content);
+    const transformedText = !isCompact && fileContextManager
+      ? fileContextManager.transformContextMentions(options.content)
+      : options.content;
+    const enabledMcpServers = this.deps.getMcpServerSelector()?.getEnabledServers();
+    const contextFiles = fileContextManager?.getAttachedFiles?.();
+
+    return {
+      displayContent: options.content,
+      turnRequest: {
+        text: transformedText,
+        images: options.images,
+        currentNotePath: shouldSendCurrentNote && currentNotePath ? currentNotePath : undefined,
+        editorSelection: options.editorContextOverride !== undefined
+          ? options.editorContextOverride
+          : this.deps.selectionController.getContext(),
+        browserSelection: options.browserContextOverride !== undefined
+          ? options.browserContextOverride
+          : (this.deps.browserSelectionController?.getContext() ?? null),
+        canvasSelection: options.canvasContextOverride !== undefined
+          ? options.canvasContextOverride
+          : this.deps.canvasSelectionController.getContext(),
+        externalContextPaths: externalContextPaths?.length ? externalContextPaths : undefined,
+        contextFiles: contextFiles?.size ? [...contextFiles] : undefined,
+        enabledMcpServers: enabledMcpServers?.size ? enabledMcpServers : undefined,
+      },
+    };
+  }
+
+  buildExecutionSubmission(
+    displayContent: string,
+    request: ChatTurnRequest,
+    user?: ChatMessage,
+    assistant?: ChatMessage,
+  ): ChatTurnSubmission {
+    const providerId = this.deps.getProviderId();
+    const settings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+      this.deps.plugin.settings,
+      providerId,
+    );
+    const permissionMode = typeof settings.permissionMode === 'string'
+      ? settings.permissionMode
+      : undefined;
+    const reasoning = typeof settings.effortLevel === 'string'
+      ? settings.effortLevel
+      : typeof settings.thinkingBudget === 'string' ? settings.thinkingBudget : undefined;
+    const serviceTier = typeof settings.serviceTier === 'string' ? settings.serviceTier : undefined;
+    const mode = permissionMode === 'plan' && this.deps.getProviderCapabilities().supportsPlanMode
+      ? permissionMode
+      : undefined;
+    const systemPrompt = typeof this.deps.plugin.settings.systemPrompt === 'string'
+      ? this.deps.plugin.settings.systemPrompt.trim()
+      : '';
+    const existingUserTurns = this.deps.state.messages.filter(isCanonicalUserMessage).length;
+
+    return {
+      canonicalText: request.text,
+      configuration: {
+        ...(request.enabledMcpServers ? { enabledMcpServers: [...request.enabledMcpServers] } : {}),
+        ...(request.externalContextPaths ? { externalWorkspaceRoots: [...request.externalContextPaths] } : {}),
+        ...(this.deps.getAuxiliaryModel() ? { model: this.deps.getAuxiliaryModel() ?? undefined } : {}),
+        ...(permissionMode ? { permissionMode } : {}),
+        ...(mode ? { mode } : {}),
+        ...(reasoning ? { reasoning } : {}),
+        ...(serviceTier ? { serviceTier } : {}),
+        systemInstructions: systemPrompt
+          ? { kind: 'explicit', instructions: systemPrompt }
+          : { kind: 'none' },
+      },
+      context: {
+        ...(request.browserSelection ? { browserSelection: request.browserSelection } : {}),
+        ...(request.canvasSelection ? { canvasSelection: request.canvasSelection } : {}),
+        ...(request.currentNotePath ? { currentNote: { path: request.currentNotePath } } : {}),
+        ...(request.editorSelection ? { editorSelection: request.editorSelection } : {}),
+        ...(request.externalContextPaths ? { externalContextPaths: [...request.externalContextPaths] } : {}),
+        ...(request.contextFiles ? { contextFiles: [...request.contextFiles] } : {}),
+      },
+      conversationHistory: user && assistant
+        ? this.deps.state.messages.slice(0, -2)
+        : [...this.deps.state.messages],
+      images: [...(request.images ?? [])],
+      inputRecordId: this.deps.generateId(),
+      ...(user ? { localMessageId: user.id } : {}),
+      ...(user && assistant ? { messages: { assistant, user } } : {}),
+      rawDisplayText: displayContent,
+      timestamp: user?.timestamp ?? Date.now(),
+      toolPolicy: { kind: 'provider-default' },
+      userTurnOrdinal: user ? existingUserTurns : existingUserTurns + 1,
+    };
+  }
+}

--- a/src/features/chat/ui/ComposerInputEvents.ts
+++ b/src/features/chat/ui/ComposerInputEvents.ts
@@ -1,0 +1,7 @@
+/** Notifies composer UI observers after code updates a textarea value. */
+export function dispatchComposerInputEvent(inputEl: HTMLTextAreaElement): void {
+  if (typeof inputEl.dispatchEvent !== 'function') return;
+
+  const EventConstructor = inputEl.ownerDocument?.defaultView?.Event ?? Event;
+  inputEl.dispatchEvent(new EventConstructor('input', { bubbles: true }));
+}

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -108,6 +108,7 @@
 .claudian-input-wrapper textarea.claudian-input {
   position: relative;
   z-index: 1;
+  box-sizing: border-box;
   width: 100%;
   flex: 1 1 0;
   min-height: var(--claudian-textarea-min-height, 64px);

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -101,7 +101,7 @@
 .claudian-input-editor {
   position: relative;
   display: flex;
-  flex: 1 1 0;
+  flex: 1 1 auto;
   min-height: 0;
 }
 

--- a/tests/unit/features/chat/controllers/ComposerAutoScroll.test.ts
+++ b/tests/unit/features/chat/controllers/ComposerAutoScroll.test.ts
@@ -1,0 +1,28 @@
+import { syncComposerAutoScroll } from '@/features/chat/controllers/ComposerAutoScroll';
+
+describe('syncComposerAutoScroll', () => {
+  it('does not schedule scrolling when auto scroll is disabled', () => {
+    const requestAnimationFrame = jest.fn();
+    Object.defineProperty(window, 'requestAnimationFrame', { configurable: true, value: requestAnimationFrame });
+
+    syncComposerAutoScroll(() => false, () => true, () => ({}) as HTMLElement);
+
+    expect(requestAnimationFrame).not.toHaveBeenCalled();
+  });
+
+  it('rechecks state before scrolling in the animation frame', () => {
+    let active = true;
+    let callback!: FrameRequestCallback;
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      configurable: true,
+      value: jest.fn((next: FrameRequestCallback) => { callback = next; return 1; }),
+    });
+    const messages = { scrollHeight: 80, scrollTop: 10 } as HTMLElement;
+
+    syncComposerAutoScroll(() => true, () => active, () => messages);
+    active = false;
+    callback(0);
+
+    expect(messages.scrollTop).toBe(10);
+  });
+});

--- a/tests/unit/features/chat/controllers/ComposerDraft.test.ts
+++ b/tests/unit/features/chat/controllers/ComposerDraft.test.ts
@@ -1,0 +1,16 @@
+import { captureComposerDraft } from '@/features/chat/controllers/ComposerDraft';
+
+describe('captureComposerDraft', () => {
+  it('keeps an image-only composer draft', () => {
+    const image = { id: 'image', name: 'a.png' } as any;
+    expect(captureComposerDraft('', [image])).toMatchObject({
+      content: '',
+      images: [image],
+      turnRequest: { text: '', images: [image] },
+    });
+  });
+
+  it('drops an empty composer draft', () => {
+    expect(captureComposerDraft('  ', undefined)).toBeNull();
+  });
+});

--- a/tests/unit/features/chat/controllers/DeferredReviewableSettlement.test.ts
+++ b/tests/unit/features/chat/controllers/DeferredReviewableSettlement.test.ts
@@ -1,0 +1,27 @@
+import { DeferredReviewableSettlement } from '@/features/chat/controllers/DeferredReviewableSettlement';
+
+describe('DeferredReviewableSettlement', () => {
+  it('keeps a deferred reporter available for its original conversation', () => {
+    const settlement = new DeferredReviewableSettlement();
+    const report = jest.fn();
+
+    settlement.defer('conversation-a', report);
+
+    expect(settlement.hasFor('conversation-a')).toBe(true);
+    settlement.takeFor('conversation-a')?.();
+
+    expect(report).toHaveBeenCalledTimes(1);
+    expect(settlement.hasFor('conversation-a')).toBe(false);
+  });
+
+  it('discards a reporter after switching conversations', () => {
+    const settlement = new DeferredReviewableSettlement();
+    const report = jest.fn();
+
+    settlement.defer('conversation-a', report);
+
+    expect(settlement.takeFor('conversation-b')).toBeNull();
+    expect(settlement.takeFor('conversation-a')).toBeNull();
+    expect(report).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/features/chat/controllers/InputContainerVisibility.test.ts
+++ b/tests/unit/features/chat/controllers/InputContainerVisibility.test.ts
@@ -1,0 +1,37 @@
+import { InputContainerVisibility } from '@/features/chat/controllers/InputContainerVisibility';
+
+function createInputContainer(): HTMLElement {
+  return {
+    addClass: jest.fn(),
+    removeClass: jest.fn(),
+  } as unknown as HTMLElement;
+}
+
+describe('InputContainerVisibility', () => {
+  it('keeps the composer hidden until every overlapping interaction restores it', () => {
+    const visibility = new InputContainerVisibility();
+    const inputContainer = createInputContainer();
+
+    visibility.hide(inputContainer);
+    visibility.hide(inputContainer);
+    visibility.restore(inputContainer);
+
+    expect(inputContainer.addClass).toHaveBeenCalledTimes(2);
+    expect(inputContainer.removeClass).not.toHaveBeenCalled();
+
+    visibility.restore(inputContainer);
+
+    expect(inputContainer.removeClass).toHaveBeenCalledWith('claudian-hidden');
+  });
+
+  it('resets an unfinished interaction and ignores later restores', () => {
+    const visibility = new InputContainerVisibility();
+    const inputContainer = createInputContainer();
+
+    visibility.hide(inputContainer);
+    visibility.reset(inputContainer);
+    visibility.restore(inputContainer);
+
+    expect(inputContainer.removeClass).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -274,6 +274,18 @@ describe('InputController coordinator execution', () => {
     expect(fixture.deps.conversationController.save).toHaveBeenCalledTimes(2);
   });
 
+  it('notifies composer observers after clearing a sent message', async () => {
+    const fixture = createFixture();
+    fixture.input.value = '@notes/plan.md review this';
+
+    await fixture.controller.sendMessage();
+
+    expect(fixture.input.value).toBe('');
+    expect(fixture.input.dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'input' }),
+    );
+  });
+
   it('does not add the Claudian default system instructions when no custom prompt is configured', async () => {
     const fixture = createFixture();
     fixture.input.value = 'first';

--- a/tests/unit/features/chat/controllers/QueuedTurn.test.ts
+++ b/tests/unit/features/chat/controllers/QueuedTurn.test.ts
@@ -1,0 +1,117 @@
+import type { ImageAttachment } from '@/core/types';
+import {
+  cloneQueuedMessage,
+  mergeQueuedMessages,
+  toQueuedChatTurn,
+} from '@/features/chat/controllers/QueuedTurn';
+import type { QueuedMessage } from '@/features/chat/state/types';
+
+const image: ImageAttachment = {
+  data: 'image-data',
+  id: 'image-1',
+  mediaType: 'image/png',
+  name: 'image.png',
+  size: 1,
+  source: 'paste',
+};
+
+describe('QueuedTurn', () => {
+  it('clones queue snapshots without sharing mutable request collections', () => {
+    const original: QueuedMessage = {
+      browserContext: null,
+      canvasContext: null,
+      content: 'follow up',
+      editorContext: null,
+      images: [image],
+      turnRequest: {
+        contextFiles: ['notes/plan.md'],
+        enabledMcpServers: new Set(['github']),
+        externalContextPaths: ['/project'],
+        images: [image],
+        text: 'follow up',
+      },
+    };
+
+    const cloned = cloneQueuedMessage(original);
+    cloned.images?.push({ ...image, id: 'image-2' });
+    cloned.turnRequest?.contextFiles?.push('notes/todo.md');
+    cloned.turnRequest?.enabledMcpServers?.add('filesystem');
+    cloned.turnRequest?.externalContextPaths?.push('/other-project');
+
+    expect(original.images).toHaveLength(1);
+    expect(original.turnRequest?.contextFiles).toEqual(['notes/plan.md']);
+    expect(original.turnRequest?.enabledMcpServers).toEqual(new Set(['github']));
+    expect(original.turnRequest?.externalContextPaths).toEqual(['/project']);
+  });
+
+  it('converts legacy queue messages into a provider-neutral turn request', () => {
+    const legacy: QueuedMessage = {
+      browserContext: {
+        selectedText: 'browser selection',
+        source: 'web',
+        url: 'https://example.com',
+      },
+      canvasContext: { canvasPath: 'diagram.canvas', nodeIds: ['node-1'] },
+      content: 'legacy message',
+      editorContext: {
+        mode: 'selection',
+        notePath: 'notes/plan.md',
+        selectedText: 'editor selection',
+        startLine: 4,
+      },
+      images: [image],
+    };
+
+    expect(toQueuedChatTurn(legacy)).toEqual({
+      displayContent: 'legacy message',
+      request: {
+        browserSelection: legacy.browserContext,
+        canvasSelection: legacy.canvasContext,
+        editorSelection: legacy.editorContext,
+        images: [image],
+        text: 'legacy message',
+      },
+    });
+  });
+
+  it('merges queued turns while retaining all unique context and latest request settings', () => {
+    const existing: QueuedMessage = {
+      browserContext: null,
+      canvasContext: null,
+      content: 'first display',
+      editorContext: null,
+      turnRequest: {
+        contextFiles: ['notes/one.md'],
+        enabledMcpServers: new Set(['github']),
+        externalContextPaths: ['/workspace-a'],
+        text: 'first request',
+      },
+    };
+    const incoming: QueuedMessage = {
+      browserContext: null,
+      canvasContext: null,
+      content: 'second display',
+      editorContext: null,
+      turnRequest: {
+        contextFiles: ['notes/one.md', 'notes/two.md'],
+        currentNotePath: 'notes/two.md',
+        enabledMcpServers: new Set(['github', 'filesystem']),
+        externalContextPaths: ['/workspace-a', '/workspace-b'],
+        images: [image],
+        text: 'second request',
+      },
+    };
+
+    expect(mergeQueuedMessages(existing, incoming)).toMatchObject({
+      content: 'first display\n\nsecond display',
+      turnRequest: {
+        contextFiles: ['notes/one.md', 'notes/two.md'],
+        currentNotePath: 'notes/two.md',
+        enabledMcpServers: new Set(['github', 'filesystem']),
+        externalContextPaths: ['/workspace-a', '/workspace-b'],
+        images: [image],
+        text: 'first request\n\nsecond request',
+      },
+    });
+  });
+});

--- a/tests/unit/features/chat/controllers/TurnCompletionCoordinator.test.ts
+++ b/tests/unit/features/chat/controllers/TurnCompletionCoordinator.test.ts
@@ -1,0 +1,99 @@
+import type { ChatMessage } from '@/core/types';
+import { TurnCompletionCoordinator } from '@/features/chat/controllers/TurnCompletionCoordinator';
+import { ChatState } from '@/features/chat/state/ChatState';
+
+function createFixture() {
+  const state = new ChatState();
+  const deps = {
+    state,
+    requestPlanApproval: jest.fn().mockResolvedValue({ decision: null, invalidated: false }),
+    restorePrePlanPermissionModeIfNeeded: jest.fn(),
+    saveConversation: jest.fn().mockResolvedValue(undefined),
+    refreshActionButtons: jest.fn(),
+    setComposerText: jest.fn(),
+    scheduleCurrentControllerContinuation: jest.fn(),
+    startNewConversation: jest.fn().mockResolvedValue(undefined),
+    handleNewSessionPlan: jest.fn().mockResolvedValue(false),
+    processQueuedMessage: jest.fn().mockReturnValue(false),
+  };
+  return { coordinator: new TurnCompletionCoordinator(deps), deps, state };
+}
+
+const userMessage: ChatMessage = {
+  id: 'user-1',
+  role: 'user',
+  content: 'Make a plan',
+  timestamp: 1,
+};
+
+describe('TurnCompletionCoordinator', () => {
+  it('saves before scheduling the approved plan implementation', async () => {
+    const { coordinator, deps, state } = createFixture();
+    state.bumpStreamGeneration();
+    state.bumpStreamGeneration();
+    state.bumpStreamGeneration();
+    deps.requestPlanApproval.mockResolvedValue({ decision: { type: 'implement' }, invalidated: false });
+
+    const result = await coordinator.complete({
+      streamGeneration: 3,
+      didEnqueueToSdk: true,
+      planCompleted: true,
+      didCancelThisTurn: false,
+      userMessage,
+      reviewableSettlementReporter: null,
+    });
+
+    expect(deps.restorePrePlanPermissionModeIfNeeded).toHaveBeenCalledTimes(1);
+    expect(deps.saveConversation).toHaveBeenCalledWith(true);
+    expect(deps.refreshActionButtons).toHaveBeenCalledWith(userMessage);
+    expect(deps.scheduleCurrentControllerContinuation).toHaveBeenCalledWith('Implement the plan.', null);
+    expect(deps.processQueuedMessage).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      planApprovalInvalidated: false,
+      scheduledContinuation: true,
+      continuationStaysInCurrentController: true,
+    });
+  });
+
+  it('keeps revision feedback in the composer without consuming queued input', async () => {
+    const { coordinator, deps, state } = createFixture();
+    state.bumpStreamGeneration();
+    state.bumpStreamGeneration();
+    deps.requestPlanApproval.mockResolvedValue({
+      decision: { type: 'revise', text: 'Add deployment constraints.' },
+      invalidated: false,
+    });
+
+    const result = await coordinator.complete({
+      streamGeneration: 2,
+      didEnqueueToSdk: true,
+      planCompleted: true,
+      didCancelThisTurn: false,
+      userMessage,
+      reviewableSettlementReporter: null,
+    });
+
+    expect(deps.setComposerText).toHaveBeenCalledWith('Add deployment constraints.');
+    expect(deps.processQueuedMessage).not.toHaveBeenCalled();
+    expect(result.scheduledContinuation).toBe(false);
+  });
+
+  it('does not persist or schedule stale plan approval results', async () => {
+    const { coordinator, deps, state } = createFixture();
+    for (let generation = 0; generation < 5; generation++) state.bumpStreamGeneration();
+    deps.requestPlanApproval.mockResolvedValue({ decision: { type: 'implement' }, invalidated: true });
+
+    const result = await coordinator.complete({
+      streamGeneration: 5,
+      didEnqueueToSdk: true,
+      planCompleted: true,
+      didCancelThisTurn: false,
+      userMessage,
+      reviewableSettlementReporter: null,
+    });
+
+    expect(deps.saveConversation).not.toHaveBeenCalled();
+    expect(deps.scheduleCurrentControllerContinuation).not.toHaveBeenCalled();
+    expect(result.planApprovalInvalidated).toBe(true);
+  });
+});

--- a/tests/unit/style/components/input.test.ts
+++ b/tests/unit/style/components/input.test.ts
@@ -58,4 +58,10 @@ describe('Chat input toolbar styles', () => {
       /\.claudian-input-mention-highlights\s*\{[\s\S]*?line-height:\s*1\.4;/,
     );
   });
+
+  it('keeps the editor tall enough for text when context rows consume composer space', () => {
+    expect(css).toMatch(
+      /\.claudian-input-editor\s*\{[^}]*flex:\s*1 1 auto;/,
+    );
+  });
 });

--- a/tests/unit/style/components/input.test.ts
+++ b/tests/unit/style/components/input.test.ts
@@ -46,6 +46,9 @@ describe('Chat input toolbar styles', () => {
 
   it('does not let inline mention highlighting change textarea text metrics', () => {
     expect(css).toMatch(
+      /\.claudian-input-wrapper textarea\.claudian-input\s*\{[^}]*box-sizing:\s*border-box;/,
+    );
+    expect(css).toMatch(
       /\.claudian-input-mention-highlight\s*\{[^}]*padding:\s*0;/,
     );
     expect(css).toMatch(


### PR DESCRIPTION
## Summary
- split InputController turn submission and completion responsibilities into focused controllers
- preserve queued turns, plan approval, review settlement, and missing-session recovery behavior
- fix inline @ mention alignment, long-composer sizing, and stale highlighter content after programmatic input changes

## Verification
- pnpm exec tsc --noEmit
- pnpm run lint (9 existing warnings, no errors)
- pnpm run test
- pnpm run build