### PR TITLE
fix: preserve Pi Windows shim arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
           tests/unit/providers/acp/AcpSubprocess.test.ts
           tests/unit/providers/codex/runtime/CodexAppServerProcess.test.ts
           tests/unit/providers/pi/runtime/PiSubprocess.test.ts
+          tests/integration/providers/pi/PiSubprocess.windows.test.ts
 
       - name: Build
         run: pnpm run build

--- a/src/providers/pi/runtime/PiSubprocess.ts
+++ b/src/providers/pi/runtime/PiSubprocess.ts
@@ -1,9 +1,15 @@
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { ManagedSubprocess } from '@/core/process/ManagedSubprocess';
-import { getEnhancedPath } from '@/utils/env';
+import {
+  cliPathRequiresNode,
+  findNodeExecutable,
+  getEnhancedPath,
+} from '@/utils/env';
 
 const STDERR_BUFFER_LIMIT = 8_000;
+const PI_PACKAGE_NAME = '@earendil-works/pi-coding-agent';
 
 export interface PiSubprocessLaunchSpec {
   args: string[];
@@ -14,16 +20,149 @@ export interface PiSubprocessLaunchSpec {
 
 export class PiSubprocess extends ManagedSubprocess {
   constructor(launchSpec: PiSubprocessLaunchSpec) {
+    const enhancedPath = getEnhancedPath(
+      launchSpec.env.PATH,
+      path.isAbsolute(launchSpec.command) ? launchSpec.command : undefined,
+    );
+    const processSpec = resolvePiProcessSpec(launchSpec, enhancedPath);
     super({
       ...launchSpec,
+      ...processSpec,
       env: {
         ...launchSpec.env,
-        PATH: getEnhancedPath(
-          launchSpec.env.PATH,
-          path.isAbsolute(launchSpec.command) ? launchSpec.command : undefined,
-        ),
+        PATH: enhancedPath,
       },
       stderrBufferLimit: STDERR_BUFFER_LIMIT,
     });
+  }
+}
+
+function resolvePiProcessSpec(
+  launchSpec: PiSubprocessLaunchSpec,
+  enhancedPath: string,
+): Pick<PiSubprocessLaunchSpec, 'args' | 'command'> {
+  const command = launchSpec.command.trim();
+  if (process.platform !== 'win32') {
+    return { args: launchSpec.args, command };
+  }
+
+  let nodeEntrypoint: string | null = null;
+  if (command.toLowerCase().endsWith('.cmd')) {
+    nodeEntrypoint = resolveInstalledPiBin(command);
+    if (!nodeEntrypoint) {
+      throw new Error(
+        `The Pi Windows launcher could not be resolved to its Node.js entry point: ${command}`,
+      );
+    }
+  } else if (cliPathRequiresNode(command)) {
+    nodeEntrypoint = command;
+  }
+
+  if (!nodeEntrypoint) {
+    return { args: launchSpec.args, command };
+  }
+
+  const nodeExecutable = findNodeExecutable(enhancedPath);
+  if (!nodeExecutable) {
+    throw new Error(
+      'Pi requires Node.js, but node.exe was not found on PATH. Install Node.js or configure a native Pi executable.',
+    );
+  }
+  return {
+    args: [nodeEntrypoint, ...launchSpec.args],
+    command: nodeExecutable,
+  };
+}
+
+function resolveInstalledPiBin(command: string): string | null {
+  if (path.basename(command).toLowerCase() !== 'pi.cmd') return null;
+
+  const shimTarget = readWindowsCommandShimTarget(command);
+  return shimTarget ? resolveOwningPiPackageBin(shimTarget) : null;
+}
+
+function readWindowsCommandShimTarget(command: string): string | null {
+  try {
+    const contents = fs.readFileSync(command, 'utf8');
+    for (const rawLine of contents.split(/\r?\n/u)) {
+      const line = rawLine.trim();
+      const relativeMatch = /"%(?:~dp0|dp0%)\\([^"\r\n]+?)"\s+%\*\s*$/iu.exec(line);
+      if (
+        relativeMatch?.[1]
+        && isSupportedWindowsNodeInvocation(line.slice(0, relativeMatch.index))
+      ) {
+        const relativeTarget = relativeMatch[1].replace(/[\\/]/gu, path.sep);
+        return path.resolve(path.dirname(command), relativeTarget);
+      }
+
+      const absoluteMatch = /"([^"\r\n]+)"\s+%\*\s*$/u.exec(line);
+      if (
+        absoluteMatch?.[1]
+        && path.isAbsolute(absoluteMatch[1])
+        && isSupportedWindowsNodeInvocation(line.slice(0, absoluteMatch.index))
+      ) {
+        return path.normalize(absoluteMatch[1]);
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function isSupportedWindowsNodeInvocation(value: string): boolean {
+  const invocation = value.trim().replace(/^@/u, '').trim();
+  if (/^node(?:\.exe)?$/iu.test(invocation)) return true;
+  if (/^"%~dp0\\node(?:\.exe)?"$/iu.test(invocation)) return true;
+  if (/^"(?:[a-z]:[\\/]|\\\\)[^"\r\n]*[\\/]node(?:\.exe)?"$/iu.test(invocation)) {
+    return true;
+  }
+  return /^endLocal\s+&\s+goto\s+#_undefined_#\s+2>NUL\s+\|\|\s+title\s+%COMSPEC%\s+&\s+(?:set\s+PATHEXT=[^&\r\n]+\s+&\s+)?"%_prog%"$/iu.test(invocation);
+}
+
+function resolveOwningPiPackageBin(target: string): string | null {
+  const resolvedTarget = path.resolve(target);
+  let current = path.dirname(resolvedTarget);
+  while (true) {
+    const binPath = readPiPackageBin(current);
+    if (binPath && pathsEqual(binPath, resolvedTarget)) return binPath;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return null;
+}
+
+function pathsEqual(left: string, right: string): boolean {
+  const normalizedLeft = path.normalize(left);
+  const normalizedRight = path.normalize(right);
+  return process.platform === 'win32'
+    ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+    : normalizedLeft === normalizedRight;
+}
+
+function readPiPackageBin(packageRoot: string): string | null {
+  try {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'),
+    ) as {
+      bin?: string | Record<string, unknown>;
+      name?: unknown;
+    };
+    if (packageJson.name !== PI_PACKAGE_NAME) return null;
+    const relativeBin = typeof packageJson.bin === 'object'
+      && packageJson.bin !== null
+      && typeof packageJson.bin.pi === 'string'
+      ? packageJson.bin.pi
+      : null;
+    if (!relativeBin) return null;
+
+    const resolvedRoot = path.resolve(packageRoot);
+    const resolvedBin = path.resolve(resolvedRoot, relativeBin);
+    const relative = path.relative(resolvedRoot, resolvedBin);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) return null;
+    return fs.statSync(resolvedBin).isFile() ? resolvedBin : null;
+  } catch {
+    return null;
   }
 }

--- a/tests/integration/providers/pi/PiSubprocess.windows.test.ts
+++ b/tests/integration/providers/pi/PiSubprocess.windows.test.ts
@@ -1,0 +1,110 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { PiSubprocess } from '@/providers/pi/runtime/PiSubprocess';
+
+const describeOnWindows = process.platform === 'win32' ? describe : describe.skip;
+
+describeOnWindows('PiSubprocess Windows argv integration', () => {
+  it('preserves opaque arguments after bypassing the npm command shim', async () => {
+    const npmPrefix = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-argv-integration-'));
+    const packageRoot = path.join(
+      npmPrefix,
+      'node_modules',
+      '@earendil-works',
+      'pi-coding-agent',
+    );
+    const cliPath = path.join(packageRoot, 'dist', 'bundle', 'cli.js');
+    const commandPath = path.join(npmPrefix, 'pi.cmd');
+    const expectedArgs = [
+      '--mode',
+      'rpc',
+      '--system-prompt',
+      'First line\r\nSecond line with "%PATH%" and !caret^',
+      '--session',
+      'D:\\文档\\Pi Sessions\\session.jsonl',
+    ];
+    let subprocess: PiSubprocess | null = null;
+
+    try {
+      await fs.mkdir(path.dirname(cliPath), { recursive: true });
+      await fs.writeFile(path.join(packageRoot, 'package.json'), JSON.stringify({
+        bin: { pi: 'dist/bundle/cli.js' },
+        name: '@earendil-works/pi-coding-agent',
+      }));
+      await fs.writeFile(cliPath, [
+        'process.stdout.write(`${JSON.stringify(process.argv.slice(2))}\\n`);',
+        'process.stdin.resume();',
+      ].join('\n'));
+      await fs.writeFile(commandPath, createWindowsCommandShim(commandPath, cliPath));
+
+      subprocess = new PiSubprocess({
+        args: expectedArgs,
+        command: commandPath,
+        cwd: npmPrefix,
+        env: { ...process.env },
+      });
+      subprocess.start();
+
+      await expect(readFirstLine(subprocess)).resolves.toEqual(expectedArgs);
+    } finally {
+      await subprocess?.shutdown();
+      await fs.rm(npmPrefix, { force: true, recursive: true });
+    }
+  });
+});
+
+function createWindowsCommandShim(commandPath: string, targetPath: string): string {
+  const relativeTarget = path.relative(path.dirname(commandPath), targetPath)
+    .split(path.sep)
+    .join('\\');
+  return [
+    '@ECHO off',
+    'GOTO start',
+    ':find_dp0',
+    'SET dp0=%~dp0',
+    'EXIT /b',
+    ':start',
+    'SETLOCAL',
+    'CALL :find_dp0',
+    'IF EXIST "%dp0%\\node.exe" (',
+    '  SET "_prog=%dp0%\\node.exe"',
+    ') ELSE (',
+    '  SET "_prog=node"',
+    ')',
+    `endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\${relativeTarget}" %*`,
+    '',
+  ].join('\r\n');
+}
+
+function readFirstLine(subprocess: PiSubprocess): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let buffered = '';
+    const timeout = window.setTimeout(() => {
+      cleanup();
+      reject(new Error('Timed out waiting for the Pi argv fixture'));
+    }, 10_000);
+    const onData = (chunk: Buffer | string): void => {
+      buffered += chunk.toString();
+      const newlineIndex = buffered.indexOf('\n');
+      if (newlineIndex < 0) return;
+      cleanup();
+      try {
+        resolve(JSON.parse(buffered.slice(0, newlineIndex)) as unknown);
+      } catch (error) {
+        reject(error);
+      }
+    };
+    const removeCloseListener = subprocess.onClose(error => {
+      cleanup();
+      reject(error ?? new Error('Pi argv fixture exited before producing output'));
+    });
+    const cleanup = (): void => {
+      window.clearTimeout(timeout);
+      subprocess.stdout.off('data', onData);
+      removeCloseListener();
+    };
+    subprocess.stdout.on('data', onData);
+  });
+}

--- a/tests/unit/providers/pi/runtime/PiSubprocess.test.ts
+++ b/tests/unit/providers/pi/runtime/PiSubprocess.test.ts
@@ -46,73 +46,14 @@ describe('PiSubprocess', () => {
     }));
   });
 
-  it('passes Windows .cmd shims to cross-spawn', () => {
+  it('fails closed for an unverified Windows command shim', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
-    const subprocess = new PiSubprocess({
-      args: ['--mode', 'rpc', '--system-prompt', 'Use R&D policy'],
-      command: 'C:\\Users\\R&D\\AppData\\Roaming\\npm\\pi.cmd',
-      cwd: 'C:\\Vault',
-      env: { PATH: 'C:\\Windows\\System32' },
-    });
-
-    subprocess.start();
-
-    expect(mockSpawn).toHaveBeenCalledWith(
-      'C:\\Users\\R&D\\AppData\\Roaming\\npm\\pi.cmd',
-      ['--mode', 'rpc', '--system-prompt', 'Use R&D policy'],
-      expect.objectContaining({
-        cwd: 'C:\\Vault',
-        windowsHide: true,
-      }),
-    );
-  });
-
-  it('preserves Unicode Windows session paths when resuming through a .cmd shim', () => {
-    Object.defineProperty(process, 'platform', { value: 'win32' });
-    const sessionFile = 'D:\\文档\\Documents\\Atlas\\Pi Sessions\\session.jsonl';
-    const subprocess = new PiSubprocess({
-      args: ['--mode', 'rpc', '--session', sessionFile],
-      command: 'C:\\Users\\dev\\AppData\\Roaming\\npm\\pi.cmd',
-      cwd: 'D:\\文档\\Documents\\Atlas',
-      env: { PATH: 'C:\\Windows\\System32' },
-    });
-
-    subprocess.start();
-
-    expect(mockSpawn).toHaveBeenCalledWith(
-      'C:\\Users\\dev\\AppData\\Roaming\\npm\\pi.cmd',
-      ['--mode', 'rpc', '--session', sessionFile],
-      expect.objectContaining({
-        cwd: 'D:\\文档\\Documents\\Atlas',
-      }),
-    );
-  });
-
-  it('kills the process tree when shutting down Windows .cmd shims', async () => {
-    Object.defineProperty(process, 'platform', { value: 'win32' });
-    const subprocess = new PiSubprocess({
+    expect(() => new PiSubprocess({
       args: ['--mode', 'rpc'],
-      command: 'C:\\Users\\R&D\\AppData\\Roaming\\npm\\pi.cmd',
+      command: '/missing/pi.cmd',
       cwd: 'C:\\Vault',
       env: { PATH: 'C:\\Windows\\System32' },
-    });
-    subprocess.start();
-
-    const shutdown = subprocess.shutdown();
-
-    expect(mockSpawn).toHaveBeenCalledWith(
-      'taskkill.exe',
-      ['/pid', '12345', '/t', '/f'],
-      expect.objectContaining({
-        stdio: 'ignore',
-        windowsHide: true,
-      }),
-    );
-    expect(proc.kill).not.toHaveBeenCalled();
-
-    proc.exitCode = 0;
-    proc.emit('exit', 0, null);
-    await shutdown;
+    })).toThrow('could not be resolved to its Node.js entry point');
   });
 
   it('keeps a bounded stderr snapshot for runtime errors', () => {


### PR DESCRIPTION
## Summary

- Resolve verified Pi npm command shims to their package-owned Node entry point on Windows.
- Preserve multiline, shell-sensitive, and Unicode Pi arguments without routing through `cmd.exe`.
- Add a real Windows argv integration test to the provider runtime CI job.

## Verification

- `pnpm run test:unit -- --runInBand tests/unit/core/process/ManagedStdioProcess.test.ts tests/unit/providers/acp/AcpSubprocess.test.ts tests/unit/providers/codex/runtime/CodexAppServerProcess.test.ts tests/unit/providers/pi/runtime/PiSubprocess.test.ts tests/integration/providers/pi/PiSubprocess.windows.test.ts`
- `pnpm run typecheck`
- `pnpm run lint` (9 existing warnings)
- `pnpm run test`
- `pnpm run build`