### PR TITLE
fix: use CSS classes instead of static styles in mention highlighter

### DIFF
--- a/src/features/chat/ui/MentionTextHighlighter.ts
+++ b/src/features/chat/ui/MentionTextHighlighter.ts
@@ -13,7 +13,7 @@ export class MentionTextHighlighter {
     private readonly highlightEl: HTMLElement,
     private readonly app?: App,
   ) {
-    this.highlightEl.style.zIndex = '2';
+    this.highlightEl.addClass('claudian-input-mention-highlights');
     this.contentEl = this.highlightEl.createDiv({ cls: 'claudian-input-mention-highlights-content' });
     this.inputEl.addEventListener('input', this.syncHandler);
     this.inputEl.addEventListener('scroll', this.scrollHandler);
@@ -59,8 +59,7 @@ export class MentionTextHighlighter {
     });
     if (!file || !this.app) return;
 
-    mentionEl.style.pointerEvents = 'auto';
-    mentionEl.style.cursor = 'pointer';
+    mentionEl.addClass('claudian-input-mention-highlight--clickable');
     const isFolder = mention.endsWith('/');
     mentionEl.setAttribute('data-href', normalizedPath);
     mentionEl.setAttribute('href', normalizedPath);

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -145,6 +145,7 @@
   inset: 0;
   overflow: hidden;
   pointer-events: none;
+  z-index: 2;
   color: var(--text-normal);
   font-family: inherit;
   font-size: 14px;
@@ -170,6 +171,11 @@
   background: color-mix(in srgb, var(--interactive-accent) 14%, transparent);
   color: var(--interactive-accent);
   line-height: inherit;
+}
+
+.claudian-input-mention-highlight--clickable {
+  pointer-events: auto;
+  cursor: pointer;
 }
 
 .claudian-input-send-button {

--- a/tests/setupWindow.ts
+++ b/tests/setupWindow.ts
@@ -126,6 +126,25 @@ if (globalThis.HTMLElement && !Reflect.has(globalThis.HTMLElement.prototype, 'cr
   };
 }
 
+if (globalThis.HTMLElement && !Reflect.has(globalThis.HTMLElement.prototype, 'addClass')) {
+  globalThis.HTMLElement.prototype.addClass = function (this: HTMLElement, cls: string): HTMLElement {
+    this.classList.add(...String(cls).split(/\s+/).filter(Boolean));
+    return this;
+  };
+  globalThis.HTMLElement.prototype.removeClass = function (this: HTMLElement, cls: string): HTMLElement {
+    this.classList.remove(...String(cls).split(/\s+/).filter(Boolean));
+    return this;
+  };
+  globalThis.HTMLElement.prototype.toggleClass = function (this: HTMLElement, cls: string, on?: boolean): void {
+    for (const single of String(cls).split(/\s+/).filter(Boolean)) {
+      this.classList.toggle(single, on);
+    }
+  };
+  globalThis.HTMLElement.prototype.hasClass = function (this: HTMLElement, cls: string): boolean {
+    return this.classList.contains(cls);
+  };
+}
+
 if (globalThis.SVGElement && !Reflect.has(globalThis.SVGElement.prototype, 'createSvg')) {
   globalThis.SVGElement.prototype.createSvg = function (this: SVGElement, tag, info?, callback?) {
     const el = createSvg(tag, info, callback);

--- a/tests/unit/features/chat/ui/MentionTextHighlighter.test.ts
+++ b/tests/unit/features/chat/ui/MentionTextHighlighter.test.ts
@@ -49,7 +49,8 @@ describe('MentionTextHighlighter', () => {
     const highlighter = new MentionTextHighlighter(input, highlights, app);
 
     const mention = highlights.querySelector('.claudian-input-mention-highlight') as HTMLElement;
-    expect(highlights.style.zIndex).toBe('2');
+    expect(highlights.classList.contains('claudian-input-mention-highlights')).toBe(true);
+    expect(mention.classList.contains('claudian-input-mention-highlight--clickable')).toBe(true);
     expect(mention.classList.contains('internal-link')).toBe(true);
     mention.click();
     expect(app.workspace.openLinkText).toHaveBeenCalledWith('notes/plan.md', '', 'tab');


### PR DESCRIPTION
## Summary

Fixes `obsidianmd/no-static-styles-assignment` lint violations in `MentionTextHighlighter.ts`.

## Changes

- **MentionTextHighlighter.ts**: Replaced direct `element.style.*` assignments with CSS classes
- **input.css**: Added `z-index: 2` to `.claudian-input-mention-highlights` and new `.claudian-input-mention-highlight--clickable` class

## Verification

- `pnpm run typecheck` ✅
- `pnpm run lint` — 0 errors (only pre-existing warnings)