### PR TITLE
chore: release 2.5.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "packageManager": "pnpm@10.34.5",
   "description": "Oh My Claudian - provider-backed coding agents embedded in the Obsidian sidebar",
   "main": "main.js",


### PR DESCRIPTION
## 2.5.1 Release

### Fixes
- Use CSS classes instead of static styles in mention highlighter (fixes `obsidianmd/no-static-styles-assignment`)
- Polyfill Obsidian class helpers in test setup so jsdom elements support `addClass`/etc.

### Verification
- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm run test` — 7093 passed ✅