### PR TITLE
feat: make @ file mentions interactive

### DIFF
--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -870,8 +870,8 @@ export class MessageRenderer {
         }
       }
 
-      // Process wikilinks only when the source can contain them; the DOM pass is expensive.
-      if (processedMarkdown.includes('[[')) {
+      // Process vault links only when the source can contain wikilinks or @mentions.
+      if (processedMarkdown.includes('[[') || processedMarkdown.includes('@')) {
         processFileLinks(this.app, el);
       }
     } catch {

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -1474,6 +1474,7 @@ export function initializeTabUI(
   const mentionTextHighlighter = new MentionTextHighlighter(
     dom.inputEl,
     dom.inputMentionHighlightsEl,
+    plugin.app,
   );
   dom.eventCleanups.push(() => mentionTextHighlighter.destroy());
   tab.ui.scopePreview = new ScopePreview(dom.scopePreviewEl);

--- a/src/features/chat/ui/MentionTextHighlighter.ts
+++ b/src/features/chat/ui/MentionTextHighlighter.ts
@@ -1,3 +1,5 @@
+import type { App } from 'obsidian';
+
 const FILE_MENTION_PATTERN = /@(?:[^\s@]+\.[^\s@]+|[^\s@/]+(?:\/[^\s@]+)*\/)/g;
 
 /** Mirrors composer text beneath its textarea and emphasizes file-like @mentions. */
@@ -9,6 +11,7 @@ export class MentionTextHighlighter {
   constructor(
     private readonly inputEl: HTMLTextAreaElement,
     private readonly highlightEl: HTMLElement,
+    private readonly app?: App,
   ) {
     this.contentEl = this.highlightEl.createDiv({ cls: 'claudian-input-mention-highlights-content' });
     this.inputEl.addEventListener('input', this.syncHandler);
@@ -33,10 +36,7 @@ export class MentionTextHighlighter {
     for (const match of text.matchAll(FILE_MENTION_PATTERN)) {
       const start = match.index ?? 0;
       if (start > cursor) this.contentEl.createSpan({ text: text.slice(cursor, start) });
-      this.contentEl.createSpan({
-        cls: 'claudian-input-mention-highlight',
-        text: match[0],
-      });
+      this.appendMention(match[0]);
       cursor = start + match[0].length;
     }
     if (cursor < text.length) this.contentEl.createSpan({ text: text.slice(cursor) });
@@ -45,5 +45,25 @@ export class MentionTextHighlighter {
 
   private syncScroll(): void {
     this.contentEl.style.transform = `translate(${-this.inputEl.scrollLeft}px, ${-this.inputEl.scrollTop}px)`;
+  }
+
+  private appendMention(mention: string): void {
+    const linkPath = mention.slice(1);
+    const file = this.app?.metadataCache.getFirstLinkpathDest(linkPath, '');
+    const mentionEl = this.contentEl.createSpan({
+      cls: file ? 'claudian-input-mention-highlight internal-link' : 'claudian-input-mention-highlight',
+      text: mention,
+    });
+    if (!file || !this.app) return;
+
+    mentionEl.style.pointerEvents = 'auto';
+    mentionEl.style.cursor = 'pointer';
+    mentionEl.setAttribute('data-href', linkPath);
+    mentionEl.setAttribute('href', linkPath);
+    mentionEl.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      void this.app?.workspace.openLinkText(linkPath, '', 'tab');
+    });
   }
 }

--- a/src/features/chat/ui/MentionTextHighlighter.ts
+++ b/src/features/chat/ui/MentionTextHighlighter.ts
@@ -50,7 +50,9 @@ export class MentionTextHighlighter {
 
   private appendMention(mention: string): void {
     const linkPath = mention.slice(1);
-    const file = this.app?.metadataCache.getFirstLinkpathDest(linkPath, '');
+    const normalizedPath = linkPath.replace(/\/$/, '');
+    const file = this.app?.metadataCache.getFirstLinkpathDest(linkPath, '')
+      ?? this.app?.vault.getAbstractFileByPath(normalizedPath);
     const mentionEl = this.contentEl.createSpan({
       cls: file ? 'claudian-input-mention-highlight internal-link' : 'claudian-input-mention-highlight',
       text: mention,
@@ -59,12 +61,12 @@ export class MentionTextHighlighter {
 
     mentionEl.style.pointerEvents = 'auto';
     mentionEl.style.cursor = 'pointer';
-    mentionEl.setAttribute('data-href', linkPath);
-    mentionEl.setAttribute('href', linkPath);
+    mentionEl.setAttribute('data-href', normalizedPath);
+    mentionEl.setAttribute('href', normalizedPath);
     mentionEl.addEventListener('click', (event) => {
       event.preventDefault();
       event.stopPropagation();
-      void this.app?.workspace.openLinkText(linkPath, '', 'tab');
+      void this.app?.workspace.openLinkText(normalizedPath, '', 'tab');
     });
   }
 }

--- a/src/features/chat/ui/MentionTextHighlighter.ts
+++ b/src/features/chat/ui/MentionTextHighlighter.ts
@@ -13,6 +13,7 @@ export class MentionTextHighlighter {
     private readonly highlightEl: HTMLElement,
     private readonly app?: App,
   ) {
+    this.highlightEl.style.zIndex = '2';
     this.contentEl = this.highlightEl.createDiv({ cls: 'claudian-input-mention-highlights-content' });
     this.inputEl.addEventListener('input', this.syncHandler);
     this.inputEl.addEventListener('scroll', this.scrollHandler);

--- a/src/features/chat/ui/MentionTextHighlighter.ts
+++ b/src/features/chat/ui/MentionTextHighlighter.ts
@@ -61,12 +61,21 @@ export class MentionTextHighlighter {
 
     mentionEl.style.pointerEvents = 'auto';
     mentionEl.style.cursor = 'pointer';
+    const isFolder = mention.endsWith('/');
     mentionEl.setAttribute('data-href', normalizedPath);
     mentionEl.setAttribute('href', normalizedPath);
+    if (isFolder) mentionEl.setAttribute('data-claudian-folder-link', 'true');
     mentionEl.addEventListener('click', (event) => {
       event.preventDefault();
       event.stopPropagation();
-      void this.app?.workspace.openLinkText(normalizedPath, '', 'tab');
+      if (isFolder) {
+        const folder = this.app?.vault.getAbstractFileByPath(normalizedPath);
+        for (const leaf of this.app?.workspace.getLeavesOfType('file-explorer') ?? []) {
+          (leaf.view as unknown as { revealInFolder?: (target: unknown) => void }).revealInFolder?.(folder);
+        }
+      } else {
+        void this.app?.workspace.openLinkText(normalizedPath, '', 'tab');
+      }
     });
   }
 }

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -114,7 +114,7 @@
   min-height: var(--claudian-textarea-min-height, 64px);
   max-height: var(--claudian-textarea-max-height, none);
   resize: none;
-  padding: 13px 15px 48px;
+  padding: 13px 15px;
   border: none;
   border-radius: 15px;
   background: transparent;

--- a/src/utils/fileLink.ts
+++ b/src/utils/fileLink.ts
@@ -118,7 +118,8 @@ function extractLinkPathFromTarget(linkTarget: string): string {
 function createWikilink(
   parent: HTMLElement,
   linkTarget: string,
-  displayText: string
+  displayText: string,
+  isFolder = false,
 ): HTMLElement {
   return parent.createEl('a', {
     cls: 'claudian-file-link internal-link',
@@ -126,8 +127,18 @@ function createWikilink(
     attr: {
       'data-href': linkTarget,
       href: linkTarget,
+      ...(isFolder ? { 'data-claudian-folder-link': 'true' } : {}),
     },
   });
+}
+
+function revealFolder(app: App, folderPath: string): void {
+  const folder = app.vault.getAbstractFileByPath(folderPath);
+  if (!folder) return;
+  for (const leaf of app.workspace.getLeavesOfType('file-explorer')) {
+    const view = leaf.view as unknown as { revealInFolder?: (target: unknown) => void };
+    view.revealInFolder?.(folder);
+  }
 }
 
 function repairEmptyInternalLink(app: App, link: HTMLAnchorElement): void {
@@ -165,7 +176,8 @@ export function registerFileLinkHandler(
       event.preventDefault();
       const linkTarget = link.dataset.href || link.getAttribute('href');
       if (linkTarget) {
-        void app.workspace.openLinkText(linkTarget, '', 'tab');
+        if (link.dataset.claudianFolderLink === 'true') revealFolder(app, linkTarget);
+        else void app.workspace.openLinkText(linkTarget, '', 'tab');
       }
     }
   });
@@ -186,7 +198,10 @@ function buildFragmentWithLinks(parent: HTMLElement, text: string, matches: Wiki
       );
     }
 
-    fragment.insertBefore(createWikilink(parent, linkTarget, displayText), fragment.firstChild);
+    fragment.insertBefore(
+      createWikilink(parent, linkTarget, displayText, fullMatch.startsWith('@') && fullMatch.endsWith('/')),
+      fragment.firstChild,
+    );
     currentIndex = index;
   }
 

--- a/src/utils/fileLink.ts
+++ b/src/utils/fileLink.ts
@@ -22,10 +22,15 @@ export { stripFileLineRange } from './FileReference';
  * Does NOT match image embeds ![[image.png]] (those are handled separately).
  */
 const WIKILINK_PATTERN_SOURCE = '(?<!!)\\[\\[([^\\]|#^]+)(?:#[^\\]|]+)?(?:\\^[^\\]|]+)?(?:\\|[^\\]]+)?\\]\\]';
+const AT_MENTION_PATTERN_SOURCE = '@([^\\s@]+\\.[^\\s@]+)';
 
 /** Creates a fresh regex instance to avoid global state issues */
 function createWikilinkPattern(): RegExp {
   return new RegExp(WIKILINK_PATTERN_SOURCE, 'g');
+}
+
+function createAtMentionPattern(): RegExp {
+  return new RegExp(AT_MENTION_PATTERN_SOURCE, 'g');
 }
 
 interface WikilinkMatch {
@@ -197,15 +202,31 @@ function buildFragmentWithLinks(parent: HTMLElement, text: string, matches: Wiki
 
 function processTextNode(app: App, node: Text): boolean {
   const text = node.textContent;
-  if (!text || !text.includes('[[')) return false;
+  if (!text || (!text.includes('[[') && !text.includes('@'))) return false;
 
   const matches = findWikilinks(app, text);
+  const atMentionPattern = createAtMentionPattern();
+  let atMention: RegExpExecArray | null;
+  while ((atMention = atMentionPattern.exec(text)) !== null) {
+    const linkPath = atMention[1];
+    if (!fileExistsInVault(app, linkPath)) continue;
+    matches.push({
+      index: atMention.index,
+      fullMatch: atMention[0],
+      linkPath,
+      linkTarget: linkPath,
+      displayText: atMention[0],
+    });
+  }
   if (matches.length === 0) return false;
 
   const parent = node.parentElement;
   if (!parent) return false;
 
-  node.parentNode?.replaceChild(buildFragmentWithLinks(parent, text, matches), node);
+  node.parentNode?.replaceChild(
+    buildFragmentWithLinks(parent, text, matches.sort((a, b) => b.index - a.index)),
+    node,
+  );
   return true;
 }
 

--- a/src/utils/fileLink.ts
+++ b/src/utils/fileLink.ts
@@ -22,7 +22,7 @@ export { stripFileLineRange } from './FileReference';
  * Does NOT match image embeds ![[image.png]] (those are handled separately).
  */
 const WIKILINK_PATTERN_SOURCE = '(?<!!)\\[\\[([^\\]|#^]+)(?:#[^\\]|]+)?(?:\\^[^\\]|]+)?(?:\\|[^\\]]+)?\\]\\]';
-const AT_MENTION_PATTERN_SOURCE = '@([^\\s@]+\\.[^\\s@]+)';
+const AT_MENTION_PATTERN_SOURCE = '@([^\\s@]+(?:\\.[^\\s@]+|/))';
 
 /** Creates a fresh regex instance to avoid global state issues */
 function createWikilinkPattern(): RegExp {
@@ -91,7 +91,7 @@ function fileExistsInVault(app: App, linkPath: string): boolean {
     return true;
   }
 
-  const directFile = getVaultFileByPath(app, linkPath);
+  const directFile = app.vault.getAbstractFileByPath(linkPath.replace(/\/$/, ''));
   if (directFile) {
     return true;
   }
@@ -214,7 +214,7 @@ function processTextNode(app: App, node: Text): boolean {
       index: atMention.index,
       fullMatch: atMention[0],
       linkPath,
-      linkTarget: linkPath,
+      linkTarget: linkPath.replace(/\/$/, ''),
       displayText: atMention[0],
     });
   }

--- a/tests/unit/features/chat/ui/MentionTextHighlighter.test.ts
+++ b/tests/unit/features/chat/ui/MentionTextHighlighter.test.ts
@@ -49,6 +49,7 @@ describe('MentionTextHighlighter', () => {
     const highlighter = new MentionTextHighlighter(input, highlights, app);
 
     const mention = highlights.querySelector('.claudian-input-mention-highlight') as HTMLElement;
+    expect(highlights.style.zIndex).toBe('2');
     expect(mention.classList.contains('internal-link')).toBe(true);
     mention.click();
     expect(app.workspace.openLinkText).toHaveBeenCalledWith('notes/plan.md', '', 'tab');

--- a/tests/unit/features/chat/ui/MentionTextHighlighter.test.ts
+++ b/tests/unit/features/chat/ui/MentionTextHighlighter.test.ts
@@ -39,6 +39,24 @@ describe('MentionTextHighlighter', () => {
     wrapper.remove();
   });
 
+  it('makes existing file mentions interactive', () => {
+    const { highlights, input, wrapper } = createFixture();
+    const app = {
+      metadataCache: { getFirstLinkpathDest: jest.fn().mockReturnValue({ path: 'notes/plan.md' }) },
+      workspace: { openLinkText: jest.fn() },
+    } as any;
+    input.value = '@notes/plan.md';
+    const highlighter = new MentionTextHighlighter(input, highlights, app);
+
+    const mention = highlights.querySelector('.claudian-input-mention-highlight') as HTMLElement;
+    expect(mention.classList.contains('internal-link')).toBe(true);
+    mention.click();
+    expect(app.workspace.openLinkText).toHaveBeenCalledWith('notes/plan.md', '', 'tab');
+
+    highlighter.destroy();
+    wrapper.remove();
+  });
+
   it('keeps its mirrored text aligned with textarea scrolling', () => {
     const { highlights, input, wrapper } = createFixture();
     const highlighter = new MentionTextHighlighter(input, highlights);

--- a/tests/unit/utils/fileLink.dom.test.ts
+++ b/tests/unit/utils/fileLink.dom.test.ts
@@ -37,6 +37,16 @@ describe('processFileLinks', () => {
     expect(link?.getAttribute('data-href')).toBe('notes/plan.md');
   });
 
+  it('converts existing @ folder mentions into Obsidian internal links', () => {
+    const app = createMockApp(['notes']);
+    const container = document.createElement('div');
+    container.textContent = 'Review @notes/ before merging.';
+
+    processFileLinks(app, container);
+
+    expect(container.querySelector('a.claudian-file-link')?.getAttribute('data-href')).toBe('notes');
+  });
+
   describe('null/empty inputs', () => {
     it('handles null app gracefully', () => {
       const container = document.createElement('div');

--- a/tests/unit/utils/fileLink.dom.test.ts
+++ b/tests/unit/utils/fileLink.dom.test.ts
@@ -25,6 +25,18 @@ function createMockApp(existingFiles: string[]) {
 }
 
 describe('processFileLinks', () => {
+  it('converts existing @ file mentions into Obsidian internal links', () => {
+    const app = createMockApp(['notes/plan.md']);
+    const container = document.createElement('div');
+    container.textContent = 'Review @notes/plan.md before merging.';
+
+    processFileLinks(app, container);
+
+    const link = container.querySelector('a.claudian-file-link');
+    expect(link?.textContent).toBe('@notes/plan.md');
+    expect(link?.getAttribute('data-href')).toBe('notes/plan.md');
+  });
+
   describe('null/empty inputs', () => {
     it('handles null app gracefully', () => {
       const container = document.createElement('div');


### PR DESCRIPTION
## Summary
- make existing @file references interactive in the composer and chat bubbles
- use Obsidian internal-link behavior for hover previews and file navigation
- recognize @folder/ references and reveal folders in the file explorer instead of creating notes
- preserve composer text space for multi-line mentions

## Verification
- pnpm exec tsc --noEmit
- pnpm exec jest tests/unit/utils/fileLink.handler.test.ts tests/unit/utils/fileLink.dom.test.ts tests/unit/features/chat/ui/MentionTextHighlighter.test.ts --runInBand