### PR TITLE
fix: avoid duplicate Claude API error text

### DIFF
--- a/src/providers/claude/execution/ClaudeExecutionEventNormalizer.ts
+++ b/src/providers/claude/execution/ClaudeExecutionEventNormalizer.ts
@@ -262,6 +262,8 @@ export class ClaudeExecutionEventNormalizer {
       return;
     }
 
+    if (chunk.type === 'text' && isSyntheticApiErrorMessage(message)) return;
+
     if (
       (chunk.type === 'text' || chunk.type === 'thinking')
       && message.type === 'stream_event'
@@ -507,6 +509,20 @@ function normalizeToolCompleted(
     isBlocked: state.blockedToolIds.has(chunk.id),
     toolUseResult: chunk.toolUseResult,
   };
+}
+
+function isSyntheticApiErrorMessage(message: SDKMessage): boolean {
+  if (message.type !== 'assistant') return false;
+  if (typeof message.error !== 'string' || message.error.trim() === '') return false;
+  const wireOnly = message as unknown as {
+    isApiErrorMessage?: unknown;
+    apiErrorStatus?: unknown;
+  };
+  return (
+    wireOnly.isApiErrorMessage === true
+    || typeof wireOnly.apiErrorStatus === 'number'
+    || (message.message as { model?: unknown } | undefined)?.model === '<synthetic>'
+  );
 }
 
 function isAssistantOutputChunk(chunk: StreamChunk): boolean {

--- a/tests/unit/providers/claude/execution/ClaudeExecutionEventNormalizer.test.ts
+++ b/tests/unit/providers/claude/execution/ClaudeExecutionEventNormalizer.test.ts
@@ -137,3 +137,42 @@ describe('ClaudeExecutionEventNormalizer task tools', () => {
     }));
   });
 });
+
+describe('ClaudeExecutionEventNormalizer API errors', () => {
+  const resetText = "You've hit your session limit · resets 4:10pm (Europe/Berlin)";
+
+  const apiErrorMessage = () => msg({
+    type: 'assistant',
+    error: 'rate_limit',
+    isApiErrorMessage: true,
+    apiErrorStatus: 429,
+    message: {
+      model: '<synthetic>',
+      content: [{ type: 'text', text: resetText }],
+    },
+  });
+
+  it('uses synthetic API error text for the native error', () => {
+    const events = new ClaudeExecutionEventNormalizer().normalize(
+      apiErrorMessage(),
+      'requested',
+    );
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'native_error',
+      message: resetText,
+    }));
+  });
+
+  it('does not render synthetic API error text twice', () => {
+    const events = new ClaudeExecutionEventNormalizer().normalize(
+      apiErrorMessage(),
+      'requested',
+    );
+
+    expect(events).not.toContainEqual(expect.objectContaining({
+      type: 'output',
+      event: expect.objectContaining({ type: 'text_delta', text: resetText }),
+    }));
+  });
+});


### PR DESCRIPTION
## Summary\n\n- keep readable Claude synthetic API errors in the native error event\n- avoid rendering the same API error text as assistant output\n- cover the synthetic API error path with regression tests\n\n## Verification\n\n- pnpm run test:unit -- --runInBand tests/unit/providers/claude/execution/ClaudeExecutionEventNormalizer.test.ts\n- pnpm run typecheck\n- pnpm run lint (9 existing warnings)