### PR TITLE
fix: keep reasoning selector accessible

### DIFF
--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -303,8 +303,22 @@ export class ThinkingBudgetSelector {
     const options = uiConfig.getReasoningOptions(model, settings);
     const currentInfo = options.find(e => e.value === currentEffort);
 
-    const currentEl = this.effortGearsEl.createDiv({ cls: 'claudian-thinking-current' });
+    const currentEl = this.effortGearsEl.createEl('button', {
+      cls: 'claudian-thinking-current',
+      type: 'button',
+    });
     currentEl.setText(currentInfo?.label || options[0]?.label || 'High');
+    currentEl.setAttribute('aria-expanded', 'false');
+    currentEl.setAttribute('aria-haspopup', 'listbox');
+    currentEl.addEventListener('click', (event) => {
+      event.stopPropagation();
+      const isOpen = !this.effortGearsEl?.hasClass('is-open');
+      this.effortGearsEl?.toggleClass('is-open', isOpen);
+      currentEl.setAttribute(
+        'aria-expanded',
+        isOpen ? 'true' : 'false',
+      );
+    });
 
     const optionsEl = this.effortGearsEl.createDiv({ cls: 'claudian-thinking-options' });
 

--- a/src/style/toolbar/thinking-selector.css
+++ b/src/style/toolbar/thinking-selector.css
@@ -23,12 +23,16 @@
   display: flex;
   align-items: center;
   border-radius: 4px;
+  z-index: 1;
 }
 
 /* Current selection (visible when collapsed) */
 .claudian-thinking-current {
+  border: 0;
   padding: 4px 6px;
   font-size: 11px;
+  background: transparent;
+  box-shadow: none;
   color: var(--claudian-brand);
   font-weight: 500;
   cursor: pointer;
@@ -46,7 +50,8 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
-  background: var(--background-secondary);
+  z-index: 2;
+  background: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
   border-radius: 4px;
   padding: 4px;
@@ -56,7 +61,9 @@
 }
 
 /* Expand on hover */
-.claudian-thinking-gears:hover .claudian-thinking-options {
+.claudian-thinking-gears:hover .claudian-thinking-options,
+.claudian-thinking-gears:focus-within .claudian-thinking-options,
+.claudian-thinking-gears.is-open .claudian-thinking-options {
   opacity: 1;
   visibility: visible;
 }

--- a/tests/integration/providers/pi/PiSubprocess.windows.test.ts
+++ b/tests/integration/providers/pi/PiSubprocess.windows.test.ts
@@ -52,7 +52,7 @@ describeOnWindows('PiSubprocess Windows argv integration', () => {
       await subprocess?.shutdown();
       await fs.rm(npmPrefix, { force: true, recursive: true });
     }
-  });
+  }, 20_000);
 });
 
 function createWindowsCommandShim(commandPath: string, targetPath: string): string {


### PR DESCRIPTION
## Summary

- make the reasoning selector explicitly clickable instead of hover-only
- keep the options visible while hovered, focused, or opened
- render the menu on an opaque surface above the composer

## Verification

- `pnpm run test:unit -- --runInBand tests/unit/features/chat/ui/InputToolbar.test.ts`
- `pnpm run typecheck`
- `pnpm run build`