### PR TITLE
fix: restore Claude response duration from history

### DIFF
--- a/src/providers/claude/history/ClaudeHistoryStore.ts
+++ b/src/providers/claude/history/ClaudeHistoryStore.ts
@@ -148,10 +148,24 @@ export async function loadSDKSessionMessages(
   const toolResults = collectToolResults(filteredEntries);
   const toolUseResults = collectStructuredPatchResults(filteredEntries);
   const asyncSubagentResults = collectAsyncSubagentResults(filteredEntries);
+  const nativeTurnDurations = collectNativeTurnDurations(result.messages);
 
   const chatMessages: ChatMessage[] = [];
   let pendingAssistant: ChatMessage | null = null;
   const taskToolNormalizer = new ClaudeTaskToolNormalizer();
+
+  const flushPendingAssistant = (includeDuration: boolean): void => {
+    if (pendingAssistant) {
+      const nativeDuration = pendingAssistant.assistantMessageId
+        ? nativeTurnDurations.get(pendingAssistant.assistantMessageId)
+        : undefined;
+      if (includeDuration && nativeDuration !== undefined && nativeDuration > 0) {
+        pendingAssistant.durationSeconds = nativeDuration;
+      }
+      chatMessages.push(pendingAssistant);
+    }
+    pendingAssistant = null;
+  };
 
   // Merge consecutive assistant messages until an actual user message appears
   for (const sdkMsg of filteredEntries) {
@@ -168,28 +182,20 @@ export async function loadSDKSessionMessages(
       // context_compacted must not merge with previous assistant (it's a standalone separator)
       const isCompactBoundary = chatMsg.contentBlocks?.some(b => b.type === 'context_compacted');
       if (isCompactBoundary) {
-        if (pendingAssistant) {
-          chatMessages.push(pendingAssistant);
-        }
+        flushPendingAssistant(true);
         chatMessages.push(chatMsg);
-        pendingAssistant = null;
       } else if (pendingAssistant) {
         mergeAssistantMessage(pendingAssistant, chatMsg);
       } else {
         pendingAssistant = chatMsg;
       }
     } else {
-      if (pendingAssistant) {
-        chatMessages.push(pendingAssistant);
-        pendingAssistant = null;
-      }
+      flushPendingAssistant(!chatMsg.isInterrupt);
       chatMessages.push(chatMsg);
     }
   }
 
-  if (pendingAssistant) {
-    chatMessages.push(pendingAssistant);
-  }
+  flushPendingAssistant(true);
 
   hydrateStructuredToolResults(chatMessages, toolUseResults);
   hydrateFallbackAskUserAnswers(chatMessages);
@@ -250,6 +256,52 @@ export async function loadSDKSessionMessages(
   chatMessages.sort((a, b) => a.timestamp - b.timestamp);
 
   return { messages: chatMessages, skippedLines: result.skippedLines };
+}
+
+function collectNativeTurnDurations(
+  entries: SDKNativeMessage[],
+): Map<string, number> {
+  const durations = new Map<string, number>();
+  const entriesByUuid = new Map<string, SDKNativeMessage>();
+  for (const entry of entries) {
+    if (entry.uuid && !entriesByUuid.has(entry.uuid)) {
+      entriesByUuid.set(entry.uuid, entry);
+    }
+  }
+
+  for (const entry of entries) {
+    if (
+      entry.type !== 'system'
+      || entry.subtype !== 'turn_duration'
+      || typeof entry.parentUuid !== 'string'
+      || typeof entry.durationMs !== 'number'
+      || !Number.isFinite(entry.durationMs)
+      || entry.durationMs < 0
+    ) continue;
+
+    const assistantUuid = resolveTurnDurationAssistantUuid(entry.parentUuid, entriesByUuid);
+    if (assistantUuid) {
+      durations.set(assistantUuid, Math.floor(entry.durationMs / 1_000));
+    }
+  }
+  return durations;
+}
+
+function resolveTurnDurationAssistantUuid(
+  parentUuid: string,
+  entriesByUuid: ReadonlyMap<string, SDKNativeMessage>,
+): string | null {
+  const seen = new Set<string>();
+  let currentUuid: string | null = parentUuid;
+  while (currentUuid && !seen.has(currentUuid)) {
+    seen.add(currentUuid);
+    const entry = entriesByUuid.get(currentUuid);
+    if (!entry) return null;
+    if (entry.type === 'assistant') return currentUuid;
+    if (entry.type !== 'system') return null;
+    currentUuid = typeof entry.parentUuid === 'string' ? entry.parentUuid : null;
+  }
+  return null;
 }
 
 export function getLastSDKSessionModel(

--- a/src/providers/claude/history/sdkHistoryTypes.ts
+++ b/src/providers/claude/history/sdkHistoryTypes.ts
@@ -20,6 +20,7 @@ export interface SDKNativeMessage {
     model?: string;
   };
   subtype?: string;
+  durationMs?: number;
   duration_ms?: number;
   duration_api_ms?: number;
   toolUseResult?: unknown;

--- a/tests/unit/utils/sdkSession.test.ts
+++ b/tests/unit/utils/sdkSession.test.ts
@@ -1125,6 +1125,23 @@ describe('sdkSession', () => {
       expect(result.messages[2].content).toBe('Thanks');
     });
 
+    it('restores response duration from Claude turn metadata', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockFsPromises.readFile.mockResolvedValue([
+        '{"type":"user","uuid":"u1","timestamp":"2024-01-15T10:00:00Z","message":{"content":"Inspect the project"}}',
+        '{"type":"assistant","uuid":"a1","timestamp":"2024-01-15T10:00:09Z","message":{"content":[{"type":"text","text":"Inspection complete."}]}}',
+        '{"type":"system","subtype":"turn_duration","uuid":"duration-1","parentUuid":"a1","timestamp":"2024-01-15T10:00:09.100Z","durationMs":4500}',
+      ].join('\n'));
+
+      const result = await loadSDKSessionMessages('/Users/test/vault', 'session-native-duration');
+
+      expect(result.messages[1]).toMatchObject({
+        role: 'assistant',
+        content: 'Inspection complete.',
+        durationSeconds: 4,
+      });
+    });
+
     it('sorts messages by timestamp ascending', async () => {
       mockExistsSync.mockReturnValue(true);
       mockFsPromises.readFile.mockResolvedValue([


### PR DESCRIPTION
## Summary
- project Claude turn_duration metadata into replayed assistant messages
- resolve duration metadata through system-record ancestry
- preserve the existing rule that interrupted turns have no response duration

## Verification
- pnpm run typecheck
- pnpm run lint
- pnpm run test
- pnpm run build