### PR TITLE
fix: harden process and build boundaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/cross-spawn": "6.0.6",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.5.2",
     "@typescript-eslint/eslint-plugin": "^8.58.0",
@@ -60,6 +61,7 @@
     "@modelcontextprotocol/client": "^2.0.0",
     "@modelcontextprotocol/sdk": "~1.30.0",
     "@pierre/trees": "1.0.0-beta.6",
+    "cross-spawn": "7.0.6",
     "smol-toml": "^1.6.1",
     "tslib": "^2.8.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@pierre/trees':
         specifier: 1.0.0-beta.6
         version: 1.0.0-beta.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      cross-spawn:
+        specifier: 7.0.6
+        version: 7.0.6
       smol-toml:
         specifier: ^1.6.1
         version: 1.7.1
@@ -36,6 +39,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.8.1)
+      '@types/cross-spawn':
+        specifier: 6.0.6
+        version: 6.0.6
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -831,6 +837,9 @@ packages:
 
   '@types/codemirror@5.60.8':
     resolution: {integrity: sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==}
+
+  '@types/cross-spawn@6.0.6':
+    resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
 
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
@@ -4014,6 +4023,10 @@ snapshots:
   '@types/codemirror@5.60.8':
     dependencies:
       '@types/tern': 0.23.9
+
+  '@types/cross-spawn@6.0.6':
+    dependencies:
+      '@types/node': 25.9.5
 
   '@types/eslint@9.6.1':
     dependencies:

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -4,7 +4,7 @@
  * Avoids npm echoing commands
  */
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -12,8 +12,13 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
 
 // Run CSS build silently
-execSync('node scripts/build-css.mjs', { cwd: ROOT, stdio: 'inherit' });
+execFileSync(process.execPath, [join(ROOT, 'scripts/build-css.mjs')], {
+  cwd: ROOT,
+  stdio: 'inherit',
+});
 
 // Run esbuild with args passed through
-const args = process.argv.slice(2).join(' ');
-execSync(`node esbuild.config.mjs ${args}`, { cwd: ROOT, stdio: 'inherit' });
+execFileSync(process.execPath, [join(ROOT, 'esbuild.config.mjs'), ...process.argv.slice(2)], {
+  cwd: ROOT,
+  stdio: 'inherit',
+});

--- a/src/core/process/ManagedStdioProcess.ts
+++ b/src/core/process/ManagedStdioProcess.ts
@@ -1,5 +1,7 @@
-import { type ChildProcess, spawn } from 'node:child_process';
+import type { ChildProcess, spawn as nodeSpawn } from 'node:child_process';
 import type { Readable, Writable } from 'node:stream';
+
+import crossSpawn from 'cross-spawn';
 
 import {
   resolveWindowsCmdShimSpawnSpec,
@@ -10,6 +12,7 @@ import {
 const DEFAULT_SIGKILL_TIMEOUT_MS = 3_000;
 const DEFAULT_FINAL_SHUTDOWN_TIMEOUT_MS = 3_000;
 const DEFAULT_STDERR_BUFFER_LIMIT = 8_000;
+const spawn = crossSpawn as typeof nodeSpawn;
 
 export interface ManagedStdioProcessOptions {
   args: string[];
@@ -83,9 +86,6 @@ export class ManagedStdioProcess {
         env: this.options.env,
         stdio: this.options.stdio ?? 'pipe',
         windowsHide: true,
-        ...(resolvedSpawnSpec.windowsVerbatimArguments
-          ? { windowsVerbatimArguments: true }
-          : {}),
       });
     } catch (error) {
       const spawnError = toError(error);

--- a/src/providers/claude/runtime/customSpawn.ts
+++ b/src/providers/claude/runtime/customSpawn.ts
@@ -1,5 +1,6 @@
 import type { SpawnedProcess, SpawnOptions } from '@anthropic-ai/claude-agent-sdk';
-import { type ChildProcess, spawn } from 'child_process';
+import type { ChildProcess } from 'child_process';
+import spawn from 'cross-spawn';
 
 import { cliPathRequiresNode, findNodeExecutable } from '../../../utils/env';
 import {
@@ -41,7 +42,6 @@ export function createCustomSpawnFunction(
       env: env,
       stdio: ['pipe', 'pipe', shouldPipeStderr ? 'pipe' : 'ignore'],
       windowsHide: true,
-      ...(resolvedSpawnSpec.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
     });
     installTreeAwareKill(child, resolvedSpawnSpec);
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -225,18 +225,10 @@ export function cliPathRequiresNode(cliPath: string): boolean {
   }
 
   try {
-    if (!fs.existsSync(cliPath)) {
-      return false;
-    }
-
-    const stat = fs.statSync(cliPath);
-    if (!stat.isFile()) {
-      return false;
-    }
-
     let fd: number | null = null;
     try {
       fd = fs.openSync(cliPath, 'r');
+      if (!fs.fstatSync(fd).isFile()) return false;
       const buffer = Buffer.alloc(200);
       const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
       const header = buffer.subarray(0, bytesRead).toString('utf8');

--- a/src/utils/slashCommand.ts
+++ b/src/utils/slashCommand.ts
@@ -93,7 +93,7 @@ export function yamlString(value: string): string {
   if (value.includes(':') || value.includes('#') || value.includes('\n') ||
       value.startsWith(' ') || value.endsWith(' ') ||
       value.startsWith('[') || value.startsWith('{')) {
-    return `"${value.replace(/"/g, '\\"')}"`;
+    return JSON.stringify(value);
   }
   return value;
 }

--- a/src/utils/windowsCmdShim.ts
+++ b/src/utils/windowsCmdShim.ts
@@ -1,10 +1,7 @@
-const WINDOWS_CMD_ARGUMENT_CHARS = /[\s"&<>|{}^=;!'+,`~()%@]/u;
-
 export interface WindowsCmdShimSpawnSpec {
   args: string[];
   command: string;
   killProcessTree?: boolean;
-  windowsVerbatimArguments?: boolean;
 }
 
 interface KillableProcess {
@@ -33,15 +30,10 @@ export function resolveWindowsCmdShimSpawnSpec(
     };
   }
 
-  const shellCommand = [command, ...spec.args]
-    .map(value => quoteWindowsShellArgument(value))
-    .join(' ');
-
   return {
-    args: ['/d', '/s', '/c', `"${shellCommand}"`],
-    command: process.env.ComSpec || process.env.comspec || 'cmd.exe',
+    args: spec.args,
+    command,
     killProcessTree: true,
-    windowsVerbatimArguments: true,
   };
 }
 
@@ -77,22 +69,4 @@ function isErrorEmitterLike(value: unknown): value is ErrorEmitterLike {
   return value !== null
     && typeof value === 'object'
     && typeof (value as { on?: unknown }).on === 'function';
-}
-
-function requiresWindowsShellQuoting(value: string): boolean {
-  return WINDOWS_CMD_ARGUMENT_CHARS.test(value)
-    || value.includes('[')
-    || value.includes(']');
-}
-
-function quoteWindowsShellArgument(value: string): string {
-  if (!value.length) {
-    return '""';
-  }
-
-  if (!requiresWindowsShellQuoting(value)) {
-    return value;
-  }
-
-  return `"${value.replace(/"/g, '""')}"`;
 }

--- a/tests/integration/build/build.test.ts
+++ b/tests/integration/build/build.test.ts
@@ -1,0 +1,45 @@
+import { execFileSync } from 'node:child_process';
+import { copyFile, mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+describe('build script', () => {
+  it('forwards build arguments without evaluating them as shell commands', async () => {
+    if (process.platform === 'win32') return;
+
+    const root = await mkdtemp(path.join(tmpdir(), 'claudian-build-script-'));
+    try {
+      const scriptsDirectory = path.join(root, 'scripts');
+      const binaryDirectory = path.join(root, 'bin');
+      await mkdir(scriptsDirectory, { recursive: true });
+      await mkdir(binaryDirectory, { recursive: true });
+      await copyFile(
+        path.resolve('scripts/build.mjs'),
+        path.join(scriptsDirectory, 'build.mjs'),
+      );
+      await writeFile(path.join(scriptsDirectory, 'build-css.mjs'), '');
+      await writeFile(path.join(root, 'esbuild.config.mjs'), '');
+      await writeFile(path.join(binaryDirectory, 'node'), '#!/bin/sh\nexit 0\n', {
+        mode: 0o755,
+      });
+
+      execFileSync(
+        process.execPath,
+        [path.join(scriptsDirectory, 'build.mjs'), '; touch injected-by-shell; #'],
+        {
+          cwd: root,
+          env: {
+            ...process.env,
+            PATH: `${binaryDirectory}:${process.env.PATH ?? ''}`,
+          },
+          stdio: 'pipe',
+        },
+      );
+
+      await expect(stat(path.join(root, 'injected-by-shell')))
+        .rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/tests/unit/core/process/ManagedStdioProcess.test.ts
+++ b/tests/unit/core/process/ManagedStdioProcess.test.ts
@@ -1,10 +1,7 @@
-jest.mock('node:child_process', () => ({
-  spawn: jest.fn(),
-}));
-
-import { spawn } from 'node:child_process';
+jest.mock('cross-spawn', () => jest.fn());
 
 import { createMockChildProcess, type MockChildProcess } from '@test/helpers/MockChildProcess';
+import spawn from 'cross-spawn';
 
 import { ManagedStdioProcess } from '@/core/process/ManagedStdioProcess';
 
@@ -177,9 +174,9 @@ describe('ManagedStdioProcess', () => {
 
     expect(mockSpawn).toHaveBeenNthCalledWith(
       1,
-      process.env.ComSpec || process.env.comspec || 'cmd.exe',
-      ['/d', '/s', '/c', '""C:\\Users\\R&D\\provider.cmd" serve "R&D""'],
-      expect.objectContaining({ windowsVerbatimArguments: true }),
+      'C:\\Users\\R&D\\provider.cmd',
+      ['serve', 'R&D'],
+      expect.not.objectContaining({ shell: true }),
     );
     expect(mockSpawn).toHaveBeenNthCalledWith(
       2,

--- a/tests/unit/providers/acp/AcpSubprocess.test.ts
+++ b/tests/unit/providers/acp/AcpSubprocess.test.ts
@@ -1,10 +1,7 @@
-jest.mock('node:child_process', () => ({
-  spawn: jest.fn(),
-}));
-
-import { spawn } from 'node:child_process';
+jest.mock('cross-spawn', () => jest.fn());
 
 import { createMockChildProcess, type MockChildProcess } from '@test/helpers/MockChildProcess';
+import spawn from 'cross-spawn';
 
 import { AcpSubprocess } from '@/providers/acp/AcpSubprocess';
 
@@ -41,7 +38,7 @@ describe('AcpSubprocess', () => {
     }));
   });
 
-  it('wraps Windows .cmd shims through cmd.exe', () => {
+  it('passes Windows .cmd shims to cross-spawn', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     const subprocess = new AcpSubprocess({
       args: ['acp', '--cwd=C:\\Vault'],
@@ -53,12 +50,11 @@ describe('AcpSubprocess', () => {
     subprocess.start();
 
     expect(mockSpawn).toHaveBeenCalledWith(
-      process.env.ComSpec || process.env.comspec || 'cmd.exe',
-      ['/d', '/s', '/c', '""C:\\Users\\R&D\\AppData\\Roaming\\npm\\opencode.cmd" acp "--cwd=C:\\Vault""'],
+      'C:\\Users\\R&D\\AppData\\Roaming\\npm\\opencode.cmd',
+      ['acp', '--cwd=C:\\Vault'],
       expect.objectContaining({
         cwd: 'C:\\Vault',
         windowsHide: true,
-        windowsVerbatimArguments: true,
       }),
     );
   });

--- a/tests/unit/providers/claude/runtime/customSpawn.test.ts
+++ b/tests/unit/providers/claude/runtime/customSpawn.test.ts
@@ -1,12 +1,10 @@
 import type { SpawnOptions } from '@anthropic-ai/claude-agent-sdk';
-import { spawn } from 'child_process';
+import spawn from 'cross-spawn';
 
 import { createCustomSpawnFunction } from '@/providers/claude/runtime/customSpawn';
 import * as env from '@/utils/env';
 
-jest.mock('child_process', () => ({
-  spawn: jest.fn(),
-}));
+jest.mock('cross-spawn', () => jest.fn());
 
 describe('createCustomSpawnFunction', () => {
   const originalPlatform = process.platform;
@@ -123,7 +121,7 @@ describe('createCustomSpawnFunction', () => {
     });
 
     const spawnOptions = spawnMock.mock.calls[0][2];
-    expect(spawnOptions.stdio).toEqual(['pipe', 'pipe', 'pipe']);
+    expect(spawnOptions?.stdio).toEqual(['pipe', 'pipe', 'pipe']);
     expect(mockProcess.stderr?.on).toHaveBeenCalledWith('data', expect.any(Function));
   });
 
@@ -142,7 +140,7 @@ describe('createCustomSpawnFunction', () => {
     });
 
     const spawnOptions = spawnMock.mock.calls[0][2];
-    expect(spawnOptions.stdio).toEqual(['pipe', 'pipe', 'ignore']);
+    expect(spawnOptions?.stdio).toEqual(['pipe', 'pipe', 'ignore']);
     expect(mockProcess.stderr?.on).not.toHaveBeenCalled();
   });
 
@@ -212,7 +210,7 @@ describe('createCustomSpawnFunction', () => {
     expect(spawnMock).toHaveBeenCalledWith('python', ['script.py'], expect.any(Object));
   });
 
-  it('wraps manually configured Windows .cmd commands through cmd.exe', () => {
+  it('passes manually configured Windows .cmd commands to cross-spawn', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     const mockProcess = createMockProcess();
     spawnMock.mockReturnValue(mockProcess as unknown as ReturnType<typeof spawn>);
@@ -229,12 +227,11 @@ describe('createCustomSpawnFunction', () => {
 
     expect(findNodeExecutable).not.toHaveBeenCalled();
     expect(spawnMock).toHaveBeenCalledWith(
-      process.env.ComSpec || process.env.comspec || 'cmd.exe',
-      ['/d', '/s', '/c', '""C:\\Users\\R&D\\AppData\\Roaming\\npm\\claude.cmd" --output-format stream-json"'],
+      'C:\\Users\\R&D\\AppData\\Roaming\\npm\\claude.cmd',
+      ['--output-format', 'stream-json'],
       expect.objectContaining({
         cwd: 'C:\\Vault',
         windowsHide: true,
-        windowsVerbatimArguments: true,
       }),
     );
   });

--- a/tests/unit/providers/claude/storage/SlashCommandStorage.test.ts
+++ b/tests/unit/providers/claude/storage/SlashCommandStorage.test.ts
@@ -261,7 +261,7 @@ Do the thing`;
 
       expect(mockAdapter.write).toHaveBeenCalledWith(
         expect.anything(),
-        expect.stringContaining('description: "Line1\nLine2\nLine3"')
+          expect.stringContaining('description: "Line1\\nLine2\\nLine3"')
       );
     });
 

--- a/tests/unit/providers/codex/runtime/CodexAppServerProcess.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexAppServerProcess.test.ts
@@ -1,9 +1,7 @@
-jest.mock('child_process', () => ({
-  spawn: jest.fn(),
-}));
+jest.mock('cross-spawn', () => jest.fn());
 
 import { createMockChildProcess, type MockChildProcess } from '@test/helpers/MockChildProcess';
-import { spawn } from 'child_process';
+import spawn from 'cross-spawn';
 
 import { CodexAppServerProcess } from '@/providers/codex/runtime/CodexAppServerProcess';
 import type { CodexLaunchSpec } from '@/providers/codex/runtime/codexLaunchTypes';
@@ -68,7 +66,7 @@ describe('CodexAppServerProcess', () => {
       );
     });
 
-    it('wraps Windows .cmd shims through cmd.exe and quotes shell metacharacters', () => {
+    it('passes Windows .cmd shims and shell metacharacters to cross-spawn', () => {
       Object.defineProperty(process, 'platform', { value: 'win32' });
 
       const server = new CodexAppServerProcess(createLaunchSpec({
@@ -77,11 +75,10 @@ describe('CodexAppServerProcess', () => {
       server.start();
 
       expect(mockSpawn).toHaveBeenCalledWith(
-        process.env.ComSpec || process.env.comspec || 'cmd.exe',
-        ['/d', '/s', '/c', '""C:\\Users\\R&D\\AppData\\Roaming\\npm\\codex.cmd" app-server --listen stdio://"'],
+        'C:\\Users\\R&D\\AppData\\Roaming\\npm\\codex.cmd',
+        ['app-server', '--listen', 'stdio://'],
         expect.objectContaining({
           windowsHide: true,
-          windowsVerbatimArguments: true,
         }),
       );
     });

--- a/tests/unit/providers/pi/runtime/PiSubprocess.test.ts
+++ b/tests/unit/providers/pi/runtime/PiSubprocess.test.ts
@@ -1,10 +1,7 @@
-jest.mock('node:child_process', () => ({
-  spawn: jest.fn(),
-}));
-
-import { spawn } from 'node:child_process';
+jest.mock('cross-spawn', () => jest.fn());
 
 import { createMockChildProcess, type MockChildProcess } from '@test/helpers/MockChildProcess';
+import spawn from 'cross-spawn';
 
 import { PiSubprocess } from '@/providers/pi/runtime/PiSubprocess';
 
@@ -49,7 +46,7 @@ describe('PiSubprocess', () => {
     }));
   });
 
-  it('wraps Windows .cmd shims through cmd.exe', () => {
+  it('passes Windows .cmd shims to cross-spawn', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     const subprocess = new PiSubprocess({
       args: ['--mode', 'rpc', '--system-prompt', 'Use R&D policy'],
@@ -61,12 +58,11 @@ describe('PiSubprocess', () => {
     subprocess.start();
 
     expect(mockSpawn).toHaveBeenCalledWith(
-      process.env.ComSpec || process.env.comspec || 'cmd.exe',
-      ['/d', '/s', '/c', '""C:\\Users\\R&D\\AppData\\Roaming\\npm\\pi.cmd" --mode rpc --system-prompt "Use R&D policy""'],
+      'C:\\Users\\R&D\\AppData\\Roaming\\npm\\pi.cmd',
+      ['--mode', 'rpc', '--system-prompt', 'Use R&D policy'],
       expect.objectContaining({
         cwd: 'C:\\Vault',
         windowsHide: true,
-        windowsVerbatimArguments: true,
       }),
     );
   });
@@ -84,16 +80,10 @@ describe('PiSubprocess', () => {
     subprocess.start();
 
     expect(mockSpawn).toHaveBeenCalledWith(
-      process.env.ComSpec || process.env.comspec || 'cmd.exe',
-      [
-        '/d',
-        '/s',
-        '/c',
-        '"C:\\Users\\dev\\AppData\\Roaming\\npm\\pi.cmd --mode rpc --session "D:\\文档\\Documents\\Atlas\\Pi Sessions\\session.jsonl""',
-      ],
+      'C:\\Users\\dev\\AppData\\Roaming\\npm\\pi.cmd',
+      ['--mode', 'rpc', '--session', sessionFile],
       expect.objectContaining({
         cwd: 'D:\\文档\\Documents\\Atlas',
-        windowsVerbatimArguments: true,
       }),
     );
   });

--- a/tests/unit/utils/env.test.ts
+++ b/tests/unit/utils/env.test.ts
@@ -669,11 +669,10 @@ describe('cliPathRequiresNode', () => {
     const scriptPath = isWindows ? 'C:\\temp\\claude' : '/tmp/claude';
     const shebang = '#!/usr/bin/env node\nconsole.log("hi");\n';
 
-    jest.spyOn(fs, 'existsSync').mockImplementation(p => String(p) === scriptPath);
-    jest.spyOn(fs, 'statSync').mockImplementation(
-      p => ({ isFile: () => String(p) === scriptPath }) as fsType.Stats
-    );
     jest.spyOn(fs, 'openSync').mockImplementation(() => 1 as any);
+    jest.spyOn(fs, 'fstatSync').mockImplementation(
+      () => ({ isFile: () => true }) as fsType.Stats
+    );
     jest.spyOn(fs, 'readSync').mockImplementation((_, buffer: ArrayBufferView) => {
       Buffer.from(buffer.buffer, buffer.byteOffset, buffer.byteLength).write(shebang);
       return shebang.length;
@@ -685,10 +684,11 @@ describe('cliPathRequiresNode', () => {
 
   it('returns false when path exists but is a directory', () => {
     const dirPath = isWindows ? 'C:\\temp\\claude' : '/tmp/claude';
-    jest.spyOn(fs, 'existsSync').mockImplementation(p => String(p) === dirPath);
-    jest.spyOn(fs, 'statSync').mockImplementation(
+    jest.spyOn(fs, 'openSync').mockImplementation(() => 1 as any);
+    jest.spyOn(fs, 'fstatSync').mockImplementation(
       () => ({ isFile: () => false }) as fsType.Stats
     );
+    jest.spyOn(fs, 'closeSync').mockImplementation(() => {});
 
     expect(cliPathRequiresNode(dirPath)).toBe(false);
   });
@@ -697,11 +697,10 @@ describe('cliPathRequiresNode', () => {
     const scriptPath = isWindows ? 'C:\\temp\\script' : '/tmp/script';
     const shebang = '#!/usr/bin/env python\nprint("hi")\n';
 
-    jest.spyOn(fs, 'existsSync').mockImplementation(p => String(p) === scriptPath);
-    jest.spyOn(fs, 'statSync').mockImplementation(
-      p => ({ isFile: () => String(p) === scriptPath }) as fsType.Stats
-    );
     jest.spyOn(fs, 'openSync').mockImplementation(() => 1 as any);
+    jest.spyOn(fs, 'fstatSync').mockImplementation(
+      () => ({ isFile: () => true }) as fsType.Stats
+    );
     jest.spyOn(fs, 'readSync').mockImplementation((_, buffer: ArrayBufferView) => {
       Buffer.from(buffer.buffer, buffer.byteOffset, buffer.byteLength).write(shebang);
       return shebang.length;
@@ -721,11 +720,10 @@ describe('cliPathRequiresNode', () => {
       '',
     ].join('\n');
 
-    jest.spyOn(fs, 'existsSync').mockImplementation(p => String(p) === scriptPath);
-    jest.spyOn(fs, 'statSync').mockImplementation(
-      p => ({ isFile: () => String(p) === scriptPath }) as fsType.Stats
-    );
     jest.spyOn(fs, 'openSync').mockImplementation(() => 1 as any);
+    jest.spyOn(fs, 'fstatSync').mockImplementation(
+      () => ({ isFile: () => true }) as fsType.Stats
+    );
     jest.spyOn(fs, 'readSync').mockImplementation((_, buffer: ArrayBufferView) => {
       Buffer.from(buffer.buffer, buffer.byteOffset, buffer.byteLength).write(script);
       return script.length;

--- a/tests/unit/utils/slashCommand.test.ts
+++ b/tests/unit/utils/slashCommand.test.ts
@@ -571,7 +571,7 @@ describe('yamlString', () => {
   });
 
   it('quotes strings with newlines', () => {
-    expect(yamlString('line1\nline2')).toBe('"line1\nline2"');
+    expect(yamlString('line1\nline2')).toBe('"line1\\nline2"');
   });
 
   it('quotes strings starting with space', () => {
@@ -584,6 +584,11 @@ describe('yamlString', () => {
 
   it('escapes double quotes inside quoted strings', () => {
     expect(yamlString('has "quotes" inside: yes')).toBe('"has \\"quotes\\" inside: yes"');
+  });
+
+  it('escapes backslashes inside quoted strings', () => {
+    expect(yamlString(String.raw`C:\Users\name: value`))
+      .toBe('"C:\\\\Users\\\\name: value"');
   });
 });
 


### PR DESCRIPTION
## Summary
- prevent build arguments from being evaluated by a shell
- preserve opened-file identity while detecting Node-backed CLIs
- safely serialize slash-command YAML values
- launch Windows .cmd provider shims with cross-spawn instead of command-string interpolation

## Scope
Adapted the upstream CodeQL fixes that apply to Oh My Claudian's local-first architecture. Collab-only changes remain intentionally excluded.

## Verification
- pnpm run typecheck
- pnpm run lint
- pnpm run test
- pnpm run build