### PR TITLE
feat: CLI lifecycle management merged into provider readiness

### DIFF
--- a/src/core/process/ManagedCommandRunner.ts
+++ b/src/core/process/ManagedCommandRunner.ts
@@ -12,12 +12,16 @@ export interface ManagedCommandRequest {
   spawn?: ManagedStdioProcessOptions['spawn'];
   timeoutMs: number;
   stdoutLimitBytes: number;
+  /** Also pipe stderr and expose it on the result. Defaults to false. */
+  captureStderr?: boolean;
 }
 
 export interface ManagedCommandResult {
   exitCode: number | null;
   stdout: string;
   termination?: ManagedCommandTermination;
+  /** Captured stderr output when `captureStderr` is enabled. */
+  stderr?: string;
 }
 
 export class ManagedCommandRunner {
@@ -35,9 +39,10 @@ export class ManagedCommandRunner {
         finalShutdownTimeoutMs: 0,
         sigkillTimeoutMs: 0,
         spawn: request.spawn,
-        stdio: ['ignore', 'pipe', 'ignore'],
+        stdio: request.captureStderr ? 'pipe' : ['ignore', 'pipe', 'ignore'],
       });
       const chunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
       let byteLength = 0;
       let settled = false;
       let timeout: number | null = null;
@@ -67,10 +72,14 @@ export class ManagedCommandRunner {
           finish({ exitCode: null, stdout: '', termination: 'error' });
           return;
         }
-        finish({
+        const result: ManagedCommandResult = {
           exitCode: code,
           stdout: Buffer.concat(chunks).toString('utf8'),
-        });
+        };
+        if (stderrChunks.length > 0) {
+          result.stderr = Buffer.concat(stderrChunks).toString('utf8');
+        }
+        finish(result);
       });
 
       try {
@@ -94,6 +103,12 @@ export class ManagedCommandRunner {
         }
         chunks.push(buffer);
       });
+
+      if (request.captureStderr) {
+        process.stderr.on('data', (chunk: Buffer | string) => {
+          stderrChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        });
+      }
     });
   }
 }

--- a/src/core/providers/cli/CliProviderMetadata.ts
+++ b/src/core/providers/cli/CliProviderMetadata.ts
@@ -1,0 +1,112 @@
+/**
+ * Per-provider CLI metadata for version probing, install, and update.
+ *
+ * Each provider that exposes a CLI registers its metadata here. Core tools
+ * use this information to check local version, query the latest release,
+ * and run lifecycle actions (install/update).
+ */
+
+/** A structured command to execute (safe across platforms via cross-spawn). */
+export interface CliCommand {
+  command: string;
+  args: string[];
+}
+
+/**
+ * Per-provider CLI metadata for version probing, install, and update.
+ *
+ * Each provider that exposes a CLI registers its metadata here. Core tools
+ * use this information to check local version, query the latest release,
+ * and run lifecycle actions (install/update).
+ */
+export interface CliProviderMetadata {
+  /** Binary name used for PATH lookup (e.g. "grok", "claude", "codex"). */
+  binaryName: string;
+
+  /** Human-readable display name for the CLI (e.g. "Grok CLI"). */
+  displayName: string;
+
+  /** npm package name for registry-based version checking and install. */
+  npmPackage?: string;
+
+  /** Optional URL to an official shell installer script (macOS/Linux). */
+  installerUrl?: string;
+
+  /** Structured install command. Defaults to `npm install -g <pkg>@latest`. */
+  install?: CliCommand;
+
+  /** Structured update command. Defaults to the CLI's native update or npm update. */
+  update?: CliCommand;
+
+  /** Platform-specific overrides (applied before the generic fields). */
+  platform?: Partial<Record<NodeJS.Platform, CliPlatformOverrides>>;
+}
+
+/** Platform-specific overrides for a CLI lifecycle command. */
+export interface CliPlatformOverrides {
+  install?: CliCommand;
+  update?: CliCommand;
+  installerUrl?: string;
+}
+
+/** Result of a local version probe. */
+export interface CliVersionProbeResult {
+  /** Local version string, or null if the CLI is not installed. */
+  version: string | null;
+  /** Error message when the probe failed. */
+  error: string | null;
+  /** CLI exists but --version failed (installed but broken). */
+  installedButBroken: boolean;
+}
+
+/** Complete version info combining local probe and remote latest. */
+export interface CliVersionInfo {
+  /** Local version string, null if not installed. */
+  version: string | null;
+  /** Latest version from the package registry, null if unavailable. */
+  latestVersion: string | null;
+  /** Error message from the local probe. */
+  error: string | null;
+  /** CLI exists but --version failed. */
+  installedButBroken: boolean;
+}
+
+/** Resolve the effective install command for a metadata entry on the current platform. */
+export function resolveCliInstallCommand(metadata: CliProviderMetadata): CliCommand | null {
+  const platformOverride = metadata.platform?.[process.platform];
+  if (platformOverride?.install) {
+    return platformOverride.install;
+  }
+  if (metadata.install) {
+    return metadata.install;
+  }
+  if (metadata.npmPackage) {
+    return { command: 'npm', args: ['install', '-g', `${metadata.npmPackage}@latest`] };
+  }
+  return null;
+}
+
+/** Resolve the effective update command for a metadata entry on the current platform. */
+export function resolveCliUpdateCommand(metadata: CliProviderMetadata): CliCommand | null {
+  const platformOverride = metadata.platform?.[process.platform];
+  if (platformOverride?.update) {
+    return platformOverride.update;
+  }
+  if (metadata.update) {
+    return metadata.update;
+  }
+  if (metadata.npmPackage) {
+    // `npm update -g <pkg>` is a no-op when the current version already
+    // satisfies the installed range, and exits 0 even though nothing changed.
+    // `npm install -g <pkg>@latest` forces the latest release — same as
+    // cc-switch's npm_install_command_for.
+    return { command: 'npm', args: ['install', '-g', `${metadata.npmPackage}@latest`] };
+  }
+  return null;
+}
+
+/** Resolve the effective installer URL for the current platform. */
+export function resolveCliInstallerUrl(metadata: CliProviderMetadata): string | null {
+  const platformOverride = metadata.platform?.[process.platform];
+  return platformOverride?.installerUrl ?? metadata.installerUrl ?? null;
+}

--- a/src/core/providers/cli/CliVersionUtils.ts
+++ b/src/core/providers/cli/CliVersionUtils.ts
@@ -1,0 +1,243 @@
+import { findCliBinaryPath } from '../../../utils/cliBinaryLocator';
+import { buildShellCommand, shellQuote } from '../../../utils/shell';
+import { ManagedCommandRunner } from '../../process/ManagedCommandRunner';
+import type { CliVersionInfo, CliVersionProbeResult } from './CliProviderMetadata';
+
+// Regex to extract semver from CLI --version output (e.g. "grok 2.1.156" → "2.1.156")
+const VERSION_RE = /\d+\.\d+\.\d+(-[\w.]+)?/;
+
+interface VersionParts {
+  core: [number, number, number];
+  pre: string[];
+}
+
+function parseVersion(v: string): VersionParts | null {
+  const m = v.trim().match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?/);
+  if (!m) return null;
+  return {
+    core: [Number(m[1]), Number(m[2]), Number(m[3])],
+    pre: m[4] ? m[4].split('.') : [],
+  };
+}
+
+function comparePre(a: string[], b: string[]): number {
+  if (a.length === 0 && b.length === 0) return 0;
+  if (a.length === 0) return 1;
+  if (b.length === 0) return -1;
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const aNum = /^\d+$/.test(a[i]);
+    const bNum = /^\d+$/.test(b[i]);
+    if (aNum && bNum) {
+      const d = Number(a[i]) - Number(b[i]);
+      if (d !== 0) return d < 0 ? -1 : 1;
+    } else if (aNum) {
+      return -1;
+    } else if (bNum) {
+      return 1;
+    } else if (a[i] !== b[i]) {
+      return a[i] < b[i] ? -1 : 1;
+    }
+  }
+  return a.length === b.length ? 0 : a.length < b.length ? -1 : 1;
+}
+
+/**
+ * Compare two semver strings. Returns >0 if a > b, <0 if a < b, 0 if equal or
+ * either cannot be parsed.
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  if (!pa || !pb) return 0;
+  for (let i = 0; i < 3; i++) {
+    const d = pa.core[i] - pb.core[i];
+    if (d !== 0) return d < 0 ? -1 : 1;
+  }
+  return comparePre(pa.pre, pb.pre);
+}
+
+/**
+ * Whether an update is available: latest is strictly greater than current.
+ */
+export function isUpdateAvailable(
+  current: string | null | undefined,
+  latest: string | null | undefined,
+): boolean {
+  if (!current || !latest) return false;
+  // If current is a prerelease of the same base version as latest (e.g.
+  // current=1.2.3-next.1, latest=1.2.3), don't report an update — the user is
+  // already on the development track for that release.
+  if (current !== latest && current.startsWith(latest)) {
+    return false;
+  }
+  return compareVersions(latest, current) > 0;
+}
+
+/**
+ * Extract a version string from raw CLI --version output.
+ */
+export function extractVersion(raw: string): string {
+  const match = VERSION_RE.exec(raw);
+  return match ? match[0] : raw.trim();
+}
+
+/**
+ * Probe local CLI version by running `<command> --version`.
+ *
+ * @param command    - Resolved CLI path or binary name.
+ * @param runner     - Optional ManagedCommandRunner instance.
+ * @param env        - Optional environment variables to pass.
+ * @param binaryName - Binary name for shell fallback lookup (e.g. "codex").
+ *                     When provided, the shell fallback runs `<binaryName>
+ *                     --version` so the login shell resolves the binary via
+ *                     its own PATH after loading the profile — mirroring
+ *                     cc-switch's try_get_version. This matters for version
+ *                     managers (fnm/nvm/volta) whose bin dirs are only present
+ *                     in the shell profile PATH, not in process.env.
+ */
+export async function probeCliVersion(
+  command: string | null,
+  runner?: ManagedCommandRunner,
+  env?: Record<string, string>,
+  binaryName?: string,
+): Promise<CliVersionProbeResult> {
+  const r = runner ?? new ManagedCommandRunner();
+  const mergedEnv = { ...process.env, ...env } as Record<string, string>;
+
+  /** Try probing --version via a single spawn; returns null when the spawn
+   *  itself failed (ENOENT) so the caller can retry via shell. */
+  const tryProbe = async (cmd: string, args: string[]): Promise<CliVersionProbeResult | null> => {
+    try {
+      const result = await r.run({
+        args,
+        command: cmd,
+        cwd: process.cwd(),
+        env: mergedEnv,
+        timeoutMs: 15_000,
+        stdoutLimitBytes: 8_192,
+        captureStderr: true,
+      });
+
+      if (result.termination === 'abort' || result.termination === 'timeout') {
+        return { version: null, error: 'Version probe timed out', installedButBroken: false };
+      }
+
+      if (result.termination === 'error') {
+        return null; // Spawn itself failed — caller may retry via shell.
+      }
+
+      if (result.termination === 'output-limit') {
+        return { version: null, error: 'Version probe output too large', installedButBroken: true };
+      }
+
+      const stdout = result.stdout.trim();
+      const stderr = result.stderr?.trim() ?? '';
+      const exitCode = result.exitCode;
+      const output = stdout || stderr;
+
+      if (output) {
+        const version = extractVersion(output);
+        const hasVersion = VERSION_RE.test(output);
+        if (exitCode === 0 || hasVersion) {
+          return {
+            version: hasVersion ? version : null,
+            error: exitCode !== 0 ? output.slice(0, 200) : null,
+            installedButBroken: false,
+          };
+        }
+        // exit 127 means the runner (shell / env) could not find the command
+        // or its dependencies (e.g. "env: node: No such file or directory").
+        // Don't treat this as final — a different fallback method may succeed.
+        if (exitCode === 127) {
+          return null;
+        }
+        return { version: null, error: output.slice(0, 200), installedButBroken: true };
+      }
+
+      return { version: null, error: 'CLI not installed or not on PATH', installedButBroken: false };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { version: null, error: message, installedButBroken: false };
+    }
+  };
+
+  // First attempt: direct spawn of the resolved command (when available).
+  if (command) {
+    const result = await tryProbe(command, ['--version']);
+    if (result !== null) return result;
+  }
+
+  // Second attempt: the resolved path may be stale or absent (e.g. an expired
+  // fnm/nvm multishell path captured in process.env). Re-resolve the binary
+  // against the provider's runtime PATH (user-configured env) and spawn that.
+  if (binaryName) {
+    const reResolved = findCliBinaryPath(binaryName, mergedEnv.PATH);
+    if (reResolved && reResolved !== command) {
+      const result = await tryProbe(reResolved, ['--version']);
+      if (result !== null) return result;
+    }
+  }
+
+  // Fallback: run through user shell (e.g., `bash -lic "codex --version"`)
+  // so that the user's login profile PATH (fnm/nvm/homebrew, etc.) is loaded.
+  // Use the binary name (not the resolved path) so the shell can find it via
+  // its own PATH — same approach as cc-switch's try_get_version.
+  const probeName = binaryName ?? command;
+  if (probeName) {
+    const shellCmd = buildShellCommand(`${shellQuote(probeName)} --version`);
+    if (shellCmd) {
+      const result = await tryProbe(shellCmd.command, shellCmd.args);
+      if (result !== null) return result;
+    }
+  }
+
+  return { version: null, error: 'CLI not installed or not on PATH', installedButBroken: false };
+}
+
+/**
+ * Fetch the latest version of an npm package from the registry.
+ * Uses fetch() which is available in Obsidian's renderer.
+ */
+export async function fetchLatestNpmVersion(packageName: string): Promise<string | null> {
+  const url = `https://registry.npmjs.org/${packageName}/latest`;
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+    if (!response.ok) return null;
+    const data = await response.json() as { version?: string };
+    return data.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Complete version info for a CLI: local probe + remote latest.
+ */
+export async function resolveCliVersionInfo(
+  command: string | null,
+  metadata: {
+    binaryName: string;
+    npmPackage?: string;
+  },
+  runner?: ManagedCommandRunner,
+  env?: Record<string, string>,
+): Promise<CliVersionInfo> {
+  // Always probe, even when command is null — the probe's fallback chain
+  // (findCliBinaryPath from env PATH + shell fallback with binaryName) can
+  // locate the CLI even when the resolver returned null (e.g. stale fnm
+  // multishell path in the cache resolved to a now-nonexistent file).
+  const probe = await probeCliVersion(command, runner, env, metadata.binaryName);
+
+  let latestVersion: string | null = null;
+  if (metadata.npmPackage) {
+    latestVersion = await fetchLatestNpmVersion(metadata.npmPackage);
+  }
+
+  return {
+    version: probe.version,
+    latestVersion,
+    error: probe.error,
+    installedButBroken: probe.installedButBroken,
+  };
+}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -105,13 +105,156 @@
       "claude": "Claude",
       "codex": "Codex"
     },
-    "omp": { "setup": "Einrichtung", "enable": "OMP aktivieren", "enableDesc": "Oh My Pi ACP-Anbieter aktivieren.", "cliPath": "CLI-Pfad", "cliPathDesc": "Absoluter OMP-Pfad auf diesem Computer.", "models": "Modelle", "noModels": "Noch keine OMP-Modelle gefunden.", "catalogFailed": "OMP-Modellkatalog konnte nicht geladen werden.", "loadingModels": "OMP-Modelle werden geladen…", "discoveryFailed": "OMP-Modellerkennung fehlgeschlagen: {error}", "workspaceNotInitialized": "OMP-Arbeitsbereich ist nicht initialisiert", "safe": "Sicher", "yolo": "YOLO", "permissionRequest": "OMP bittet um Berechtigung für {tool}.", "tool": "ein Tool" },
-    "cursor": {"setup":"Setup","enable":"Enable Cursor","enableDesc":"Enable Cursor Agent through its ACP CLI.","cliPath":"CLI path","cliPathDesc":"Absolute path to the Cursor Agent CLI on this computer.","models":"Models","noModels":"No Cursor models discovered yet. Run agent login and click Discover.","catalogFailed":"Could not load the Cursor model catalog. Check the CLI path and login state.","loadingModels":"Loading Cursor models...","discoveryFailed":"Cursor model discovery failed: {error}","workspaceNotInitialized":"Cursor workspace is not initialized","agent":"Agent","plan":"Plan","ask":"Ask","permissionRequest":"Cursor requests permission to use {tool}.","tool":"a tool"},
-    "grok": {"cliPathDesc":"Optional absolute path to the Grok CLI. Leave empty to prefer known installs, then PATH. Paste the output of \"which grok\" (or \"where grok\" on Windows)."},
-    "opencode": {"cliPathDesc":"Optional absolute path to the OpenCode CLI. Leave empty to use PATH. Paste the output of \"which opencode\" (or \"where opencode\" on Windows)."},
-    "pi": {"cliPathDesc":"Optional absolute path to the Pi CLI. Leave empty to use PATH. Paste the output of \"which pi\" (or \"where pi\" on Windows)."},
-    "providerReadiness": { "title": "Bereitschaft", "desc": "Prüfen, ob {provider} für einen Chat bereit ist.", "checking": "Provider-Bereitschaft wird geprüft…", "refresh": "Erneut prüfen", "status": { "disabled": "Deaktiviert", "blocked": "Aktion erforderlich", "attention": "Aufmerksamkeit erforderlich", "ready": "Bereit" }, "check": { "enabled": "Provider aktiviert", "cli": "CLI verfügbar", "models": "Modellkatalog verfügbar", "selection": "Chat-Modell ausgewählt" }, "hint": { "enableProvider": "Aktiviere diesen Provider, um ihn im Chat zu verwenden.", "configureCli": "Lege einen gültigen CLI-Pfad fest oder stelle sicher, dass Obsidian die CLI über PATH findet.", "refreshModels": "Prüfe die Anmeldung oder Sitzung des Providers und prüfe erneut, um Modelle zu laden.", "selectModel": "Wähle unten mindestens ein Chat-Modell aus." } },
-    "providerDiagnostics": { "kicker": "Fehlerbehebung", "title": "Provider-Diagnose", "whatHappened": "Was ist passiert", "readiness": "Bereitschaftsprüfungen", "provider": "Provider", "category": "Kategorie", "status": "Status", "platform": "Plattform", "time": "Zeit", "retry": "Nachricht erneut versuchen", "rebuild": "Sitzung neu erstellen", "details": "Details anzeigen", "copy": "Bericht kopieren", "close": "Schließen", "copied": "Diagnosebericht kopiert.", "copyFailed": "Diagnosebericht konnte nicht kopiert werden.", "statusValue": { "idle": "Inaktiv", "starting": "Wird gestartet", "running": "Läuft", "failed": "Fehlgeschlagen" }, "check": { "enabled": "Provider aktiviert", "cli": "CLI verfügbar", "models": "Modellkatalog verfügbar", "selection": "Chat-Modell ausgewählt" }, "checkStatus": { "disabled": "Deaktiviert", "blocked": "Blockiert", "attention": "Aufmerksamkeit erforderlich", "ready": "Bereit" }, "remediation": { "enableProvider": "Provider aktivieren", "configureCli": "CLI konfigurieren", "refreshModels": "Modelle aktualisieren", "selectModel": "Modell auswählen" }, "categoryValue": { "unknown": "Unbekannter Fehler", "cli-not-found": "CLI nicht gefunden", "cli-start-failed": "CLI-Start fehlgeschlagen", "session-resume-failed": "Sitzungsfortsetzung fehlgeschlagen", "model-unavailable": "Modell nicht verfügbar", "permission-denied": "Zugriff verweigert", "timeout": "Zeitüberschreitung", "rate-limited": "Ratenlimit", "protocol-error": "Protokollfehler", "authentication": "Authentifizierung fehlgeschlagen", "not-configured": "Nicht konfiguriert", "provider": "Provider-Fehler" } },
+    "omp": {
+      "setup": "Einrichtung",
+      "enable": "OMP aktivieren",
+      "enableDesc": "Oh My Pi ACP-Anbieter aktivieren.",
+      "cliPath": "CLI-Pfad",
+      "cliPathDesc": "Absoluter OMP-Pfad auf diesem Computer.",
+      "models": "Modelle",
+      "noModels": "Noch keine OMP-Modelle gefunden.",
+      "catalogFailed": "OMP-Modellkatalog konnte nicht geladen werden.",
+      "loadingModels": "OMP-Modelle werden geladen…",
+      "discoveryFailed": "OMP-Modellerkennung fehlgeschlagen: {error}",
+      "workspaceNotInitialized": "OMP-Arbeitsbereich ist nicht initialisiert",
+      "safe": "Sicher",
+      "yolo": "YOLO",
+      "permissionRequest": "OMP bittet um Berechtigung für {tool}.",
+      "tool": "ein Tool"
+    },
+    "cursor": {
+      "setup": "Setup",
+      "enable": "Enable Cursor",
+      "enableDesc": "Enable Cursor Agent through its ACP CLI.",
+      "cliPath": "CLI path",
+      "cliPathDesc": "Absolute path to the Cursor Agent CLI on this computer.",
+      "models": "Models",
+      "noModels": "No Cursor models discovered yet. Run agent login and click Discover.",
+      "catalogFailed": "Could not load the Cursor model catalog. Check the CLI path and login state.",
+      "loadingModels": "Loading Cursor models...",
+      "discoveryFailed": "Cursor model discovery failed: {error}",
+      "workspaceNotInitialized": "Cursor workspace is not initialized",
+      "agent": "Agent",
+      "plan": "Plan",
+      "ask": "Ask",
+      "permissionRequest": "Cursor requests permission to use {tool}.",
+      "tool": "a tool"
+    },
+    "grok": {
+      "cliPathDesc": "Optional absolute path to the Grok CLI. Leave empty to prefer known installs, then PATH. Paste the output of \"which grok\" (or \"where grok\" on Windows)."
+    },
+    "opencode": {
+      "cliPathDesc": "Optional absolute path to the OpenCode CLI. Leave empty to use PATH. Paste the output of \"which opencode\" (or \"where opencode\" on Windows)."
+    },
+    "pi": {
+      "cliPathDesc": "Optional absolute path to the Pi CLI. Leave empty to use PATH. Paste the output of \"which pi\" (or \"where pi\" on Windows)."
+    },
+    "providerReadiness": {
+      "title": "Bereitschaft",
+      "desc": "Prüfen, ob {provider} für einen Chat bereit ist.",
+      "checking": "Provider-Bereitschaft wird geprüft…",
+      "refresh": "Erneut prüfen",
+      "status": {
+        "disabled": "Deaktiviert",
+        "blocked": "Aktion erforderlich",
+        "attention": "Aufmerksamkeit erforderlich",
+        "ready": "Bereit"
+      },
+      "check": {
+        "enabled": "Provider aktiviert",
+        "cli": "CLI verfügbar",
+        "models": "Modellkatalog verfügbar",
+        "selection": "Chat-Modell ausgewählt"
+      },
+      "hint": {
+        "enableProvider": "Aktiviere diesen Provider, um ihn im Chat zu verwenden.",
+        "configureCli": "Lege einen gültigen CLI-Pfad fest oder stelle sicher, dass Obsidian die CLI über PATH findet.",
+        "refreshModels": "Prüfe die Anmeldung oder Sitzung des Providers und prüfe erneut, um Modelle zu laden.",
+        "selectModel": "Wähle unten mindestens ein Chat-Modell aus."
+      }
+    },
+    "cliLifecycle": {
+      "label": "CLI {cli}",
+      "checking": "CLI wird geprüft…",
+      "currentVersion": "Aktuelle Version",
+      "latestVersion": "Neueste Version",
+      "notInstalled": "Nicht installiert",
+      "installedButBroken": "Installiert, aber nicht ausführbar",
+      "updateAvailable": "Update verfügbar",
+      "install": "Installieren",
+      "installConfirm": "{cli} installieren?\n\nBefehl: {command}",
+      "installDone": "{cli} erfolgreich installiert.",
+      "installFailed": "Installation von {cli} fehlgeschlagen.",
+      "update": "Aktualisieren",
+      "updateConfirm": "{cli} aktualisieren?\n\nBefehl: {command}",
+      "updateDone": "{cli} erfolgreich aktualisiert.",
+      "updateFailed": "Aktualisierung von {cli} fehlgeschlagen.",
+      "ready": "Aktuell",
+      "checkEnv": "Die CLI ist installiert, kann aber nicht ausgeführt werden. Prüfe die Laufzeitumgebung (Node-Version, PATH).",
+      "probe": {
+        "timedOut": "Zeitüberschreitung bei der Versionsprüfung.",
+        "failedToStart": "CLI-Prozess konnte nicht gestartet werden.",
+        "outputTooLarge": "Ausgabe der Versionsprüfung zu groß.",
+        "notFound": "CLI nicht installiert oder nicht im PATH."
+      },
+      "versionUnchanged": "{cli} ist nach dem Update weiterhin auf {version}. Der Befehl hat möglicherweise nichts geändert."
+    },
+    "providerDiagnostics": {
+      "kicker": "Fehlerbehebung",
+      "title": "Provider-Diagnose",
+      "whatHappened": "Was ist passiert",
+      "readiness": "Bereitschaftsprüfungen",
+      "provider": "Provider",
+      "category": "Kategorie",
+      "status": "Status",
+      "platform": "Plattform",
+      "time": "Zeit",
+      "retry": "Nachricht erneut versuchen",
+      "rebuild": "Sitzung neu erstellen",
+      "details": "Details anzeigen",
+      "copy": "Bericht kopieren",
+      "close": "Schließen",
+      "copied": "Diagnosebericht kopiert.",
+      "copyFailed": "Diagnosebericht konnte nicht kopiert werden.",
+      "statusValue": {
+        "idle": "Inaktiv",
+        "starting": "Wird gestartet",
+        "running": "Läuft",
+        "failed": "Fehlgeschlagen"
+      },
+      "check": {
+        "enabled": "Provider aktiviert",
+        "cli": "CLI verfügbar",
+        "models": "Modellkatalog verfügbar",
+        "selection": "Chat-Modell ausgewählt"
+      },
+      "checkStatus": {
+        "disabled": "Deaktiviert",
+        "blocked": "Blockiert",
+        "attention": "Aufmerksamkeit erforderlich",
+        "ready": "Bereit"
+      },
+      "remediation": {
+        "enableProvider": "Provider aktivieren",
+        "configureCli": "CLI konfigurieren",
+        "refreshModels": "Modelle aktualisieren",
+        "selectModel": "Modell auswählen"
+      },
+      "categoryValue": {
+        "unknown": "Unbekannter Fehler",
+        "cli-not-found": "CLI nicht gefunden",
+        "cli-start-failed": "CLI-Start fehlgeschlagen",
+        "session-resume-failed": "Sitzungsfortsetzung fehlgeschlagen",
+        "model-unavailable": "Modell nicht verfügbar",
+        "permission-denied": "Zugriff verweigert",
+        "timeout": "Zeitüberschreitung",
+        "rate-limited": "Ratenlimit",
+        "protocol-error": "Protokollfehler",
+        "authentication": "Authentifizierung fehlgeschlagen",
+        "not-configured": "Nicht konfiguriert",
+        "provider": "Provider-Fehler"
+      }
+    },
     "display": "Anzeige",
     "conversations": "Unterhaltungen",
     "content": "Inhalte",
@@ -438,9 +581,40 @@
       }
     },
     "agentSkills": {
-      "sectionTitle": "Skills", "fixedRoot": "Managed in .agents/skills", "sharedExpectation": "Manage shared skills in .agents/skills/ for compatible providers.", "noSkills": "No shared skills configured. Click + to create one.", "skillBadge": "skill", "diagnosticsTitle": "Skills needing attention", "loadFailed": "Could not load shared skills.", "savedRefreshFailed": "Saved, but provider refresh failed.", "validationFailed": "Invalid skill: {message}", "collisionFailed": "A skill named \"{name}\" already exists.", "saveFailed": "Failed to save shared skill: {message}", "deleteFailed": "Failed to move shared skill to trash: {message}", "staleConflict": "This skill changed elsewhere; refresh before saving.", "created": "Shared skill \"{name}\" created.", "updated": "Shared skill \"{name}\" updated.", "deleted": "Shared skill \"{name}\" moved to trash.",
-      "modal": { "titleEdit": "Edit Shared Skill", "titleAdd": "Add Shared Skill", "name": "Skill name", "nameDesc": "Lowercase letters and numbers separated by single hyphens", "namePlaceholder": "code-reviewer", "description": "Description", "descriptionDesc": "Required portable description used by providers to select the skill", "descriptionPlaceholder": "Reviews code for correctness and maintainability", "instructions": "Instructions", "instructionsDesc": "Required SKILL.md instructions", "instructionsPlaceholder": "Review the supplied code and report actionable findings..." },
-      "delete": { "title": "Delete Shared Skill", "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.", "confirm": "Move to trash" }
+      "sectionTitle": "Skills",
+      "fixedRoot": "Managed in .agents/skills",
+      "sharedExpectation": "Manage shared skills in .agents/skills/ for compatible providers.",
+      "noSkills": "No shared skills configured. Click + to create one.",
+      "skillBadge": "skill",
+      "diagnosticsTitle": "Skills needing attention",
+      "loadFailed": "Could not load shared skills.",
+      "savedRefreshFailed": "Saved, but provider refresh failed.",
+      "validationFailed": "Invalid skill: {message}",
+      "collisionFailed": "A skill named \"{name}\" already exists.",
+      "saveFailed": "Failed to save shared skill: {message}",
+      "deleteFailed": "Failed to move shared skill to trash: {message}",
+      "staleConflict": "This skill changed elsewhere; refresh before saving.",
+      "created": "Shared skill \"{name}\" created.",
+      "updated": "Shared skill \"{name}\" updated.",
+      "deleted": "Shared skill \"{name}\" moved to trash.",
+      "modal": {
+        "titleEdit": "Edit Shared Skill",
+        "titleAdd": "Add Shared Skill",
+        "name": "Skill name",
+        "nameDesc": "Lowercase letters and numbers separated by single hyphens",
+        "namePlaceholder": "code-reviewer",
+        "description": "Description",
+        "descriptionDesc": "Required portable description used by providers to select the skill",
+        "descriptionPlaceholder": "Reviews code for correctness and maintainability",
+        "instructions": "Instructions",
+        "instructionsDesc": "Required SKILL.md instructions",
+        "instructionsPlaceholder": "Review the supplied code and report actionable findings..."
+      },
+      "delete": {
+        "title": "Delete Shared Skill",
+        "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.",
+        "confirm": "Move to trash"
+      }
     },
     "codexSkills": {
       "modal": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -106,35 +106,154 @@
       "codex": "Codex"
     },
     "omp": {
-      "setup": "Setup", "enable": "Enable OMP", "enableDesc": "Enable the Oh My Pi ACP provider.",
-      "cliPath": "CLI path", "cliPathDesc": "Absolute path to OMP on this computer. Paste the output of \"which omp\" (or \"where omp\" on Windows). Leave empty to use automatic detection.",
-      "models": "Models", "noModels": "No OMP models discovered yet. Check OMP login and click Discover.",
-      "catalogFailed": "Could not load the OMP model catalog. Check the CLI path and login state.", "loadingModels": "Loading OMP models...",
-      "discoveryFailed": "OMP model discovery failed: {error}", "workspaceNotInitialized": "OMP workspace is not initialized",
-      "safe": "Safe", "yolo": "YOLO", "permissionRequest": "OMP requests permission to use {tool}.", "tool": "a tool"
+      "setup": "Setup",
+      "enable": "Enable OMP",
+      "enableDesc": "Enable the Oh My Pi ACP provider.",
+      "cliPath": "CLI path",
+      "cliPathDesc": "Absolute path to OMP on this computer. Paste the output of \"which omp\" (or \"where omp\" on Windows). Leave empty to use automatic detection.",
+      "models": "Models",
+      "noModels": "No OMP models discovered yet. Check OMP login and click Discover.",
+      "catalogFailed": "Could not load the OMP model catalog. Check the CLI path and login state.",
+      "loadingModels": "Loading OMP models...",
+      "discoveryFailed": "OMP model discovery failed: {error}",
+      "workspaceNotInitialized": "OMP workspace is not initialized",
+      "safe": "Safe",
+      "yolo": "YOLO",
+      "permissionRequest": "OMP requests permission to use {tool}.",
+      "tool": "a tool"
     },
-    "cursor": {"setup":"Setup","enable":"Enable Cursor","enableDesc":"Enable Cursor Agent through its ACP CLI.","cliPath":"CLI path","cliPathDesc":"Absolute path to the Cursor Agent CLI. Paste the output of \"which agent\" (or \"where agent\" on Windows). Leave empty for automatic detection.","models":"Models","noModels":"No Cursor models discovered yet. Run agent login and click Discover.","catalogFailed":"Could not load the Cursor model catalog. Check the CLI path and login state.","loadingModels":"Loading Cursor models...","discoveryFailed":"Cursor model discovery failed: {error}","workspaceNotInitialized":"Cursor workspace is not initialized","agent":"Agent","plan":"Plan","ask":"Ask","permissionRequest":"Cursor requests permission to use {tool}.","tool":"a tool"},
-    "grok": {"cliPathDesc":"Optional absolute path to the Grok CLI. Leave empty to prefer known installs, then PATH. Paste the output of \"which grok\" (or \"where grok\" on Windows)."},
-    "opencode": {"cliPathDesc":"Optional absolute path to the OpenCode CLI. Leave empty to use PATH. Paste the output of \"which opencode\" (or \"where opencode\" on Windows)."},
-    "pi": {"cliPathDesc":"Optional absolute path to the Pi CLI. Leave empty to use PATH. Paste the output of \"which pi\" (or \"where pi\" on Windows)."},
+    "cursor": {
+      "setup": "Setup",
+      "enable": "Enable Cursor",
+      "enableDesc": "Enable Cursor Agent through its ACP CLI.",
+      "cliPath": "CLI path",
+      "cliPathDesc": "Absolute path to the Cursor Agent CLI. Paste the output of \"which agent\" (or \"where agent\" on Windows). Leave empty for automatic detection.",
+      "models": "Models",
+      "noModels": "No Cursor models discovered yet. Run agent login and click Discover.",
+      "catalogFailed": "Could not load the Cursor model catalog. Check the CLI path and login state.",
+      "loadingModels": "Loading Cursor models...",
+      "discoveryFailed": "Cursor model discovery failed: {error}",
+      "workspaceNotInitialized": "Cursor workspace is not initialized",
+      "agent": "Agent",
+      "plan": "Plan",
+      "ask": "Ask",
+      "permissionRequest": "Cursor requests permission to use {tool}.",
+      "tool": "a tool"
+    },
+    "grok": {
+      "cliPathDesc": "Optional absolute path to the Grok CLI. Leave empty to prefer known installs, then PATH. Paste the output of \"which grok\" (or \"where grok\" on Windows)."
+    },
+    "opencode": {
+      "cliPathDesc": "Optional absolute path to the OpenCode CLI. Leave empty to use PATH. Paste the output of \"which opencode\" (or \"where opencode\" on Windows)."
+    },
+    "pi": {
+      "cliPathDesc": "Optional absolute path to the Pi CLI. Leave empty to use PATH. Paste the output of \"which pi\" (or \"where pi\" on Windows)."
+    },
     "providerReadiness": {
       "title": "Readiness",
       "desc": "Check whether {provider} is ready to start a chat.",
       "checking": "Checking provider readiness…",
       "refresh": "Check again",
-      "status": { "disabled": "Disabled", "blocked": "Action required", "attention": "Needs attention", "ready": "Ready" },
-      "check": { "enabled": "Provider enabled", "cli": "CLI available", "models": "Model catalog available", "selection": "Chat model selected" },
-      "hint": { "enableProvider": "Enable this provider to use it in chat.", "configureCli": "Set a valid CLI path or make the CLI available on Obsidian's PATH.", "refreshModels": "Check the provider login or session, then check again to load models.", "selectModel": "Select at least one chat model below." }
+      "status": {
+        "disabled": "Disabled",
+        "blocked": "Action required",
+        "attention": "Needs attention",
+        "ready": "Ready"
+      },
+      "check": {
+        "enabled": "Provider enabled",
+        "cli": "CLI available",
+        "models": "Model catalog available",
+        "selection": "Chat model selected"
+      },
+      "hint": {
+        "enableProvider": "Enable this provider to use it in chat.",
+        "configureCli": "Set a valid CLI path or make the CLI available on Obsidian's PATH.",
+        "refreshModels": "Check the provider login or session, then check again to load models.",
+        "selectModel": "Select at least one chat model below."
+      }
+    },
+    "cliLifecycle": {
+      "label": "{cli} CLI",
+      "checking": "Checking CLI…",
+      "currentVersion": "Current version",
+      "latestVersion": "Latest version",
+      "notInstalled": "Not installed",
+      "installedButBroken": "Installed but not running",
+      "updateAvailable": "Update available",
+      "install": "Install",
+      "installConfirm": "Install {cli}?\n\nCommand: {command}",
+      "installDone": "{cli} installed successfully.",
+      "installFailed": "{cli} installation failed.",
+      "update": "Update",
+      "updateConfirm": "Update {cli}?\n\nCommand: {command}",
+      "updateDone": "{cli} updated successfully.",
+      "updateFailed": "{cli} update failed.",
+      "versionUnchanged": "{cli} is still on {version} after updating. The command may have been a no-op.",
+      "ready": "Up to date",
+      "checkEnv": "The CLI is installed but cannot run. Check the runtime environment (Node version, PATH).",
+      "probe": {
+        "timedOut": "Version probe timed out.",
+        "failedToStart": "Failed to start the CLI process.",
+        "outputTooLarge": "Version probe produced too much output.",
+        "notFound": "CLI not installed or not on PATH."
+      }
     },
     "providerDiagnostics": {
-      "kicker": "Troubleshooting", "title": "Provider diagnostics", "whatHappened": "What happened", "readiness": "Readiness checks",
-      "provider": "Provider", "category": "Category", "status": "Status", "platform": "Platform", "time": "Time",
-      "retry": "Retry message", "rebuild": "Rebuild session", "details": "View details", "copy": "Copy report", "close": "Close", "copied": "Provider diagnostic report copied.", "copyFailed": "Could not copy provider diagnostic report.",
-      "statusValue": { "idle": "Idle", "starting": "Starting", "running": "Running", "failed": "Failed" },
-      "check": { "enabled": "Provider enabled", "cli": "CLI available", "models": "Model catalog available", "selection": "Chat model selected" },
-      "checkStatus": { "disabled": "Disabled", "blocked": "Blocked", "attention": "Needs attention", "ready": "Ready" },
-      "remediation": { "enableProvider": "enable provider", "configureCli": "configure CLI", "refreshModels": "refresh models", "selectModel": "select model" },
-      "categoryValue": { "unknown": "Unknown", "cli-not-found": "CLI not found", "cli-start-failed": "CLI failed to start", "session-resume-failed": "Session resume failed", "model-unavailable": "Model unavailable", "permission-denied": "Permission denied", "timeout": "Timed out", "rate-limited": "Rate limited", "protocol-error": "Protocol error", "authentication": "Authentication failed", "not-configured": "Not configured", "provider": "Provider error" }
+      "kicker": "Troubleshooting",
+      "title": "Provider diagnostics",
+      "whatHappened": "What happened",
+      "readiness": "Readiness checks",
+      "provider": "Provider",
+      "category": "Category",
+      "status": "Status",
+      "platform": "Platform",
+      "time": "Time",
+      "retry": "Retry message",
+      "rebuild": "Rebuild session",
+      "details": "View details",
+      "copy": "Copy report",
+      "close": "Close",
+      "copied": "Provider diagnostic report copied.",
+      "copyFailed": "Could not copy provider diagnostic report.",
+      "statusValue": {
+        "idle": "Idle",
+        "starting": "Starting",
+        "running": "Running",
+        "failed": "Failed"
+      },
+      "check": {
+        "enabled": "Provider enabled",
+        "cli": "CLI available",
+        "models": "Model catalog available",
+        "selection": "Chat model selected"
+      },
+      "checkStatus": {
+        "disabled": "Disabled",
+        "blocked": "Blocked",
+        "attention": "Needs attention",
+        "ready": "Ready"
+      },
+      "remediation": {
+        "enableProvider": "enable provider",
+        "configureCli": "configure CLI",
+        "refreshModels": "refresh models",
+        "selectModel": "select model"
+      },
+      "categoryValue": {
+        "unknown": "Unknown",
+        "cli-not-found": "CLI not found",
+        "cli-start-failed": "CLI failed to start",
+        "session-resume-failed": "Session resume failed",
+        "model-unavailable": "Model unavailable",
+        "permission-denied": "Permission denied",
+        "timeout": "Timed out",
+        "rate-limited": "Rate limited",
+        "protocol-error": "Protocol error",
+        "authentication": "Authentication failed",
+        "not-configured": "Not configured",
+        "provider": "Provider error"
+      }
     },
     "display": "Display",
     "conversations": "Conversations",
@@ -408,8 +527,8 @@
       },
       "cliPath": {
         "name": "Codex CLI path",
-      "descUnix": "Custom path to the local Codex CLI. Leave empty to prefer known Codex installs, then PATH. Paste the output of \"which codex\" (or \"where codex\" on Windows).",
-      "descWindows": "Custom path to the local Codex CLI. Leave empty to auto-detect from PATH. Paste the output of \"where codex\" or use the native executable path, usually `codex.exe`.",
+        "descUnix": "Custom path to the local Codex CLI. Leave empty to prefer known Codex installs, then PATH. Paste the output of \"which codex\" (or \"where codex\" on Windows).",
+        "descWindows": "Custom path to the local Codex CLI. Leave empty to auto-detect from PATH. Paste the output of \"where codex\" or use the native executable path, usually `codex.exe`.",
         "descWsl": "Linux-side Codex command or absolute path to run inside WSL. Leave empty for PATH lookup inside the selected distro.",
         "validation": {
           "wslWindowsPath": "WSL mode expects a Linux command or Linux absolute path, not a Windows executable path."

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -105,13 +105,156 @@
       "claude": "Claude",
       "codex": "Codex"
     },
-    "omp": { "setup": "Configuración", "enable": "Activar OMP", "enableDesc": "Activar el proveedor ACP de Oh My Pi.", "cliPath": "Ruta del CLI", "cliPathDesc": "Ruta absoluta a OMP en este equipo.", "models": "Modelos", "noModels": "Aún no se han descubierto modelos OMP.", "catalogFailed": "No se pudo cargar el catálogo de modelos OMP.", "loadingModels": "Cargando modelos OMP…", "discoveryFailed": "Error al descubrir modelos OMP: {error}", "workspaceNotInitialized": "El espacio de trabajo OMP no está inicializado", "safe": "Seguro", "yolo": "YOLO", "permissionRequest": "OMP solicita permiso para usar {tool}.", "tool": "una herramienta" },
-    "cursor": {"setup":"Setup","enable":"Enable Cursor","enableDesc":"Enable Cursor Agent through its ACP CLI.","cliPath":"CLI path","cliPathDesc":"Absolute path to the Cursor Agent CLI on this computer.","models":"Models","noModels":"No Cursor models discovered yet. Run agent login and click Discover.","catalogFailed":"Could not load the Cursor model catalog. Check the CLI path and login state.","loadingModels":"Loading Cursor models...","discoveryFailed":"Cursor model discovery failed: {error}","workspaceNotInitialized":"Cursor workspace is not initialized","agent":"Agent","plan":"Plan","ask":"Ask","permissionRequest":"Cursor requests permission to use {tool}.","tool":"a tool"},
-    "grok": {"cliPathDesc":"Optional absolute path to the Grok CLI. Leave empty to prefer known installs, then PATH. Paste the output of \"which grok\" (or \"where grok\" on Windows)."},
-    "opencode": {"cliPathDesc":"Optional absolute path to the OpenCode CLI. Leave empty to use PATH. Paste the output of \"which opencode\" (or \"where opencode\" on Windows)."},
-    "pi": {"cliPathDesc":"Optional absolute path to the Pi CLI. Leave empty to use PATH. Paste the output of \"which pi\" (or \"where pi\" on Windows)."},
-    "providerReadiness": { "title": "Preparación", "desc": "Comprueba si {provider} está listo para iniciar un chat.", "checking": "Comprobando el estado del proveedor…", "refresh": "Comprobar de nuevo", "status": { "disabled": "Desactivado", "blocked": "Acción necesaria", "attention": "Requiere atención", "ready": "Listo" }, "check": { "enabled": "Proveedor activado", "cli": "CLI disponible", "models": "Catálogo de modelos disponible", "selection": "Modelo de chat seleccionado" }, "hint": { "enableProvider": "Activa este proveedor para usarlo en el chat.", "configureCli": "Establece una ruta CLI válida o asegúrate de que Obsidian pueda encontrarla en PATH.", "refreshModels": "Comprueba el inicio de sesión o la sesión del proveedor y vuelve a comprobar para cargar modelos.", "selectModel": "Selecciona al menos un modelo de chat abajo." } },
-    "providerDiagnostics": { "kicker": "Solución de problemas", "title": "Diagnóstico del proveedor", "whatHappened": "Qué ocurrió", "readiness": "Comprobaciones de preparación", "provider": "Proveedor", "category": "Categoría", "status": "Estado", "platform": "Plataforma", "time": "Hora", "retry": "Reintentar mensaje", "rebuild": "Reconstruir sesión", "details": "Ver detalles", "copy": "Copiar informe", "close": "Cerrar", "copied": "Informe de diagnóstico copiado.", "copyFailed": "No se pudo copiar el informe de diagnóstico.", "statusValue": { "idle": "Inactivo", "starting": "Iniciando", "running": "En ejecución", "failed": "Fallido" }, "check": { "enabled": "Proveedor activado", "cli": "CLI disponible", "models": "Catálogo de modelos disponible", "selection": "Modelo de chat seleccionado" }, "checkStatus": { "disabled": "Desactivado", "blocked": "Bloqueado", "attention": "Requiere atención", "ready": "Listo" }, "remediation": { "enableProvider": "activar proveedor", "configureCli": "configurar CLI", "refreshModels": "actualizar modelos", "selectModel": "seleccionar modelo" }, "categoryValue": { "unknown": "Error desconocido", "cli-not-found": "CLI no encontrada", "cli-start-failed": "Error al iniciar la CLI", "session-resume-failed": "Error al reanudar la sesión", "model-unavailable": "Modelo no disponible", "permission-denied": "Permiso denegado", "timeout": "Tiempo de espera agotado", "rate-limited": "Límite de solicitudes", "protocol-error": "Error de protocolo", "authentication": "Error de autenticación", "not-configured": "Sin configurar", "provider": "Error del proveedor" } },
+    "omp": {
+      "setup": "Configuración",
+      "enable": "Activar OMP",
+      "enableDesc": "Activar el proveedor ACP de Oh My Pi.",
+      "cliPath": "Ruta del CLI",
+      "cliPathDesc": "Ruta absoluta a OMP en este equipo.",
+      "models": "Modelos",
+      "noModels": "Aún no se han descubierto modelos OMP.",
+      "catalogFailed": "No se pudo cargar el catálogo de modelos OMP.",
+      "loadingModels": "Cargando modelos OMP…",
+      "discoveryFailed": "Error al descubrir modelos OMP: {error}",
+      "workspaceNotInitialized": "El espacio de trabajo OMP no está inicializado",
+      "safe": "Seguro",
+      "yolo": "YOLO",
+      "permissionRequest": "OMP solicita permiso para usar {tool}.",
+      "tool": "una herramienta"
+    },
+    "cursor": {
+      "setup": "Setup",
+      "enable": "Enable Cursor",
+      "enableDesc": "Enable Cursor Agent through its ACP CLI.",
+      "cliPath": "CLI path",
+      "cliPathDesc": "Absolute path to the Cursor Agent CLI on this computer.",
+      "models": "Models",
+      "noModels": "No Cursor models discovered yet. Run agent login and click Discover.",
+      "catalogFailed": "Could not load the Cursor model catalog. Check the CLI path and login state.",
+      "loadingModels": "Loading Cursor models...",
+      "discoveryFailed": "Cursor model discovery failed: {error}",
+      "workspaceNotInitialized": "Cursor workspace is not initialized",
+      "agent": "Agent",
+      "plan": "Plan",
+      "ask": "Ask",
+      "permissionRequest": "Cursor requests permission to use {tool}.",
+      "tool": "a tool"
+    },
+    "grok": {
+      "cliPathDesc": "Optional absolute path to the Grok CLI. Leave empty to prefer known installs, then PATH. Paste the output of \"which grok\" (or \"where grok\" on Windows)."
+    },
+    "opencode": {
+      "cliPathDesc": "Optional absolute path to the OpenCode CLI. Leave empty to use PATH. Paste the output of \"which opencode\" (or \"where opencode\" on Windows)."
+    },
+    "pi": {
+      "cliPathDesc": "Optional absolute path to the Pi CLI. Leave empty to use PATH. Paste the output of \"which pi\" (or \"where pi\" on Windows)."
+    },
+    "providerReadiness": {
+      "title": "Preparación",
+      "desc": "Comprueba si {provider} está listo para iniciar un chat.",
+      "checking": "Comprobando el estado del proveedor…",
+      "refresh": "Comprobar de nuevo",
+      "status": {
+        "disabled": "Desactivado",
+        "blocked": "Acción necesaria",
+        "attention": "Requiere atención",
+        "ready": "Listo"
+      },
+      "check": {
+        "enabled": "Proveedor activado",
+        "cli": "CLI disponible",
+        "models": "Catálogo de modelos disponible",
+        "selection": "Modelo de chat seleccionado"
+      },
+      "hint": {
+        "enableProvider": "Activa este proveedor para usarlo en el chat.",
+        "configureCli": "Establece una ruta CLI válida o asegúrate de que Obsidian pueda encontrarla en PATH.",
+        "refreshModels": "Comprueba el inicio de sesión o la sesión del proveedor y vuelve a comprobar para cargar modelos.",
+        "selectModel": "Selecciona al menos un modelo de chat abajo."
+      }
+    },
+    "cliLifecycle": {
+      "label": "CLI {cli}",
+      "checking": "Comprobando CLI…",
+      "currentVersion": "Versión actual",
+      "latestVersion": "Última versión",
+      "notInstalled": "No instalado",
+      "installedButBroken": "Instalado pero no ejecutable",
+      "updateAvailable": "Actualización disponible",
+      "install": "Instalar",
+      "installConfirm": "¿Instalar {cli}?\n\nComando: {command}",
+      "installDone": "{cli} instalado correctamente.",
+      "installFailed": "No se pudo instalar {cli}.",
+      "update": "Actualizar",
+      "updateConfirm": "¿Actualizar {cli}?\n\nComando: {command}",
+      "updateDone": "{cli} actualizado correctamente.",
+      "updateFailed": "No se pudo actualizar {cli}.",
+      "ready": "Actualizado",
+      "checkEnv": "El CLI está instalado pero no puede ejecutarse. Comprueba el entorno de ejecución (versión de Node, PATH).",
+      "probe": {
+        "timedOut": "Se agotó el tiempo de la comprobación de versión.",
+        "failedToStart": "No se pudo iniciar el proceso CLI.",
+        "outputTooLarge": "La salida de la comprobación de versión es demasiado grande.",
+        "notFound": "CLI no instalado o no está en PATH."
+      },
+      "versionUnchanged": "{cli} sigue en {version} después de actualizar. Es posible que el comando no haya surtido efecto."
+    },
+    "providerDiagnostics": {
+      "kicker": "Solución de problemas",
+      "title": "Diagnóstico del proveedor",
+      "whatHappened": "Qué ocurrió",
+      "readiness": "Comprobaciones de preparación",
+      "provider": "Proveedor",
+      "category": "Categoría",
+      "status": "Estado",
+      "platform": "Plataforma",
+      "time": "Hora",
+      "retry": "Reintentar mensaje",
+      "rebuild": "Reconstruir sesión",
+      "details": "Ver detalles",
+      "copy": "Copiar informe",
+      "close": "Cerrar",
+      "copied": "Informe de diagnóstico copiado.",
+      "copyFailed": "No se pudo copiar el informe de diagnóstico.",
+      "statusValue": {
+        "idle": "Inactivo",
+        "starting": "Iniciando",
+        "running": "En ejecución",
+        "failed": "Fallido"
+      },
+      "check": {
+        "enabled": "Proveedor activado",
+        "cli": "CLI disponible",
+        "models": "Catálogo de modelos disponible",
+        "selection": "Modelo de chat seleccionado"
+      },
+      "checkStatus": {
+        "disabled": "Desactivado",
+        "blocked": "Bloqueado",
+        "attention": "Requiere atención",
+        "ready": "Listo"
+      },
+      "remediation": {
+        "enableProvider": "activar proveedor",
+        "configureCli": "configurar CLI",
+        "refreshModels": "actualizar modelos",
+        "selectModel": "seleccionar modelo"
+      },
+      "categoryValue": {
+        "unknown": "Error desconocido",
+        "cli-not-found": "CLI no encontrada",
+        "cli-start-failed": "Error al iniciar la CLI",
+        "session-resume-failed": "Error al reanudar la sesión",
+        "model-unavailable": "Modelo no disponible",
+        "permission-denied": "Permiso denegado",
+        "timeout": "Tiempo de espera agotado",
+        "rate-limited": "Límite de solicitudes",
+        "protocol-error": "Error de protocolo",
+        "authentication": "Error de autenticación",
+        "not-configured": "Sin configurar",
+        "provider": "Error del proveedor"
+      }
+    },
     "display": "Pantalla",
     "conversations": "Conversaciones",
     "content": "Contenido",
@@ -438,9 +581,40 @@
       }
     },
     "agentSkills": {
-      "sectionTitle": "Skills", "fixedRoot": "Managed in .agents/skills", "sharedExpectation": "Manage shared skills in .agents/skills/ for compatible providers.", "noSkills": "No shared skills configured. Click + to create one.", "skillBadge": "skill", "diagnosticsTitle": "Skills needing attention", "loadFailed": "Could not load shared skills.", "savedRefreshFailed": "Saved, but provider refresh failed.", "validationFailed": "Invalid skill: {message}", "collisionFailed": "A skill named \"{name}\" already exists.", "saveFailed": "Failed to save shared skill: {message}", "deleteFailed": "Failed to move shared skill to trash: {message}", "staleConflict": "This skill changed elsewhere; refresh before saving.", "created": "Shared skill \"{name}\" created.", "updated": "Shared skill \"{name}\" updated.", "deleted": "Shared skill \"{name}\" moved to trash.",
-      "modal": { "titleEdit": "Edit Shared Skill", "titleAdd": "Add Shared Skill", "name": "Skill name", "nameDesc": "Lowercase letters and numbers separated by single hyphens", "namePlaceholder": "code-reviewer", "description": "Description", "descriptionDesc": "Required portable description used by providers to select the skill", "descriptionPlaceholder": "Reviews code for correctness and maintainability", "instructions": "Instructions", "instructionsDesc": "Required SKILL.md instructions", "instructionsPlaceholder": "Review the supplied code and report actionable findings..." },
-      "delete": { "title": "Delete Shared Skill", "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.", "confirm": "Move to trash" }
+      "sectionTitle": "Skills",
+      "fixedRoot": "Managed in .agents/skills",
+      "sharedExpectation": "Manage shared skills in .agents/skills/ for compatible providers.",
+      "noSkills": "No shared skills configured. Click + to create one.",
+      "skillBadge": "skill",
+      "diagnosticsTitle": "Skills needing attention",
+      "loadFailed": "Could not load shared skills.",
+      "savedRefreshFailed": "Saved, but provider refresh failed.",
+      "validationFailed": "Invalid skill: {message}",
+      "collisionFailed": "A skill named \"{name}\" already exists.",
+      "saveFailed": "Failed to save shared skill: {message}",
+      "deleteFailed": "Failed to move shared skill to trash: {message}",
+      "staleConflict": "This skill changed elsewhere; refresh before saving.",
+      "created": "Shared skill \"{name}\" created.",
+      "updated": "Shared skill \"{name}\" updated.",
+      "deleted": "Shared skill \"{name}\" moved to trash.",
+      "modal": {
+        "titleEdit": "Edit Shared Skill",
+        "titleAdd": "Add Shared Skill",
+        "name": "Skill name",
+        "nameDesc": "Lowercase letters and numbers separated by single hyphens",
+        "namePlaceholder": "code-reviewer",
+        "description": "Description",
+        "descriptionDesc": "Required portable description used by providers to select the skill",
+        "descriptionPlaceholder": "Reviews code for correctness and maintainability",
+        "instructions": "Instructions",
+        "instructionsDesc": "Required SKILL.md instructions",
+        "instructionsPlaceholder": "Review the supplied code and report actionable findings..."
+      },
+      "delete": {
+        "title": "Delete Shared Skill",
+        "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.",
+        "confirm": "Move to trash"
+      }
     },
     "codexSkills": {
       "modal": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -105,13 +105,156 @@
       "claude": "Claude",
       "codex": "Codex"
     },
-    "omp": { "setup": "Configuration", "enable": "Activer OMP", "enableDesc": "Activer le fournisseur ACP Oh My Pi.", "cliPath": "Chemin CLI", "cliPathDesc": "Chemin absolu vers OMP sur cet ordinateur.", "models": "Modèles", "noModels": "Aucun modèle OMP trouvé.", "catalogFailed": "Impossible de charger le catalogue des modèles OMP.", "loadingModels": "Chargement des modèles OMP…", "discoveryFailed": "Échec de la détection des modèles OMP : {error}", "workspaceNotInitialized": "L’espace de travail OMP n’est pas initialisé", "safe": "Sûr", "yolo": "YOLO", "permissionRequest": "OMP demande l’autorisation d’utiliser {tool}.", "tool": "un outil" },
-    "cursor": {"setup":"Setup","enable":"Enable Cursor","enableDesc":"Enable Cursor Agent through its ACP CLI.","cliPath":"CLI path","cliPathDesc":"Absolute path to the Cursor Agent CLI on this computer.","models":"Models","noModels":"No Cursor models discovered yet. Run agent login and click Discover.","catalogFailed":"Could not load the Cursor model catalog. Check the CLI path and login state.","loadingModels":"Loading Cursor models...","discoveryFailed":"Cursor model discovery failed: {error}","workspaceNotInitialized":"Cursor workspace is not initialized","agent":"Agent","plan":"Plan","ask":"Ask","permissionRequest":"Cursor requests permission to use {tool}.","tool":"a tool"},
-    "grok": {"cliPathDesc":"Optional absolute path to the Grok CLI. Leave empty to prefer known installs, then PATH. Paste the output of \"which grok\" (or \"where grok\" on Windows)."},
-    "opencode": {"cliPathDesc":"Optional absolute path to the OpenCode CLI. Leave empty to use PATH. Paste the output of \"which opencode\" (or \"where opencode\" on Windows)."},
-    "pi": {"cliPathDesc":"Optional absolute path to the Pi CLI. Leave empty to use PATH. Paste the output of \"which pi\" (or \"where pi\" on Windows)."},
-    "providerReadiness": { "title": "État de préparation", "desc": "Vérifier si {provider} est prêt à démarrer une conversation.", "checking": "Vérification de l’état du fournisseur…", "refresh": "Vérifier à nouveau", "status": { "disabled": "Désactivé", "blocked": "Action requise", "attention": "Attention requise", "ready": "Prêt" }, "check": { "enabled": "Fournisseur activé", "cli": "CLI disponible", "models": "Catalogue de modèles disponible", "selection": "Modèle de chat sélectionné" }, "hint": { "enableProvider": "Activez ce fournisseur pour l’utiliser dans le chat.", "configureCli": "Définissez un chemin CLI valide ou rendez la CLI disponible dans le PATH d’Obsidian.", "refreshModels": "Vérifiez la connexion ou la session du fournisseur, puis vérifiez à nouveau pour charger les modèles.", "selectModel": "Sélectionnez au moins un modèle de chat ci-dessous." } },
-    "providerDiagnostics": { "kicker": "Dépannage", "title": "Diagnostic du fournisseur", "whatHappened": "Ce qui s’est passé", "readiness": "Vérifications de préparation", "provider": "Fournisseur", "category": "Catégorie", "status": "État", "platform": "Plateforme", "time": "Heure", "retry": "Réessayer le message", "rebuild": "Reconstruire la session", "details": "Voir les détails", "copy": "Copier le rapport", "close": "Fermer", "copied": "Rapport de diagnostic copié.", "copyFailed": "Impossible de copier le rapport de diagnostic.", "statusValue": { "idle": "Inactif", "starting": "Démarrage", "running": "En cours", "failed": "Échec" }, "check": { "enabled": "Fournisseur activé", "cli": "CLI disponible", "models": "Catalogue de modèles disponible", "selection": "Modèle de chat sélectionné" }, "checkStatus": { "disabled": "Désactivé", "blocked": "Bloqué", "attention": "Attention requise", "ready": "Prêt" }, "remediation": { "enableProvider": "activer le fournisseur", "configureCli": "configurer la CLI", "refreshModels": "actualiser les modèles", "selectModel": "sélectionner un modèle" }, "categoryValue": { "unknown": "Erreur inconnue", "cli-not-found": "CLI introuvable", "cli-start-failed": "Échec du démarrage de la CLI", "session-resume-failed": "Échec de la reprise de session", "model-unavailable": "Modèle indisponible", "permission-denied": "Permission refusée", "timeout": "Délai dépassé", "rate-limited": "Limite de débit", "protocol-error": "Erreur de protocole", "authentication": "Échec de l’authentification", "not-configured": "Non configuré", "provider": "Erreur du fournisseur" } },
+    "omp": {
+      "setup": "Configuration",
+      "enable": "Activer OMP",
+      "enableDesc": "Activer le fournisseur ACP Oh My Pi.",
+      "cliPath": "Chemin CLI",
+      "cliPathDesc": "Chemin absolu vers OMP sur cet ordinateur.",
+      "models": "Modèles",
+      "noModels": "Aucun modèle OMP trouvé.",
+      "catalogFailed": "Impossible de charger le catalogue des modèles OMP.",
+      "loadingModels": "Chargement des modèles OMP…",
+      "discoveryFailed": "Échec de la détection des modèles OMP : {error}",
+      "workspaceNotInitialized": "L’espace de travail OMP n’est pas initialisé",
+      "safe": "Sûr",
+      "yolo": "YOLO",
+      "permissionRequest": "OMP demande l’autorisation d’utiliser {tool}.",
+      "tool": "un outil"
+    },
+    "cursor": {
+      "setup": "Setup",
+      "enable": "Enable Cursor",
+      "enableDesc": "Enable Cursor Agent through its ACP CLI.",
+      "cliPath": "CLI path",
+      "cliPathDesc": "Absolute path to the Cursor Agent CLI on this computer.",
+      "models": "Models",
+      "noModels": "No Cursor models discovered yet. Run agent login and click Discover.",
+      "catalogFailed": "Could not load the Cursor model catalog. Check the CLI path and login state.",
+      "loadingModels": "Loading Cursor models...",
+      "discoveryFailed": "Cursor model discovery failed: {error}",
+      "workspaceNotInitialized": "Cursor workspace is not initialized",
+      "agent": "Agent",
+      "plan": "Plan",
+      "ask": "Ask",
+      "permissionRequest": "Cursor requests permission to use {tool}.",
+      "tool": "a tool"
+    },
+    "grok": {
+      "cliPathDesc": "Optional absolute path to the Grok CLI. Leave empty to prefer known installs, then PATH. Paste the output of \"which grok\" (or \"where grok\" on Windows)."
+    },
+    "opencode": {
+      "cliPathDesc": "Optional absolute path to the OpenCode CLI. Leave empty to use PATH. Paste the output of \"which opencode\" (or \"where opencode\" on Windows)."
+    },
+    "pi": {
+      "cliPathDesc": "Optional absolute path to the Pi CLI. Leave empty to use PATH. Paste the output of \"which pi\" (or \"where pi\" on Windows)."
+    },
+    "providerReadiness": {
+      "title": "État de préparation",
+      "desc": "Vérifier si {provider} est prêt à démarrer une conversation.",
+      "checking": "Vérification de l’état du fournisseur…",
+      "refresh": "Vérifier à nouveau",
+      "status": {
+        "disabled": "Désactivé",
+        "blocked": "Action requise",
+        "attention": "Attention requise",
+        "ready": "Prêt"
+      },
+      "check": {
+        "enabled": "Fournisseur activé",
+        "cli": "CLI disponible",
+        "models": "Catalogue de modèles disponible",
+        "selection": "Modèle de chat sélectionné"
+      },
+      "hint": {
+        "enableProvider": "Activez ce fournisseur pour l’utiliser dans le chat.",
+        "configureCli": "Définissez un chemin CLI valide ou rendez la CLI disponible dans le PATH d’Obsidian.",
+        "refreshModels": "Vérifiez la connexion ou la session du fournisseur, puis vérifiez à nouveau pour charger les modèles.",
+        "selectModel": "Sélectionnez au moins un modèle de chat ci-dessous."
+      }
+    },
+    "cliLifecycle": {
+      "label": "CLI {cli}",
+      "checking": "Vérification du CLI…",
+      "currentVersion": "Version actuelle",
+      "latestVersion": "Dernière version",
+      "notInstalled": "Non installé",
+      "installedButBroken": "Installé mais non exécutable",
+      "updateAvailable": "Mise à jour disponible",
+      "install": "Installer",
+      "installConfirm": "Installer {cli} ?\n\nCommande : {command}",
+      "installDone": "{cli} installé avec succès.",
+      "installFailed": "Échec de l'installation de {cli}.",
+      "update": "Mettre à jour",
+      "updateConfirm": "Mettre à jour {cli} ?\n\nCommande : {command}",
+      "updateDone": "{cli} mis à jour avec succès.",
+      "updateFailed": "Échec de la mise à jour de {cli}.",
+      "ready": "À jour",
+      "checkEnv": "Le CLI est installé mais ne peut pas s'exécuter. Vérifiez l'environnement d'exécution (version Node, PATH).",
+      "probe": {
+        "timedOut": "Délai dépassé lors de la vérification de version.",
+        "failedToStart": "Impossible de démarrer le processus CLI.",
+        "outputTooLarge": "Sortie de la vérification de version trop grande.",
+        "notFound": "CLI non installé ou introuvable dans le PATH."
+      },
+      "versionUnchanged": "{cli} est toujours en {version} après la mise à jour. La commande n’a peut-être rien changé."
+    },
+    "providerDiagnostics": {
+      "kicker": "Dépannage",
+      "title": "Diagnostic du fournisseur",
+      "whatHappened": "Ce qui s’est passé",
+      "readiness": "Vérifications de préparation",
+      "provider": "Fournisseur",
+      "category": "Catégorie",
+      "status": "État",
+      "platform": "Plateforme",
+      "time": "Heure",
+      "retry": "Réessayer le message",
+      "rebuild": "Reconstruire la session",
+      "details": "Voir les détails",
+      "copy": "Copier le rapport",
+      "close": "Fermer",
+      "copied": "Rapport de diagnostic copié.",
+      "copyFailed": "Impossible de copier le rapport de diagnostic.",
+      "statusValue": {
+        "idle": "Inactif",
+        "starting": "Démarrage",
+        "running": "En cours",
+        "failed": "Échec"
+      },
+      "check": {
+        "enabled": "Fournisseur activé",
+        "cli": "CLI disponible",
+        "models": "Catalogue de modèles disponible",
+        "selection": "Modèle de chat sélectionné"
+      },
+      "checkStatus": {
+        "disabled": "Désactivé",
+        "blocked": "Bloqué",
+        "attention": "Attention requise",
+        "ready": "Prêt"
+      },
+      "remediation": {
+        "enableProvider": "activer le fournisseur",
+        "configureCli": "configurer la CLI",
+        "refreshModels": "actualiser les modèles",
+        "selectModel": "sélectionner un modèle"
+      },
+      "categoryValue": {
+        "unknown": "Erreur inconnue",
+        "cli-not-found": "CLI introuvable",
+        "cli-start-failed": "Échec du démarrage de la CLI",
+        "session-resume-failed": "Échec de la reprise de session",
+        "model-unavailable": "Modèle indisponible",
+        "permission-denied": "Permission refusée",
+        "timeout": "Délai dépassé",
+        "rate-limited": "Limite de débit",
+        "protocol-error": "Erreur de protocole",
+        "authentication": "Échec de l’authentification",
+        "not-configured": "Non configuré",
+        "provider": "Erreur du fournisseur"
+      }
+    },
     "display": "Affichage",
     "conversations": "Conversations",
     "content": "Contenu",
@@ -438,9 +581,40 @@
       }
     },
     "agentSkills": {
-      "sectionTitle": "Skills", "fixedRoot": "Managed in .agents/skills", "sharedExpectation": "Manage shared skills in .agents/skills/ for compatible providers.", "noSkills": "No shared skills configured. Click + to create one.", "skillBadge": "skill", "diagnosticsTitle": "Skills needing attention", "loadFailed": "Could not load shared skills.", "savedRefreshFailed": "Saved, but provider refresh failed.", "validationFailed": "Invalid skill: {message}", "collisionFailed": "A skill named \"{name}\" already exists.", "saveFailed": "Failed to save shared skill: {message}", "deleteFailed": "Failed to move shared skill to trash: {message}", "staleConflict": "This skill changed elsewhere; refresh before saving.", "created": "Shared skill \"{name}\" created.", "updated": "Shared skill \"{name}\" updated.", "deleted": "Shared skill \"{name}\" moved to trash.",
-      "modal": { "titleEdit": "Edit Shared Skill", "titleAdd": "Add Shared Skill", "name": "Skill name", "nameDesc": "Lowercase letters and numbers separated by single hyphens", "namePlaceholder": "code-reviewer", "description": "Description", "descriptionDesc": "Required portable description used by providers to select the skill", "descriptionPlaceholder": "Reviews code for correctness and maintainability", "instructions": "Instructions", "instructionsDesc": "Required SKILL.md instructions", "instructionsPlaceholder": "Review the supplied code and report actionable findings..." },
-      "delete": { "title": "Delete Shared Skill", "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.", "confirm": "Move to trash" }
+      "sectionTitle": "Skills",
+      "fixedRoot": "Managed in .agents/skills",
+      "sharedExpectation": "Manage shared skills in .agents/skills/ for compatible providers.",
+      "noSkills": "No shared skills configured. Click + to create one.",
+      "skillBadge": "skill",
+      "diagnosticsTitle": "Skills needing attention",
+      "loadFailed": "Could not load shared skills.",
+      "savedRefreshFailed": "Saved, but provider refresh failed.",
+      "validationFailed": "Invalid skill: {message}",
+      "collisionFailed": "A skill named \"{name}\" already exists.",
+      "saveFailed": "Failed to save shared skill: {message}",
+      "deleteFailed": "Failed to move shared skill to trash: {message}",
+      "staleConflict": "This skill changed elsewhere; refresh before saving.",
+      "created": "Shared skill \"{name}\" created.",
+      "updated": "Shared skill \"{name}\" updated.",
+      "deleted": "Shared skill \"{name}\" moved to trash.",
+      "modal": {
+        "titleEdit": "Edit Shared Skill",
+        "titleAdd": "Add Shared Skill",
+        "name": "Skill name",
+        "nameDesc": "Lowercase letters and numbers separated by single hyphens",
+        "namePlaceholder": "code-reviewer",
+        "description": "Description",
+        "descriptionDesc": "Required portable description used by providers to select the skill",
+        "descriptionPlaceholder": "Reviews code for correctness and maintainability",
+        "instructions": "Instructions",
+        "instructionsDesc": "Required SKILL.md instructions",
+        "instructionsPlaceholder": "Review the supplied code and report actionable findings..."
+      },
+      "delete": {
+        "title": "Delete Shared Skill",
+        "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.",
+        "confirm": "Move to trash"
+      }
     },
     "codexSkills": {
       "modal": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -105,13 +105,156 @@
       "claude": "Claude",
       "codex": "Codex"
     },
-    "omp": { "setup": "セットアップ", "enable": "OMP を有効化", "enableDesc": "Oh My Pi ACP プロバイダーを有効にします。", "cliPath": "CLI パス", "cliPathDesc": "このコンピューター上の OMP の絶対パスです。", "models": "モデル", "noModels": "OMP モデルがまだ見つかりません。", "catalogFailed": "OMP モデルカタログを読み込めませんでした。", "loadingModels": "OMP モデルを読み込み中…", "discoveryFailed": "OMP モデルの検出に失敗しました：{error}", "workspaceNotInitialized": "OMP ワークスペースが初期化されていません", "safe": "安全", "yolo": "YOLO", "permissionRequest": "OMP が{tool}を使用する権限を要求しています。", "tool": "ツール" },
-    "cursor": {"setup":"Setup","enable":"Enable Cursor","enableDesc":"Enable Cursor Agent through its ACP CLI.","cliPath":"CLI path","cliPathDesc":"Absolute path to the Cursor Agent CLI on this computer.","models":"Models","noModels":"No Cursor models discovered yet. Run agent login and click Discover.","catalogFailed":"Could not load the Cursor model catalog. Check the CLI path and login state.","loadingModels":"Loading Cursor models...","discoveryFailed":"Cursor model discovery failed: {error}","workspaceNotInitialized":"Cursor workspace is not initialized","agent":"Agent","plan":"Plan","ask":"Ask","permissionRequest":"Cursor requests permission to use {tool}.","tool":"a tool"},
-    "grok": {"cliPathDesc":"Optional absolute path to the Grok CLI. Leave empty to prefer known installs, then PATH. Paste the output of \"which grok\" (or \"where grok\" on Windows)."},
-    "opencode": {"cliPathDesc":"Optional absolute path to the OpenCode CLI. Leave empty to use PATH. Paste the output of \"which opencode\" (or \"where opencode\" on Windows)."},
-    "pi": {"cliPathDesc":"Optional absolute path to the Pi CLI. Leave empty to use PATH. Paste the output of \"which pi\" (or \"where pi\" on Windows)."},
-    "providerReadiness": { "title": "準備状況", "desc": "{provider} がチャットを開始できる状態か確認します。", "checking": "プロバイダーの準備状況を確認中…", "refresh": "再確認", "status": { "disabled": "無効", "blocked": "対応が必要", "attention": "要確認", "ready": "準備完了" }, "check": { "enabled": "プロバイダーが有効", "cli": "CLI が利用可能", "models": "モデルカタログが利用可能", "selection": "チャットモデルを選択済み" }, "hint": { "enableProvider": "このプロバイダーを有効にするとチャットで使用できます。", "configureCli": "有効な CLI パスを設定するか、Obsidian の PATH から CLI を見つけられるようにしてください。", "refreshModels": "プロバイダーのログインまたはセッションを確認してから、再確認してモデルを読み込んでください。", "selectModel": "下からチャットモデルを1つ以上選択してください。" } },
-    "providerDiagnostics": { "kicker": "トラブルシューティング", "title": "Provider 診断", "whatHappened": "発生した問題", "readiness": "準備状況チェック", "provider": "Provider", "category": "カテゴリ", "status": "状態", "platform": "プラットフォーム", "time": "時刻", "retry": "メッセージを再試行", "rebuild": "セッションを再構築", "details": "詳細を表示", "copy": "レポートをコピー", "close": "閉じる", "copied": "診断レポートをコピーしました。", "copyFailed": "診断レポートをコピーできませんでした。", "statusValue": { "idle": "待機中", "starting": "起動中", "running": "実行中", "failed": "失敗" }, "check": { "enabled": "Provider が有効", "cli": "CLI が利用可能", "models": "モデルカタログが利用可能", "selection": "チャットモデルを選択済み" }, "checkStatus": { "disabled": "無効", "blocked": "ブロック", "attention": "要確認", "ready": "準備完了" }, "remediation": { "enableProvider": "Provider を有効化", "configureCli": "CLI を設定", "refreshModels": "モデルを更新", "selectModel": "モデルを選択" }, "categoryValue": { "unknown": "不明なエラー", "cli-not-found": "CLI が見つかりません", "cli-start-failed": "CLI の起動に失敗", "session-resume-failed": "セッションの再開に失敗", "model-unavailable": "モデルを利用できません", "permission-denied": "権限がありません", "timeout": "タイムアウト", "rate-limited": "レート制限", "protocol-error": "プロトコルエラー", "authentication": "認証に失敗", "not-configured": "未設定", "provider": "Provider エラー" } },
+    "omp": {
+      "setup": "セットアップ",
+      "enable": "OMP を有効化",
+      "enableDesc": "Oh My Pi ACP プロバイダーを有効にします。",
+      "cliPath": "CLI パス",
+      "cliPathDesc": "このコンピューター上の OMP の絶対パスです。",
+      "models": "モデル",
+      "noModels": "OMP モデルがまだ見つかりません。",
+      "catalogFailed": "OMP モデルカタログを読み込めませんでした。",
+      "loadingModels": "OMP モデルを読み込み中…",
+      "discoveryFailed": "OMP モデルの検出に失敗しました：{error}",
+      "workspaceNotInitialized": "OMP ワークスペースが初期化されていません",
+      "safe": "安全",
+      "yolo": "YOLO",
+      "permissionRequest": "OMP が{tool}を使用する権限を要求しています。",
+      "tool": "ツール"
+    },
+    "cursor": {
+      "setup": "Setup",
+      "enable": "Enable Cursor",
+      "enableDesc": "Enable Cursor Agent through its ACP CLI.",
+      "cliPath": "CLI path",
+      "cliPathDesc": "Absolute path to the Cursor Agent CLI on this computer.",
+      "models": "Models",
+      "noModels": "No Cursor models discovered yet. Run agent login and click Discover.",
+      "catalogFailed": "Could not load the Cursor model catalog. Check the CLI path and login state.",
+      "loadingModels": "Loading Cursor models...",
+      "discoveryFailed": "Cursor model discovery failed: {error}",
+      "workspaceNotInitialized": "Cursor workspace is not initialized",
+      "agent": "Agent",
+      "plan": "Plan",
+      "ask": "Ask",
+      "permissionRequest": "Cursor requests permission to use {tool}.",
+      "tool": "a tool"
+    },
+    "grok": {
+      "cliPathDesc": "Optional absolute path to the Grok CLI. Leave empty to prefer known installs, then PATH. Paste the output of \"which grok\" (or \"where grok\" on Windows)."
+    },
+    "opencode": {
+      "cliPathDesc": "Optional absolute path to the OpenCode CLI. Leave empty to use PATH. Paste the output of \"which opencode\" (or \"where opencode\" on Windows)."
+    },
+    "pi": {
+      "cliPathDesc": "Optional absolute path to the Pi CLI. Leave empty to use PATH. Paste the output of \"which pi\" (or \"where pi\" on Windows)."
+    },
+    "providerReadiness": {
+      "title": "準備状況",
+      "desc": "{provider} がチャットを開始できる状態か確認します。",
+      "checking": "プロバイダーの準備状況を確認中…",
+      "refresh": "再確認",
+      "status": {
+        "disabled": "無効",
+        "blocked": "対応が必要",
+        "attention": "要確認",
+        "ready": "準備完了"
+      },
+      "check": {
+        "enabled": "プロバイダーが有効",
+        "cli": "CLI が利用可能",
+        "models": "モデルカタログが利用可能",
+        "selection": "チャットモデルを選択済み"
+      },
+      "hint": {
+        "enableProvider": "このプロバイダーを有効にするとチャットで使用できます。",
+        "configureCli": "有効な CLI パスを設定するか、Obsidian の PATH から CLI を見つけられるようにしてください。",
+        "refreshModels": "プロバイダーのログインまたはセッションを確認してから、再確認してモデルを読み込んでください。",
+        "selectModel": "下からチャットモデルを1つ以上選択してください。"
+      }
+    },
+    "cliLifecycle": {
+      "label": "{cli} CLI",
+      "checking": "CLI を確認中…",
+      "currentVersion": "現在のバージョン",
+      "latestVersion": "最新バージョン",
+      "notInstalled": "未インストール",
+      "installedButBroken": "インストール済みだが起動不可",
+      "updateAvailable": "更新があります",
+      "install": "インストール",
+      "installConfirm": "{cli} をインストールしますか？\n\nコマンド: {command}",
+      "installDone": "{cli} のインストールが完了しました。",
+      "installFailed": "{cli} のインストールに失敗しました。",
+      "update": "更新",
+      "updateConfirm": "{cli} を更新しますか？\n\nコマンド: {command}",
+      "updateDone": "{cli} を更新しました。",
+      "updateFailed": "{cli} の更新に失敗しました。",
+      "ready": "最新です",
+      "checkEnv": "CLI はインストールされていますが実行できません。実行環境（Node バージョン、PATH など）を確認してください。",
+      "probe": {
+        "timedOut": "バージョン確認がタイムアウトしました。",
+        "failedToStart": "CLI プロセスを起動できませんでした。",
+        "outputTooLarge": "バージョン確認の出力が大きすぎます。",
+        "notFound": "CLI が見つからないか、PATH にありません。"
+      },
+      "versionUnchanged": "更新後も {cli} は {version} のままです。コマンドが実際には実行されなかった可能性があります。"
+    },
+    "providerDiagnostics": {
+      "kicker": "トラブルシューティング",
+      "title": "Provider 診断",
+      "whatHappened": "発生した問題",
+      "readiness": "準備状況チェック",
+      "provider": "Provider",
+      "category": "カテゴリ",
+      "status": "状態",
+      "platform": "プラットフォーム",
+      "time": "時刻",
+      "retry": "メッセージを再試行",
+      "rebuild": "セッションを再構築",
+      "details": "詳細を表示",
+      "copy": "レポートをコピー",
+      "close": "閉じる",
+      "copied": "診断レポートをコピーしました。",
+      "copyFailed": "診断レポートをコピーできませんでした。",
+      "statusValue": {
+        "idle": "待機中",
+        "starting": "起動中",
+        "running": "実行中",
+        "failed": "失敗"
+      },
+      "check": {
+        "enabled": "Provider が有効",
+        "cli": "CLI が利用可能",
+        "models": "モデルカタログが利用可能",
+        "selection": "チャットモデルを選択済み"
+      },
+      "checkStatus": {
+        "disabled": "無効",
+        "blocked": "ブロック",
+        "attention": "要確認",
+        "ready": "準備完了"
+      },
+      "remediation": {
+        "enableProvider": "Provider を有効化",
+        "configureCli": "CLI を設定",
+        "refreshModels": "モデルを更新",
+        "selectModel": "モデルを選択"
+      },
+      "categoryValue": {
+        "unknown": "不明なエラー",
+        "cli-not-found": "CLI が見つかりません",
+        "cli-start-failed": "CLI の起動に失敗",
+        "session-resume-failed": "セッションの再開に失敗",
+        "model-unavailable": "モデルを利用できません",
+        "permission-denied": "権限がありません",
+        "timeout": "タイムアウト",
+        "rate-limited": "レート制限",
+        "protocol-error": "プロトコルエラー",
+        "authentication": "認証に失敗",
+        "not-configured": "未設定",
+        "provider": "Provider エラー"
+      }
+    },
     "display": "表示",
     "conversations": "会話",
     "content": "コンテンツ",
@@ -438,9 +581,40 @@
       }
     },
     "agentSkills": {
-      "sectionTitle": "Skills", "fixedRoot": "Managed in .agents/skills", "sharedExpectation": "Manage shared skills in .agents/skills/ for compatible providers.", "noSkills": "No shared skills configured. Click + to create one.", "skillBadge": "skill", "diagnosticsTitle": "Skills needing attention", "loadFailed": "Could not load shared skills.", "savedRefreshFailed": "Saved, but provider refresh failed.", "validationFailed": "Invalid skill: {message}", "collisionFailed": "A skill named \"{name}\" already exists.", "saveFailed": "Failed to save shared skill: {message}", "deleteFailed": "Failed to move shared skill to trash: {message}", "staleConflict": "This skill changed elsewhere; refresh before saving.", "created": "Shared skill \"{name}\" created.", "updated": "Shared skill \"{name}\" updated.", "deleted": "Shared skill \"{name}\" moved to trash.",
-      "modal": { "titleEdit": "Edit Shared Skill", "titleAdd": "Add Shared Skill", "name": "Skill name", "nameDesc": "Lowercase letters and numbers separated by single hyphens", "namePlaceholder": "code-reviewer", "description": "Description", "descriptionDesc": "Required portable description used by providers to select the skill", "descriptionPlaceholder": "Reviews code for correctness and maintainability", "instructions": "Instructions", "instructionsDesc": "Required SKILL.md instructions", "instructionsPlaceholder": "Review the supplied code and report actionable findings..." },
-      "delete": { "title": "Delete Shared Skill", "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.", "confirm": "Move to trash" }
+      "sectionTitle": "Skills",
+      "fixedRoot": "Managed in .agents/skills",
+      "sharedExpectation": "Manage shared skills in .agents/skills/ for compatible providers.",
+      "noSkills": "No shared skills configured. Click + to create one.",
+      "skillBadge": "skill",
+      "diagnosticsTitle": "Skills needing attention",
+      "loadFailed": "Could not load shared skills.",
+      "savedRefreshFailed": "Saved, but provider refresh failed.",
+      "validationFailed": "Invalid skill: {message}",
+      "collisionFailed": "A skill named \"{name}\" already exists.",
+      "saveFailed": "Failed to save shared skill: {message}",
+      "deleteFailed": "Failed to move shared skill to trash: {message}",
+      "staleConflict": "This skill changed elsewhere; refresh before saving.",
+      "created": "Shared skill \"{name}\" created.",
+      "updated": "Shared skill \"{name}\" updated.",
+      "deleted": "Shared skill \"{name}\" moved to trash.",
+      "modal": {
+        "titleEdit": "Edit Shared Skill",
+        "titleAdd": "Add Shared Skill",
+        "name": "Skill name",
+        "nameDesc": "Lowercase letters and numbers separated by single hyphens",
+        "namePlaceholder": "code-reviewer",
+        "description": "Description",
+        "descriptionDesc": "Required portable description used by providers to select the skill",
+        "descriptionPlaceholder": "Reviews code for correctness and maintainability",
+        "instructions": "Instructions",
+        "instructionsDesc": "Required SKILL.md instructions",
+        "instructionsPlaceholder": "Review the supplied code and report actionable findings..."
+      },
+      "delete": {
+        "title": "Delete Shared Skill",
+        "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.",
+        "confirm": "Move to trash"
+      }
     },
     "codexSkills": {
       "modal": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -105,13 +105,156 @@
       "claude": "Claude",
       "codex": "Codex"
     },
-    "omp": { "setup": "설정", "enable": "OMP 활성화", "enableDesc": "Oh My Pi ACP 공급자를 활성화합니다.", "cliPath": "CLI 경로", "cliPathDesc": "이 컴퓨터의 OMP 절대 경로입니다.", "models": "모델", "noModels": "아직 OMP 모델을 찾지 못했습니다.", "catalogFailed": "OMP 모델 카탈로그를 불러오지 못했습니다.", "loadingModels": "OMP 모델을 불러오는 중…", "discoveryFailed": "OMP 모델 검색 실패: {error}", "workspaceNotInitialized": "OMP 작업 공간이 초기화되지 않았습니다", "safe": "안전", "yolo": "YOLO", "permissionRequest": "OMP가 {tool} 사용 권한을 요청합니다.", "tool": "도구" },
-    "cursor": {"setup":"Setup","enable":"Enable Cursor","enableDesc":"Enable Cursor Agent through its ACP CLI.","cliPath":"CLI path","cliPathDesc":"Absolute path to the Cursor Agent CLI on this computer.","models":"Models","noModels":"No Cursor models discovered yet. Run agent login and click Discover.","catalogFailed":"Could not load the Cursor model catalog. Check the CLI path and login state.","loadingModels":"Loading Cursor models...","discoveryFailed":"Cursor model discovery failed: {error}","workspaceNotInitialized":"Cursor workspace is not initialized","agent":"Agent","plan":"Plan","ask":"Ask","permissionRequest":"Cursor requests permission to use {tool}.","tool":"a tool"},
-    "grok": {"cliPathDesc":"Optional absolute path to the Grok CLI. Leave empty to prefer known installs, then PATH. Paste the output of \"which grok\" (or \"where grok\" on Windows)."},
-    "opencode": {"cliPathDesc":"Optional absolute path to the OpenCode CLI. Leave empty to use PATH. Paste the output of \"which opencode\" (or \"where opencode\" on Windows)."},
-    "pi": {"cliPathDesc":"Optional absolute path to the Pi CLI. Leave empty to use PATH. Paste the output of \"which pi\" (or \"where pi\" on Windows)."},
-    "providerReadiness": { "title": "준비 상태", "desc": "{provider}가 채팅을 시작할 준비가 되었는지 확인합니다.", "checking": "공급자 준비 상태 확인 중…", "refresh": "다시 확인", "status": { "disabled": "비활성화됨", "blocked": "조치 필요", "attention": "확인 필요", "ready": "준비됨" }, "check": { "enabled": "공급자 활성화됨", "cli": "CLI 사용 가능", "models": "모델 카탈로그 사용 가능", "selection": "채팅 모델 선택됨" }, "hint": { "enableProvider": "이 공급자를 활성화하면 채팅에서 사용할 수 있습니다.", "configureCli": "유효한 CLI 경로를 설정하거나 Obsidian의 PATH에서 CLI를 찾을 수 있게 하세요.", "refreshModels": "공급자 로그인 또는 세션을 확인한 다음 다시 확인하여 모델을 불러오세요.", "selectModel": "아래에서 채팅 모델을 하나 이상 선택하세요." } },
-    "providerDiagnostics": { "kicker": "문제 해결", "title": "Provider 진단", "whatHappened": "발생한 문제", "readiness": "준비 상태 확인", "provider": "Provider", "category": "분류", "status": "상태", "platform": "플랫폼", "time": "시간", "retry": "메시지 재시도", "rebuild": "세션 재구성", "details": "세부 정보 보기", "copy": "보고서 복사", "close": "닫기", "copied": "진단 보고서를 복사했습니다.", "copyFailed": "진단 보고서를 복사할 수 없습니다.", "statusValue": { "idle": "대기", "starting": "시작 중", "running": "실행 중", "failed": "실패" }, "check": { "enabled": "Provider 활성화됨", "cli": "CLI 사용 가능", "models": "모델 카탈로그 사용 가능", "selection": "채팅 모델 선택됨" }, "checkStatus": { "disabled": "비활성화됨", "blocked": "차단됨", "attention": "확인 필요", "ready": "준비됨" }, "remediation": { "enableProvider": "Provider 활성화", "configureCli": "CLI 설정", "refreshModels": "모델 새로고침", "selectModel": "모델 선택" }, "categoryValue": { "unknown": "알 수 없는 오류", "cli-not-found": "CLI를 찾을 수 없음", "cli-start-failed": "CLI 시작 실패", "session-resume-failed": "세션 재개 실패", "model-unavailable": "모델을 사용할 수 없음", "permission-denied": "권한 거부", "timeout": "시간 초과", "rate-limited": "요청 제한", "protocol-error": "프로토콜 오류", "authentication": "인증 실패", "not-configured": "구성되지 않음", "provider": "Provider 오류" } },
+    "omp": {
+      "setup": "설정",
+      "enable": "OMP 활성화",
+      "enableDesc": "Oh My Pi ACP 공급자를 활성화합니다.",
+      "cliPath": "CLI 경로",
+      "cliPathDesc": "이 컴퓨터의 OMP 절대 경로입니다.",
+      "models": "모델",
+      "noModels": "아직 OMP 모델을 찾지 못했습니다.",
+      "catalogFailed": "OMP 모델 카탈로그를 불러오지 못했습니다.",
+      "loadingModels": "OMP 모델을 불러오는 중…",
+      "discoveryFailed": "OMP 모델 검색 실패: {error}",
+      "workspaceNotInitialized": "OMP 작업 공간이 초기화되지 않았습니다",
+      "safe": "안전",
+      "yolo": "YOLO",
+      "permissionRequest": "OMP가 {tool} 사용 권한을 요청합니다.",
+      "tool": "도구"
+    },
+    "cursor": {
+      "setup": "Setup",
+      "enable": "Enable Cursor",
+      "enableDesc": "Enable Cursor Agent through its ACP CLI.",
+      "cliPath": "CLI path",
+      "cliPathDesc": "Absolute path to the Cursor Agent CLI on this computer.",
+      "models": "Models",
+      "noModels": "No Cursor models discovered yet. Run agent login and click Discover.",
+      "catalogFailed": "Could not load the Cursor model catalog. Check the CLI path and login state.",
+      "loadingModels": "Loading Cursor models...",
+      "discoveryFailed": "Cursor model discovery failed: {error}",
+      "workspaceNotInitialized": "Cursor workspace is not initialized",
+      "agent": "Agent",
+      "plan": "Plan",
+      "ask": "Ask",
+      "permissionRequest": "Cursor requests permission to use {tool}.",
+      "tool": "a tool"
+    },
+    "grok": {
+      "cliPathDesc": "Optional absolute path to the Grok CLI. Leave empty to prefer known installs, then PATH. Paste the output of \"which grok\" (or \"where grok\" on Windows)."
+    },
+    "opencode": {
+      "cliPathDesc": "Optional absolute path to the OpenCode CLI. Leave empty to use PATH. Paste the output of \"which opencode\" (or \"where opencode\" on Windows)."
+    },
+    "pi": {
+      "cliPathDesc": "Optional absolute path to the Pi CLI. Leave empty to use PATH. Paste the output of \"which pi\" (or \"where pi\" on Windows)."
+    },
+    "providerReadiness": {
+      "title": "준비 상태",
+      "desc": "{provider}가 채팅을 시작할 준비가 되었는지 확인합니다.",
+      "checking": "공급자 준비 상태 확인 중…",
+      "refresh": "다시 확인",
+      "status": {
+        "disabled": "비활성화됨",
+        "blocked": "조치 필요",
+        "attention": "확인 필요",
+        "ready": "준비됨"
+      },
+      "check": {
+        "enabled": "공급자 활성화됨",
+        "cli": "CLI 사용 가능",
+        "models": "모델 카탈로그 사용 가능",
+        "selection": "채팅 모델 선택됨"
+      },
+      "hint": {
+        "enableProvider": "이 공급자를 활성화하면 채팅에서 사용할 수 있습니다.",
+        "configureCli": "유효한 CLI 경로를 설정하거나 Obsidian의 PATH에서 CLI를 찾을 수 있게 하세요.",
+        "refreshModels": "공급자 로그인 또는 세션을 확인한 다음 다시 확인하여 모델을 불러오세요.",
+        "selectModel": "아래에서 채팅 모델을 하나 이상 선택하세요."
+      }
+    },
+    "cliLifecycle": {
+      "label": "{cli} CLI",
+      "checking": "CLI 확인 중…",
+      "currentVersion": "현재 버전",
+      "latestVersion": "최신 버전",
+      "notInstalled": "설치되지 않음",
+      "installedButBroken": "설치됨, 실행 불가",
+      "updateAvailable": "업데이트 가능",
+      "install": "설치",
+      "installConfirm": "{cli}을(를) 설치할까요?\n\n명령: {command}",
+      "installDone": "{cli} 설치가 완료되었습니다.",
+      "installFailed": "{cli} 설치에 실패했습니다.",
+      "update": "업데이트",
+      "updateConfirm": "{cli}을(를) 업데이트할까요?\n\n명령: {command}",
+      "updateDone": "{cli} 업데이트가 완료되었습니다.",
+      "updateFailed": "{cli} 업데이트에 실패했습니다.",
+      "ready": "최신 버전입니다",
+      "checkEnv": "CLI가 설치되어 있지만 실행할 수 없습니다. 실행 환경(Node 버전, PATH 등)을 확인하세요.",
+      "probe": {
+        "timedOut": "버전 확인 시간이 초과되었습니다.",
+        "failedToStart": "CLI 프로세스를 시작할 수 없습니다.",
+        "outputTooLarge": "버전 확인 출력이 너무 큽니다.",
+        "notFound": "CLI를 찾을 수 없거나 PATH에 없습니다."
+      },
+      "versionUnchanged": "업데이트 후에도 {cli}이(가) {version}로 유지됩니다. 명령이 실제로 적용되지 않았을 수 있습니다."
+    },
+    "providerDiagnostics": {
+      "kicker": "문제 해결",
+      "title": "Provider 진단",
+      "whatHappened": "발생한 문제",
+      "readiness": "준비 상태 확인",
+      "provider": "Provider",
+      "category": "분류",
+      "status": "상태",
+      "platform": "플랫폼",
+      "time": "시간",
+      "retry": "메시지 재시도",
+      "rebuild": "세션 재구성",
+      "details": "세부 정보 보기",
+      "copy": "보고서 복사",
+      "close": "닫기",
+      "copied": "진단 보고서를 복사했습니다.",
+      "copyFailed": "진단 보고서를 복사할 수 없습니다.",
+      "statusValue": {
+        "idle": "대기",
+        "starting": "시작 중",
+        "running": "실행 중",
+        "failed": "실패"
+      },
+      "check": {
+        "enabled": "Provider 활성화됨",
+        "cli": "CLI 사용 가능",
+        "models": "모델 카탈로그 사용 가능",
+        "selection": "채팅 모델 선택됨"
+      },
+      "checkStatus": {
+        "disabled": "비활성화됨",
+        "blocked": "차단됨",
+        "attention": "확인 필요",
+        "ready": "준비됨"
+      },
+      "remediation": {
+        "enableProvider": "Provider 활성화",
+        "configureCli": "CLI 설정",
+        "refreshModels": "모델 새로고침",
+        "selectModel": "모델 선택"
+      },
+      "categoryValue": {
+        "unknown": "알 수 없는 오류",
+        "cli-not-found": "CLI를 찾을 수 없음",
+        "cli-start-failed": "CLI 시작 실패",
+        "session-resume-failed": "세션 재개 실패",
+        "model-unavailable": "모델을 사용할 수 없음",
+        "permission-denied": "권한 거부",
+        "timeout": "시간 초과",
+        "rate-limited": "요청 제한",
+        "protocol-error": "프로토콜 오류",
+        "authentication": "인증 실패",
+        "not-configured": "구성되지 않음",
+        "provider": "Provider 오류"
+      }
+    },
     "display": "표시",
     "conversations": "대화",
     "content": "콘텐츠",
@@ -438,9 +581,40 @@
       }
     },
     "agentSkills": {
-      "sectionTitle": "Skills", "fixedRoot": "Managed in .agents/skills", "sharedExpectation": "Manage shared skills in .agents/skills/ for compatible providers.", "noSkills": "No shared skills configured. Click + to create one.", "skillBadge": "skill", "diagnosticsTitle": "Skills needing attention", "loadFailed": "Could not load shared skills.", "savedRefreshFailed": "Saved, but provider refresh failed.", "validationFailed": "Invalid skill: {message}", "collisionFailed": "A skill named \"{name}\" already exists.", "saveFailed": "Failed to save shared skill: {message}", "deleteFailed": "Failed to move shared skill to trash: {message}", "staleConflict": "This skill changed elsewhere; refresh before saving.", "created": "Shared skill \"{name}\" created.", "updated": "Shared skill \"{name}\" updated.", "deleted": "Shared skill \"{name}\" moved to trash.",
-      "modal": { "titleEdit": "Edit Shared Skill", "titleAdd": "Add Shared Skill", "name": "Skill name", "nameDesc": "Lowercase letters and numbers separated by single hyphens", "namePlaceholder": "code-reviewer", "description": "Description", "descriptionDesc": "Required portable description used by providers to select the skill", "descriptionPlaceholder": "Reviews code for correctness and maintainability", "instructions": "Instructions", "instructionsDesc": "Required SKILL.md instructions", "instructionsPlaceholder": "Review the supplied code and report actionable findings..." },
-      "delete": { "title": "Delete Shared Skill", "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.", "confirm": "Move to trash" }
+      "sectionTitle": "Skills",
+      "fixedRoot": "Managed in .agents/skills",
+      "sharedExpectation": "Manage shared skills in .agents/skills/ for compatible providers.",
+      "noSkills": "No shared skills configured. Click + to create one.",
+      "skillBadge": "skill",
+      "diagnosticsTitle": "Skills needing attention",
+      "loadFailed": "Could not load shared skills.",
+      "savedRefreshFailed": "Saved, but provider refresh failed.",
+      "validationFailed": "Invalid skill: {message}",
+      "collisionFailed": "A skill named \"{name}\" already exists.",
+      "saveFailed": "Failed to save shared skill: {message}",
+      "deleteFailed": "Failed to move shared skill to trash: {message}",
+      "staleConflict": "This skill changed elsewhere; refresh before saving.",
+      "created": "Shared skill \"{name}\" created.",
+      "updated": "Shared skill \"{name}\" updated.",
+      "deleted": "Shared skill \"{name}\" moved to trash.",
+      "modal": {
+        "titleEdit": "Edit Shared Skill",
+        "titleAdd": "Add Shared Skill",
+        "name": "Skill name",
+        "nameDesc": "Lowercase letters and numbers separated by single hyphens",
+        "namePlaceholder": "code-reviewer",
+        "description": "Description",
+        "descriptionDesc": "Required portable description used by providers to select the skill",
+        "descriptionPlaceholder": "Reviews code for correctness and maintainability",
+        "instructions": "Instructions",
+        "instructionsDesc": "Required SKILL.md instructions",
+        "instructionsPlaceholder": "Review the supplied code and report actionable findings..."
+      },
+      "delete": {
+        "title": "Delete Shared Skill",
+        "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.",
+        "confirm": "Move to trash"
+      }
     },
     "codexSkills": {
       "modal": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -105,13 +105,156 @@
       "claude": "Claude",
       "codex": "Codex"
     },
-    "omp": { "setup": "Configuração", "enable": "Ativar OMP", "enableDesc": "Ativar o provedor ACP do Oh My Pi.", "cliPath": "Caminho do CLI", "cliPathDesc": "Caminho absoluto para o OMP neste computador.", "models": "Modelos", "noModels": "Nenhum modelo OMP descoberto ainda.", "catalogFailed": "Não foi possível carregar o catálogo de modelos OMP.", "loadingModels": "Carregando modelos OMP…", "discoveryFailed": "Falha ao descobrir modelos OMP: {error}", "workspaceNotInitialized": "O workspace do OMP não foi inicializado", "safe": "Seguro", "yolo": "YOLO", "permissionRequest": "OMP solicita permissão para usar {tool}.", "tool": "uma ferramenta" },
-    "cursor": {"setup":"Setup","enable":"Enable Cursor","enableDesc":"Enable Cursor Agent through its ACP CLI.","cliPath":"CLI path","cliPathDesc":"Absolute path to the Cursor Agent CLI on this computer.","models":"Models","noModels":"No Cursor models discovered yet. Run agent login and click Discover.","catalogFailed":"Could not load the Cursor model catalog. Check the CLI path and login state.","loadingModels":"Loading Cursor models...","discoveryFailed":"Cursor model discovery failed: {error}","workspaceNotInitialized":"Cursor workspace is not initialized","agent":"Agent","plan":"Plan","ask":"Ask","permissionRequest":"Cursor requests permission to use {tool}.","tool":"a tool"},
-    "grok": {"cliPathDesc":"Optional absolute path to the Grok CLI. Leave empty to prefer known installs, then PATH. Paste the output of \"which grok\" (or \"where grok\" on Windows)."},
-    "opencode": {"cliPathDesc":"Optional absolute path to the OpenCode CLI. Leave empty to use PATH. Paste the output of \"which opencode\" (or \"where opencode\" on Windows)."},
-    "pi": {"cliPathDesc":"Optional absolute path to the Pi CLI. Leave empty to use PATH. Paste the output of \"which pi\" (or \"where pi\" on Windows)."},
-    "providerReadiness": { "title": "Prontidão", "desc": "Verifique se o {provider} está pronto para iniciar um chat.", "checking": "Verificando a prontidão do provedor…", "refresh": "Verificar novamente", "status": { "disabled": "Desativado", "blocked": "Ação necessária", "attention": "Requer atenção", "ready": "Pronto" }, "check": { "enabled": "Provedor ativado", "cli": "CLI disponível", "models": "Catálogo de modelos disponível", "selection": "Modelo de chat selecionado" }, "hint": { "enableProvider": "Ative este provedor para usá-lo no chat.", "configureCli": "Defina um caminho CLI válido ou disponibilize a CLI no PATH do Obsidian.", "refreshModels": "Verifique o login ou a sessão do provedor e verifique novamente para carregar modelos.", "selectModel": "Selecione pelo menos um modelo de chat abaixo." } },
-    "providerDiagnostics": { "kicker": "Solução de problemas", "title": "Diagnóstico do provedor", "whatHappened": "O que aconteceu", "readiness": "Verificações de prontidão", "provider": "Provedor", "category": "Categoria", "status": "Status", "platform": "Plataforma", "time": "Hora", "retry": "Tentar mensagem novamente", "rebuild": "Reconstruir sessão", "details": "Ver detalhes", "copy": "Copiar relatório", "close": "Fechar", "copied": "Relatório de diagnóstico copiado.", "copyFailed": "Não foi possível copiar o relatório de diagnóstico.", "statusValue": { "idle": "Inativo", "starting": "Iniciando", "running": "Em execução", "failed": "Falhou" }, "check": { "enabled": "Provedor ativado", "cli": "CLI disponível", "models": "Catálogo de modelos disponível", "selection": "Modelo de chat selecionado" }, "checkStatus": { "disabled": "Desativado", "blocked": "Bloqueado", "attention": "Requer atenção", "ready": "Pronto" }, "remediation": { "enableProvider": "ativar provedor", "configureCli": "configurar CLI", "refreshModels": "atualizar modelos", "selectModel": "selecionar modelo" }, "categoryValue": { "unknown": "Erro desconhecido", "cli-not-found": "CLI não encontrado", "cli-start-failed": "Falha ao iniciar a CLI", "session-resume-failed": "Falha ao retomar a sessão", "model-unavailable": "Modelo indisponível", "permission-denied": "Permissão negada", "timeout": "Tempo esgotado", "rate-limited": "Limite de solicitações", "protocol-error": "Erro de protocolo", "authentication": "Falha na autenticação", "not-configured": "Não configurado", "provider": "Erro do provedor" } },
+    "omp": {
+      "setup": "Configuração",
+      "enable": "Ativar OMP",
+      "enableDesc": "Ativar o provedor ACP do Oh My Pi.",
+      "cliPath": "Caminho do CLI",
+      "cliPathDesc": "Caminho absoluto para o OMP neste computador.",
+      "models": "Modelos",
+      "noModels": "Nenhum modelo OMP descoberto ainda.",
+      "catalogFailed": "Não foi possível carregar o catálogo de modelos OMP.",
+      "loadingModels": "Carregando modelos OMP…",
+      "discoveryFailed": "Falha ao descobrir modelos OMP: {error}",
+      "workspaceNotInitialized": "O workspace do OMP não foi inicializado",
+      "safe": "Seguro",
+      "yolo": "YOLO",
+      "permissionRequest": "OMP solicita permissão para usar {tool}.",
+      "tool": "uma ferramenta"
+    },
+    "cursor": {
+      "setup": "Setup",
+      "enable": "Enable Cursor",
+      "enableDesc": "Enable Cursor Agent through its ACP CLI.",
+      "cliPath": "CLI path",
+      "cliPathDesc": "Absolute path to the Cursor Agent CLI on this computer.",
+      "models": "Models",
+      "noModels": "No Cursor models discovered yet. Run agent login and click Discover.",
+      "catalogFailed": "Could not load the Cursor model catalog. Check the CLI path and login state.",
+      "loadingModels": "Loading Cursor models...",
+      "discoveryFailed": "Cursor model discovery failed: {error}",
+      "workspaceNotInitialized": "Cursor workspace is not initialized",
+      "agent": "Agent",
+      "plan": "Plan",
+      "ask": "Ask",
+      "permissionRequest": "Cursor requests permission to use {tool}.",
+      "tool": "a tool"
+    },
+    "grok": {
+      "cliPathDesc": "Optional absolute path to the Grok CLI. Leave empty to prefer known installs, then PATH. Paste the output of \"which grok\" (or \"where grok\" on Windows)."
+    },
+    "opencode": {
+      "cliPathDesc": "Optional absolute path to the OpenCode CLI. Leave empty to use PATH. Paste the output of \"which opencode\" (or \"where opencode\" on Windows)."
+    },
+    "pi": {
+      "cliPathDesc": "Optional absolute path to the Pi CLI. Leave empty to use PATH. Paste the output of \"which pi\" (or \"where pi\" on Windows)."
+    },
+    "providerReadiness": {
+      "title": "Prontidão",
+      "desc": "Verifique se o {provider} está pronto para iniciar um chat.",
+      "checking": "Verificando a prontidão do provedor…",
+      "refresh": "Verificar novamente",
+      "status": {
+        "disabled": "Desativado",
+        "blocked": "Ação necessária",
+        "attention": "Requer atenção",
+        "ready": "Pronto"
+      },
+      "check": {
+        "enabled": "Provedor ativado",
+        "cli": "CLI disponível",
+        "models": "Catálogo de modelos disponível",
+        "selection": "Modelo de chat selecionado"
+      },
+      "hint": {
+        "enableProvider": "Ative este provedor para usá-lo no chat.",
+        "configureCli": "Defina um caminho CLI válido ou disponibilize a CLI no PATH do Obsidian.",
+        "refreshModels": "Verifique o login ou a sessão do provedor e verifique novamente para carregar modelos.",
+        "selectModel": "Selecione pelo menos um modelo de chat abaixo."
+      }
+    },
+    "cliLifecycle": {
+      "label": "CLI {cli}",
+      "checking": "Verificando CLI…",
+      "currentVersion": "Versão atual",
+      "latestVersion": "Versão mais recente",
+      "notInstalled": "Não instalado",
+      "installedButBroken": "Instalado, mas não executável",
+      "updateAvailable": "Atualização disponível",
+      "install": "Instalar",
+      "installConfirm": "Instalar {cli}?\n\nComando: {command}",
+      "installDone": "{cli} instalado com sucesso.",
+      "installFailed": "Falha ao instalar {cli}.",
+      "update": "Atualizar",
+      "updateConfirm": "Atualizar {cli}?\n\nComando: {command}",
+      "updateDone": "{cli} atualizado com sucesso.",
+      "updateFailed": "Falha ao atualizar {cli}.",
+      "ready": "Atualizado",
+      "checkEnv": "O CLI está instalado, mas não pode ser executado. Verifique o ambiente de execução (versão do Node, PATH).",
+      "probe": {
+        "timedOut": "Tempo esgotado na verificação de versão.",
+        "failedToStart": "Não foi possível iniciar o processo CLI.",
+        "outputTooLarge": "Saída da verificação de versão muito grande.",
+        "notFound": "CLI não instalado ou não está no PATH."
+      },
+      "versionUnchanged": "{cli} ainda está em {version} após a atualização. O comando pode não ter surtido efeito."
+    },
+    "providerDiagnostics": {
+      "kicker": "Solução de problemas",
+      "title": "Diagnóstico do provedor",
+      "whatHappened": "O que aconteceu",
+      "readiness": "Verificações de prontidão",
+      "provider": "Provedor",
+      "category": "Categoria",
+      "status": "Status",
+      "platform": "Plataforma",
+      "time": "Hora",
+      "retry": "Tentar mensagem novamente",
+      "rebuild": "Reconstruir sessão",
+      "details": "Ver detalhes",
+      "copy": "Copiar relatório",
+      "close": "Fechar",
+      "copied": "Relatório de diagnóstico copiado.",
+      "copyFailed": "Não foi possível copiar o relatório de diagnóstico.",
+      "statusValue": {
+        "idle": "Inativo",
+        "starting": "Iniciando",
+        "running": "Em execução",
+        "failed": "Falhou"
+      },
+      "check": {
+        "enabled": "Provedor ativado",
+        "cli": "CLI disponível",
+        "models": "Catálogo de modelos disponível",
+        "selection": "Modelo de chat selecionado"
+      },
+      "checkStatus": {
+        "disabled": "Desativado",
+        "blocked": "Bloqueado",
+        "attention": "Requer atenção",
+        "ready": "Pronto"
+      },
+      "remediation": {
+        "enableProvider": "ativar provedor",
+        "configureCli": "configurar CLI",
+        "refreshModels": "atualizar modelos",
+        "selectModel": "selecionar modelo"
+      },
+      "categoryValue": {
+        "unknown": "Erro desconhecido",
+        "cli-not-found": "CLI não encontrado",
+        "cli-start-failed": "Falha ao iniciar a CLI",
+        "session-resume-failed": "Falha ao retomar a sessão",
+        "model-unavailable": "Modelo indisponível",
+        "permission-denied": "Permissão negada",
+        "timeout": "Tempo esgotado",
+        "rate-limited": "Limite de solicitações",
+        "protocol-error": "Erro de protocolo",
+        "authentication": "Falha na autenticação",
+        "not-configured": "Não configurado",
+        "provider": "Erro do provedor"
+      }
+    },
     "display": "Exibição",
     "conversations": "Conversas",
     "content": "Conteúdo",
@@ -438,9 +581,40 @@
       }
     },
     "agentSkills": {
-      "sectionTitle": "Skills", "fixedRoot": "Managed in .agents/skills", "sharedExpectation": "Manage shared skills in .agents/skills/ for compatible providers.", "noSkills": "No shared skills configured. Click + to create one.", "skillBadge": "skill", "diagnosticsTitle": "Skills needing attention", "loadFailed": "Could not load shared skills.", "savedRefreshFailed": "Saved, but provider refresh failed.", "validationFailed": "Invalid skill: {message}", "collisionFailed": "A skill named \"{name}\" already exists.", "saveFailed": "Failed to save shared skill: {message}", "deleteFailed": "Failed to move shared skill to trash: {message}", "staleConflict": "This skill changed elsewhere; refresh before saving.", "created": "Shared skill \"{name}\" created.", "updated": "Shared skill \"{name}\" updated.", "deleted": "Shared skill \"{name}\" moved to trash.",
-      "modal": { "titleEdit": "Edit Shared Skill", "titleAdd": "Add Shared Skill", "name": "Skill name", "nameDesc": "Lowercase letters and numbers separated by single hyphens", "namePlaceholder": "code-reviewer", "description": "Description", "descriptionDesc": "Required portable description used by providers to select the skill", "descriptionPlaceholder": "Reviews code for correctness and maintainability", "instructions": "Instructions", "instructionsDesc": "Required SKILL.md instructions", "instructionsPlaceholder": "Review the supplied code and report actionable findings..." },
-      "delete": { "title": "Delete Shared Skill", "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.", "confirm": "Move to trash" }
+      "sectionTitle": "Skills",
+      "fixedRoot": "Managed in .agents/skills",
+      "sharedExpectation": "Manage shared skills in .agents/skills/ for compatible providers.",
+      "noSkills": "No shared skills configured. Click + to create one.",
+      "skillBadge": "skill",
+      "diagnosticsTitle": "Skills needing attention",
+      "loadFailed": "Could not load shared skills.",
+      "savedRefreshFailed": "Saved, but provider refresh failed.",
+      "validationFailed": "Invalid skill: {message}",
+      "collisionFailed": "A skill named \"{name}\" already exists.",
+      "saveFailed": "Failed to save shared skill: {message}",
+      "deleteFailed": "Failed to move shared skill to trash: {message}",
+      "staleConflict": "This skill changed elsewhere; refresh before saving.",
+      "created": "Shared skill \"{name}\" created.",
+      "updated": "Shared skill \"{name}\" updated.",
+      "deleted": "Shared skill \"{name}\" moved to trash.",
+      "modal": {
+        "titleEdit": "Edit Shared Skill",
+        "titleAdd": "Add Shared Skill",
+        "name": "Skill name",
+        "nameDesc": "Lowercase letters and numbers separated by single hyphens",
+        "namePlaceholder": "code-reviewer",
+        "description": "Description",
+        "descriptionDesc": "Required portable description used by providers to select the skill",
+        "descriptionPlaceholder": "Reviews code for correctness and maintainability",
+        "instructions": "Instructions",
+        "instructionsDesc": "Required SKILL.md instructions",
+        "instructionsPlaceholder": "Review the supplied code and report actionable findings..."
+      },
+      "delete": {
+        "title": "Delete Shared Skill",
+        "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.",
+        "confirm": "Move to trash"
+      }
     },
     "codexSkills": {
       "modal": {

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -105,13 +105,156 @@
       "claude": "Claude",
       "codex": "Codex"
     },
-    "omp": { "setup": "Настройка", "enable": "Включить OMP", "enableDesc": "Включить провайдер Oh My Pi ACP.", "cliPath": "Путь к CLI", "cliPathDesc": "Абсолютный путь к OMP на этом компьютере.", "models": "Модели", "noModels": "Модели OMP пока не обнаружены.", "catalogFailed": "Не удалось загрузить каталог моделей OMP.", "loadingModels": "Загрузка моделей OMP…", "discoveryFailed": "Не удалось обнаружить модели OMP: {error}", "workspaceNotInitialized": "Рабочая область OMP не инициализирована", "safe": "Безопасно", "yolo": "YOLO", "permissionRequest": "OMP запрашивает разрешение на использование: {tool}.", "tool": "инструмент" },
-    "cursor": {"setup":"Setup","enable":"Enable Cursor","enableDesc":"Enable Cursor Agent through its ACP CLI.","cliPath":"CLI path","cliPathDesc":"Absolute path to the Cursor Agent CLI on this computer.","models":"Models","noModels":"No Cursor models discovered yet. Run agent login and click Discover.","catalogFailed":"Could not load the Cursor model catalog. Check the CLI path and login state.","loadingModels":"Loading Cursor models...","discoveryFailed":"Cursor model discovery failed: {error}","workspaceNotInitialized":"Cursor workspace is not initialized","agent":"Agent","plan":"Plan","ask":"Ask","permissionRequest":"Cursor requests permission to use {tool}.","tool":"a tool"},
-    "grok": {"cliPathDesc":"Optional absolute path to the Grok CLI. Leave empty to prefer known installs, then PATH. Paste the output of \"which grok\" (or \"where grok\" on Windows)."},
-    "opencode": {"cliPathDesc":"Optional absolute path to the OpenCode CLI. Leave empty to use PATH. Paste the output of \"which opencode\" (or \"where opencode\" on Windows)."},
-    "pi": {"cliPathDesc":"Optional absolute path to the Pi CLI. Leave empty to use PATH. Paste the output of \"which pi\" (or \"where pi\" on Windows)."},
-    "providerReadiness": { "title": "Готовность", "desc": "Проверить, готов ли {provider} начать чат.", "checking": "Проверка готовности провайдера…", "refresh": "Проверить снова", "status": { "disabled": "Отключено", "blocked": "Требуется действие", "attention": "Требует внимания", "ready": "Готово" }, "check": { "enabled": "Провайдер включён", "cli": "CLI доступен", "models": "Каталог моделей доступен", "selection": "Модель чата выбрана" }, "hint": { "enableProvider": "Включите этого провайдера, чтобы использовать его в чате.", "configureCli": "Укажите корректный путь к CLI или сделайте CLI доступным в PATH Obsidian.", "refreshModels": "Проверьте вход или сеанс провайдера, затем повторите проверку для загрузки моделей.", "selectModel": "Выберите ниже хотя бы одну модель чата." } },
-    "providerDiagnostics": { "kicker": "Устранение неполадок", "title": "Диагностика провайдера", "whatHappened": "Что произошло", "readiness": "Проверки готовности", "provider": "Провайдер", "category": "Категория", "status": "Состояние", "platform": "Платформа", "time": "Время", "retry": "Повторить сообщение", "rebuild": "Пересоздать сеанс", "details": "Подробнее", "copy": "Копировать отчёт", "close": "Закрыть", "copied": "Отчёт диагностики скопирован.", "copyFailed": "Не удалось скопировать отчёт диагностики.", "statusValue": { "idle": "Ожидание", "starting": "Запуск", "running": "Выполняется", "failed": "Ошибка" }, "check": { "enabled": "Провайдер включён", "cli": "CLI доступен", "models": "Каталог моделей доступен", "selection": "Модель чата выбрана" }, "checkStatus": { "disabled": "Отключено", "blocked": "Заблокировано", "attention": "Требует внимания", "ready": "Готово" }, "remediation": { "enableProvider": "включить провайдера", "configureCli": "настроить CLI", "refreshModels": "обновить модели", "selectModel": "выбрать модель" }, "categoryValue": { "unknown": "Неизвестная ошибка", "cli-not-found": "CLI не найден", "cli-start-failed": "Не удалось запустить CLI", "session-resume-failed": "Не удалось возобновить сеанс", "model-unavailable": "Модель недоступна", "permission-denied": "Доступ запрещён", "timeout": "Истекло время ожидания", "rate-limited": "Ограничение запросов", "protocol-error": "Ошибка протокола", "authentication": "Ошибка аутентификации", "not-configured": "Не настроено", "provider": "Ошибка провайдера" } },
+    "omp": {
+      "setup": "Настройка",
+      "enable": "Включить OMP",
+      "enableDesc": "Включить провайдер Oh My Pi ACP.",
+      "cliPath": "Путь к CLI",
+      "cliPathDesc": "Абсолютный путь к OMP на этом компьютере.",
+      "models": "Модели",
+      "noModels": "Модели OMP пока не обнаружены.",
+      "catalogFailed": "Не удалось загрузить каталог моделей OMP.",
+      "loadingModels": "Загрузка моделей OMP…",
+      "discoveryFailed": "Не удалось обнаружить модели OMP: {error}",
+      "workspaceNotInitialized": "Рабочая область OMP не инициализирована",
+      "safe": "Безопасно",
+      "yolo": "YOLO",
+      "permissionRequest": "OMP запрашивает разрешение на использование: {tool}.",
+      "tool": "инструмент"
+    },
+    "cursor": {
+      "setup": "Setup",
+      "enable": "Enable Cursor",
+      "enableDesc": "Enable Cursor Agent through its ACP CLI.",
+      "cliPath": "CLI path",
+      "cliPathDesc": "Absolute path to the Cursor Agent CLI on this computer.",
+      "models": "Models",
+      "noModels": "No Cursor models discovered yet. Run agent login and click Discover.",
+      "catalogFailed": "Could not load the Cursor model catalog. Check the CLI path and login state.",
+      "loadingModels": "Loading Cursor models...",
+      "discoveryFailed": "Cursor model discovery failed: {error}",
+      "workspaceNotInitialized": "Cursor workspace is not initialized",
+      "agent": "Agent",
+      "plan": "Plan",
+      "ask": "Ask",
+      "permissionRequest": "Cursor requests permission to use {tool}.",
+      "tool": "a tool"
+    },
+    "grok": {
+      "cliPathDesc": "Optional absolute path to the Grok CLI. Leave empty to prefer known installs, then PATH. Paste the output of \"which grok\" (or \"where grok\" on Windows)."
+    },
+    "opencode": {
+      "cliPathDesc": "Optional absolute path to the OpenCode CLI. Leave empty to use PATH. Paste the output of \"which opencode\" (or \"where opencode\" on Windows)."
+    },
+    "pi": {
+      "cliPathDesc": "Optional absolute path to the Pi CLI. Leave empty to use PATH. Paste the output of \"which pi\" (or \"where pi\" on Windows)."
+    },
+    "providerReadiness": {
+      "title": "Готовность",
+      "desc": "Проверить, готов ли {provider} начать чат.",
+      "checking": "Проверка готовности провайдера…",
+      "refresh": "Проверить снова",
+      "status": {
+        "disabled": "Отключено",
+        "blocked": "Требуется действие",
+        "attention": "Требует внимания",
+        "ready": "Готово"
+      },
+      "check": {
+        "enabled": "Провайдер включён",
+        "cli": "CLI доступен",
+        "models": "Каталог моделей доступен",
+        "selection": "Модель чата выбрана"
+      },
+      "hint": {
+        "enableProvider": "Включите этого провайдера, чтобы использовать его в чате.",
+        "configureCli": "Укажите корректный путь к CLI или сделайте CLI доступным в PATH Obsidian.",
+        "refreshModels": "Проверьте вход или сеанс провайдера, затем повторите проверку для загрузки моделей.",
+        "selectModel": "Выберите ниже хотя бы одну модель чата."
+      }
+    },
+    "cliLifecycle": {
+      "label": "CLI {cli}",
+      "checking": "Проверка CLI…",
+      "currentVersion": "Текущая версия",
+      "latestVersion": "Последняя версия",
+      "notInstalled": "Не установлен",
+      "installedButBroken": "Установлен, но не запускается",
+      "updateAvailable": "Доступно обновление",
+      "install": "Установить",
+      "installConfirm": "Установить {cli}?\n\nКоманда: {command}",
+      "installDone": "{cli} успешно установлен.",
+      "installFailed": "Не удалось установить {cli}.",
+      "update": "Обновить",
+      "updateConfirm": "Обновить {cli}?\n\nКоманда: {command}",
+      "updateDone": "{cli} успешно обновлён.",
+      "updateFailed": "Не удалось обновить {cli}.",
+      "ready": "Актуальная версия",
+      "checkEnv": "CLI установлен, но не запускается. Проверьте среду выполнения (версия Node, PATH).",
+      "probe": {
+        "timedOut": "Истекло время проверки версии.",
+        "failedToStart": "Не удалось запустить процесс CLI.",
+        "outputTooLarge": "Слишком большой вывод проверки версии.",
+        "notFound": "CLI не установлен или отсутствует в PATH."
+      },
+      "versionUnchanged": "{cli} после обновления всё ещё на {version}. Возможно, команда не дала результата."
+    },
+    "providerDiagnostics": {
+      "kicker": "Устранение неполадок",
+      "title": "Диагностика провайдера",
+      "whatHappened": "Что произошло",
+      "readiness": "Проверки готовности",
+      "provider": "Провайдер",
+      "category": "Категория",
+      "status": "Состояние",
+      "platform": "Платформа",
+      "time": "Время",
+      "retry": "Повторить сообщение",
+      "rebuild": "Пересоздать сеанс",
+      "details": "Подробнее",
+      "copy": "Копировать отчёт",
+      "close": "Закрыть",
+      "copied": "Отчёт диагностики скопирован.",
+      "copyFailed": "Не удалось скопировать отчёт диагностики.",
+      "statusValue": {
+        "idle": "Ожидание",
+        "starting": "Запуск",
+        "running": "Выполняется",
+        "failed": "Ошибка"
+      },
+      "check": {
+        "enabled": "Провайдер включён",
+        "cli": "CLI доступен",
+        "models": "Каталог моделей доступен",
+        "selection": "Модель чата выбрана"
+      },
+      "checkStatus": {
+        "disabled": "Отключено",
+        "blocked": "Заблокировано",
+        "attention": "Требует внимания",
+        "ready": "Готово"
+      },
+      "remediation": {
+        "enableProvider": "включить провайдера",
+        "configureCli": "настроить CLI",
+        "refreshModels": "обновить модели",
+        "selectModel": "выбрать модель"
+      },
+      "categoryValue": {
+        "unknown": "Неизвестная ошибка",
+        "cli-not-found": "CLI не найден",
+        "cli-start-failed": "Не удалось запустить CLI",
+        "session-resume-failed": "Не удалось возобновить сеанс",
+        "model-unavailable": "Модель недоступна",
+        "permission-denied": "Доступ запрещён",
+        "timeout": "Истекло время ожидания",
+        "rate-limited": "Ограничение запросов",
+        "protocol-error": "Ошибка протокола",
+        "authentication": "Ошибка аутентификации",
+        "not-configured": "Не настроено",
+        "provider": "Ошибка провайдера"
+      }
+    },
     "display": "Отображение",
     "conversations": "Разговоры",
     "content": "Содержание",
@@ -438,9 +581,40 @@
       }
     },
     "agentSkills": {
-      "sectionTitle": "Skills", "fixedRoot": "Managed in .agents/skills", "sharedExpectation": "Manage shared skills in .agents/skills/ for compatible providers.", "noSkills": "No shared skills configured. Click + to create one.", "skillBadge": "skill", "diagnosticsTitle": "Skills needing attention", "loadFailed": "Could not load shared skills.", "savedRefreshFailed": "Saved, but provider refresh failed.", "validationFailed": "Invalid skill: {message}", "collisionFailed": "A skill named \"{name}\" already exists.", "saveFailed": "Failed to save shared skill: {message}", "deleteFailed": "Failed to move shared skill to trash: {message}", "staleConflict": "This skill changed elsewhere; refresh before saving.", "created": "Shared skill \"{name}\" created.", "updated": "Shared skill \"{name}\" updated.", "deleted": "Shared skill \"{name}\" moved to trash.",
-      "modal": { "titleEdit": "Edit Shared Skill", "titleAdd": "Add Shared Skill", "name": "Skill name", "nameDesc": "Lowercase letters and numbers separated by single hyphens", "namePlaceholder": "code-reviewer", "description": "Description", "descriptionDesc": "Required portable description used by providers to select the skill", "descriptionPlaceholder": "Reviews code for correctness and maintainability", "instructions": "Instructions", "instructionsDesc": "Required SKILL.md instructions", "instructionsPlaceholder": "Review the supplied code and report actionable findings..." },
-      "delete": { "title": "Delete Shared Skill", "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.", "confirm": "Move to trash" }
+      "sectionTitle": "Skills",
+      "fixedRoot": "Managed in .agents/skills",
+      "sharedExpectation": "Manage shared skills in .agents/skills/ for compatible providers.",
+      "noSkills": "No shared skills configured. Click + to create one.",
+      "skillBadge": "skill",
+      "diagnosticsTitle": "Skills needing attention",
+      "loadFailed": "Could not load shared skills.",
+      "savedRefreshFailed": "Saved, but provider refresh failed.",
+      "validationFailed": "Invalid skill: {message}",
+      "collisionFailed": "A skill named \"{name}\" already exists.",
+      "saveFailed": "Failed to save shared skill: {message}",
+      "deleteFailed": "Failed to move shared skill to trash: {message}",
+      "staleConflict": "This skill changed elsewhere; refresh before saving.",
+      "created": "Shared skill \"{name}\" created.",
+      "updated": "Shared skill \"{name}\" updated.",
+      "deleted": "Shared skill \"{name}\" moved to trash.",
+      "modal": {
+        "titleEdit": "Edit Shared Skill",
+        "titleAdd": "Add Shared Skill",
+        "name": "Skill name",
+        "nameDesc": "Lowercase letters and numbers separated by single hyphens",
+        "namePlaceholder": "code-reviewer",
+        "description": "Description",
+        "descriptionDesc": "Required portable description used by providers to select the skill",
+        "descriptionPlaceholder": "Reviews code for correctness and maintainability",
+        "instructions": "Instructions",
+        "instructionsDesc": "Required SKILL.md instructions",
+        "instructionsPlaceholder": "Review the supplied code and report actionable findings..."
+      },
+      "delete": {
+        "title": "Delete Shared Skill",
+        "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.",
+        "confirm": "Move to trash"
+      }
     },
     "codexSkills": {
       "modal": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -106,35 +106,154 @@
       "codex": "Codex"
     },
     "omp": {
-      "setup": "配置", "enable": "启用 OMP", "enableDesc": "启用 Oh My Pi ACP 提供商。",
-      "cliPath": "CLI 路径", "cliPathDesc": "此电脑上的 OMP 绝对路径。可粘贴 \"which omp\" 的输出（Windows 使用 \"where omp\"）。留空使用自动检测。",
-      "models": "模型", "noModels": "尚未发现 OMP 模型。请检查 OMP 登录状态，然后点击“发现”。",
-      "catalogFailed": "无法加载 OMP 模型目录。请检查 CLI 路径和登录状态。", "loadingModels": "正在加载 OMP 模型……",
-      "discoveryFailed": "OMP 模型发现失败：{error}", "workspaceNotInitialized": "OMP 工作区尚未初始化",
-      "safe": "安全", "yolo": "YOLO", "permissionRequest": "OMP 请求使用{tool}的权限。", "tool": "工具"
+      "setup": "配置",
+      "enable": "启用 OMP",
+      "enableDesc": "启用 Oh My Pi ACP 提供商。",
+      "cliPath": "CLI 路径",
+      "cliPathDesc": "此电脑上的 OMP 绝对路径。可粘贴 \"which omp\" 的输出（Windows 使用 \"where omp\"）。留空使用自动检测。",
+      "models": "模型",
+      "noModels": "尚未发现 OMP 模型。请检查 OMP 登录状态，然后点击“发现”。",
+      "catalogFailed": "无法加载 OMP 模型目录。请检查 CLI 路径和登录状态。",
+      "loadingModels": "正在加载 OMP 模型……",
+      "discoveryFailed": "OMP 模型发现失败：{error}",
+      "workspaceNotInitialized": "OMP 工作区尚未初始化",
+      "safe": "安全",
+      "yolo": "YOLO",
+      "permissionRequest": "OMP 请求使用{tool}的权限。",
+      "tool": "工具"
     },
-    "cursor": {"setup":"设置","enable":"启用 Cursor","enableDesc":"通过 ACP CLI 启用 Cursor Agent。","cliPath":"CLI 路径","cliPathDesc":"Cursor Agent CLI 的绝对路径。可粘贴 \"which agent\" 的输出（Windows 使用 \"where agent\"）。留空使用自动检测。","models":"模型","noModels":"尚未发现 Cursor 模型。请先运行 agent login，再点击发现。","catalogFailed":"无法加载 Cursor 模型目录，请检查 CLI 路径和登录状态。","loadingModels":"正在加载 Cursor 模型…","discoveryFailed":"Cursor 模型发现失败：{error}","workspaceNotInitialized":"Cursor 工作区尚未初始化","agent":"Agent","plan":"计划","ask":"询问","permissionRequest":"Cursor 请求使用 {tool}。","tool":"工具"},
-    "grok": {"cliPathDesc":"可选的 Grok CLI 绝对路径。留空会优先使用已知安装，然后查找 PATH。可粘贴 \"which grok\" 的输出（Windows 使用 \"where grok\"）。"},
-    "opencode": {"cliPathDesc":"可选的 OpenCode CLI 绝对路径。留空会查找 PATH。可粘贴 \"which opencode\" 的输出（Windows 使用 \"where opencode\"）。"},
-    "pi": {"cliPathDesc":"可选的 Pi CLI 绝对路径。留空会查找 PATH。可粘贴 \"which pi\" 的输出（Windows 使用 \"where pi\"）。"},
+    "cursor": {
+      "setup": "设置",
+      "enable": "启用 Cursor",
+      "enableDesc": "通过 ACP CLI 启用 Cursor Agent。",
+      "cliPath": "CLI 路径",
+      "cliPathDesc": "Cursor Agent CLI 的绝对路径。可粘贴 \"which agent\" 的输出（Windows 使用 \"where agent\"）。留空使用自动检测。",
+      "models": "模型",
+      "noModels": "尚未发现 Cursor 模型。请先运行 agent login，再点击发现。",
+      "catalogFailed": "无法加载 Cursor 模型目录，请检查 CLI 路径和登录状态。",
+      "loadingModels": "正在加载 Cursor 模型…",
+      "discoveryFailed": "Cursor 模型发现失败：{error}",
+      "workspaceNotInitialized": "Cursor 工作区尚未初始化",
+      "agent": "Agent",
+      "plan": "计划",
+      "ask": "询问",
+      "permissionRequest": "Cursor 请求使用 {tool}。",
+      "tool": "工具"
+    },
+    "grok": {
+      "cliPathDesc": "可选的 Grok CLI 绝对路径。留空会优先使用已知安装，然后查找 PATH。可粘贴 \"which grok\" 的输出（Windows 使用 \"where grok\"）。"
+    },
+    "opencode": {
+      "cliPathDesc": "可选的 OpenCode CLI 绝对路径。留空会查找 PATH。可粘贴 \"which opencode\" 的输出（Windows 使用 \"where opencode\"）。"
+    },
+    "pi": {
+      "cliPathDesc": "可选的 Pi CLI 绝对路径。留空会查找 PATH。可粘贴 \"which pi\" 的输出（Windows 使用 \"where pi\"）。"
+    },
     "providerReadiness": {
       "title": "就绪状态",
       "desc": "检查 {provider} 是否可以开始聊天。",
       "checking": "正在检查提供商状态……",
       "refresh": "重新检查",
-      "status": { "disabled": "未启用", "blocked": "需要处理", "attention": "需要关注", "ready": "已就绪" },
-      "check": { "enabled": "提供商已启用", "cli": "CLI 可用", "models": "模型目录可用", "selection": "已选择聊天模型" },
-      "hint": { "enableProvider": "启用此提供商后才能在聊天中使用。", "configureCli": "设置有效的 CLI 路径，或让 Obsidian 可以从 PATH 找到它。", "refreshModels": "检查提供商的登录或会话状态，然后重新检查以加载模型。", "selectModel": "在下方至少选择一个聊天模型。" }
+      "status": {
+        "disabled": "未启用",
+        "blocked": "需要处理",
+        "attention": "需要关注",
+        "ready": "已就绪"
+      },
+      "check": {
+        "enabled": "提供商已启用",
+        "cli": "CLI 可用",
+        "models": "模型目录可用",
+        "selection": "已选择聊天模型"
+      },
+      "hint": {
+        "enableProvider": "启用此提供商后才能在聊天中使用。",
+        "configureCli": "设置有效的 CLI 路径，或让 Obsidian 可以从 PATH 找到它。",
+        "refreshModels": "检查提供商的登录或会话状态，然后重新检查以加载模型。",
+        "selectModel": "在下方至少选择一个聊天模型。"
+      }
+    },
+    "cliLifecycle": {
+      "label": "{cli} CLI",
+      "checking": "正在检查 CLI…",
+      "currentVersion": "当前版本",
+      "latestVersion": "最新版本",
+      "notInstalled": "未安装",
+      "installedButBroken": "已安装但无法运行",
+      "updateAvailable": "有可用更新",
+      "install": "安装",
+      "installConfirm": "安装 {cli}？\n\n命令：{command}",
+      "installDone": "{cli} 安装成功。",
+      "installFailed": "{cli} 安装失败。",
+      "update": "更新",
+      "updateConfirm": "更新 {cli}？\n\n命令：{command}",
+      "updateDone": "{cli} 更新成功。",
+      "updateFailed": "{cli} 更新失败。",
+      "ready": "已是最新",
+      "checkEnv": "CLI 已安装但无法运行。请检查运行时环境（Node 版本、PATH 等）。",
+      "probe": {
+        "timedOut": "版本探测超时。",
+        "failedToStart": "无法启动 CLI 进程。",
+        "outputTooLarge": "版本探测输出过大。",
+        "notFound": "未找到 CLI 或不在 PATH 中。"
+      },
+      "versionUnchanged": "{cli} 更新后仍为 {version}，命令可能未实际生效。"
     },
     "providerDiagnostics": {
-      "kicker": "故障排查", "title": "Provider 诊断", "whatHappened": "发生了什么", "readiness": "就绪检查",
-      "provider": "Provider", "category": "错误类型", "status": "运行状态", "platform": "平台", "time": "时间",
-      "retry": "重试消息", "rebuild": "重建会话", "details": "查看详情", "copy": "复制报告", "close": "关闭", "copied": "Provider 诊断报告已复制。", "copyFailed": "无法复制 Provider 诊断报告。",
-      "statusValue": { "idle": "空闲", "starting": "启动中", "running": "运行中", "failed": "失败" },
-      "check": { "enabled": "Provider 已启用", "cli": "CLI 可用", "models": "模型目录可用", "selection": "已选择聊天模型" },
-      "checkStatus": { "disabled": "未启用", "blocked": "阻塞", "attention": "需要关注", "ready": "已就绪" },
-      "remediation": { "enableProvider": "启用 Provider", "configureCli": "配置 CLI", "refreshModels": "刷新模型", "selectModel": "选择模型" },
-      "categoryValue": { "unknown": "未知错误", "cli-not-found": "找不到 CLI", "cli-start-failed": "CLI 启动失败", "session-resume-failed": "会话恢复失败", "model-unavailable": "模型不可用", "permission-denied": "权限不足", "timeout": "请求超时", "rate-limited": "请求受限", "protocol-error": "协议错误", "authentication": "认证失败", "not-configured": "未配置", "provider": "Provider 错误" }
+      "kicker": "故障排查",
+      "title": "Provider 诊断",
+      "whatHappened": "发生了什么",
+      "readiness": "就绪检查",
+      "provider": "Provider",
+      "category": "错误类型",
+      "status": "运行状态",
+      "platform": "平台",
+      "time": "时间",
+      "retry": "重试消息",
+      "rebuild": "重建会话",
+      "details": "查看详情",
+      "copy": "复制报告",
+      "close": "关闭",
+      "copied": "Provider 诊断报告已复制。",
+      "copyFailed": "无法复制 Provider 诊断报告。",
+      "statusValue": {
+        "idle": "空闲",
+        "starting": "启动中",
+        "running": "运行中",
+        "failed": "失败"
+      },
+      "check": {
+        "enabled": "Provider 已启用",
+        "cli": "CLI 可用",
+        "models": "模型目录可用",
+        "selection": "已选择聊天模型"
+      },
+      "checkStatus": {
+        "disabled": "未启用",
+        "blocked": "阻塞",
+        "attention": "需要关注",
+        "ready": "已就绪"
+      },
+      "remediation": {
+        "enableProvider": "启用 Provider",
+        "configureCli": "配置 CLI",
+        "refreshModels": "刷新模型",
+        "selectModel": "选择模型"
+      },
+      "categoryValue": {
+        "unknown": "未知错误",
+        "cli-not-found": "找不到 CLI",
+        "cli-start-failed": "CLI 启动失败",
+        "session-resume-failed": "会话恢复失败",
+        "model-unavailable": "模型不可用",
+        "permission-denied": "权限不足",
+        "timeout": "请求超时",
+        "rate-limited": "请求受限",
+        "protocol-error": "协议错误",
+        "authentication": "认证失败",
+        "not-configured": "未配置",
+        "provider": "Provider 错误"
+      }
     },
     "display": "显示",
     "conversations": "对话",
@@ -462,9 +581,40 @@
       }
     },
     "agentSkills": {
-      "sectionTitle": "Skills", "fixedRoot": "Managed in .agents/skills", "sharedExpectation": "Manage shared skills in .agents/skills/ for compatible providers.", "noSkills": "No shared skills configured. Click + to create one.", "skillBadge": "skill", "diagnosticsTitle": "Skills needing attention", "loadFailed": "Could not load shared skills.", "savedRefreshFailed": "Saved, but provider refresh failed.", "validationFailed": "Invalid skill: {message}", "collisionFailed": "A skill named \"{name}\" already exists.", "saveFailed": "Failed to save shared skill: {message}", "deleteFailed": "Failed to move shared skill to trash: {message}", "staleConflict": "This skill changed elsewhere; refresh before saving.", "created": "Shared skill \"{name}\" created.", "updated": "Shared skill \"{name}\" updated.", "deleted": "Shared skill \"{name}\" moved to trash.",
-      "modal": { "titleEdit": "Edit Shared Skill", "titleAdd": "Add Shared Skill", "name": "Skill name", "nameDesc": "Lowercase letters and numbers separated by single hyphens", "namePlaceholder": "code-reviewer", "description": "Description", "descriptionDesc": "Required portable description used by providers to select the skill", "descriptionPlaceholder": "Reviews code for correctness and maintainability", "instructions": "Instructions", "instructionsDesc": "Required SKILL.md instructions", "instructionsPlaceholder": "Review the supplied code and report actionable findings..." },
-      "delete": { "title": "Delete Shared Skill", "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.", "confirm": "Move to trash" }
+      "sectionTitle": "Skills",
+      "fixedRoot": "Managed in .agents/skills",
+      "sharedExpectation": "Manage shared skills in .agents/skills/ for compatible providers.",
+      "noSkills": "No shared skills configured. Click + to create one.",
+      "skillBadge": "skill",
+      "diagnosticsTitle": "Skills needing attention",
+      "loadFailed": "Could not load shared skills.",
+      "savedRefreshFailed": "Saved, but provider refresh failed.",
+      "validationFailed": "Invalid skill: {message}",
+      "collisionFailed": "A skill named \"{name}\" already exists.",
+      "saveFailed": "Failed to save shared skill: {message}",
+      "deleteFailed": "Failed to move shared skill to trash: {message}",
+      "staleConflict": "This skill changed elsewhere; refresh before saving.",
+      "created": "Shared skill \"{name}\" created.",
+      "updated": "Shared skill \"{name}\" updated.",
+      "deleted": "Shared skill \"{name}\" moved to trash.",
+      "modal": {
+        "titleEdit": "Edit Shared Skill",
+        "titleAdd": "Add Shared Skill",
+        "name": "Skill name",
+        "nameDesc": "Lowercase letters and numbers separated by single hyphens",
+        "namePlaceholder": "code-reviewer",
+        "description": "Description",
+        "descriptionDesc": "Required portable description used by providers to select the skill",
+        "descriptionPlaceholder": "Reviews code for correctness and maintainability",
+        "instructions": "Instructions",
+        "instructionsDesc": "Required SKILL.md instructions",
+        "instructionsPlaceholder": "Review the supplied code and report actionable findings..."
+      },
+      "delete": {
+        "title": "Delete Shared Skill",
+        "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.",
+        "confirm": "Move to trash"
+      }
     },
     "codexSkills": {
       "modal": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1,22 +1,22 @@
 {
   "common": {
-    "save": "保存",
+    "save": "儲存",
     "cancel": "取消",
     "delete": "刪除",
     "edit": "編輯",
-    "add": "添加",
+    "add": "新增",
     "remove": "移除",
     "clear": "清除",
     "clearAll": "清除全部",
-    "loading": "加載中",
+    "loading": "載入中",
     "error": "錯誤",
     "success": "成功",
     "warning": "警告",
     "confirm": "確認",
-    "settings": "設置",
+    "settings": "設定",
     "advanced": "高級",
     "enabled": "已啟用",
-    "disabled": "已禁用",
+    "disabled": "已停用",
     "platform": "平台",
     "refresh": "重新整理",
     "rewind": "回退"
@@ -106,32 +106,154 @@
       "codex": "Codex"
     },
     "omp": {
-      "setup": "設定", "enable": "啟用 OMP", "enableDesc": "啟用 Oh My Pi ACP 提供者。",
-      "cliPath": "CLI 路徑", "cliPathDesc": "此電腦上的 OMP 絕對路徑，也會讓 Obsidian 使用其 Bun 執行環境。",
-      "models": "模型", "noModels": "尚未發現 OMP 模型。請檢查 OMP 登入狀態，然後點擊「探索」。",
-      "catalogFailed": "無法載入 OMP 模型目錄。請檢查 CLI 路徑與登入狀態。", "loadingModels": "正在載入 OMP 模型……",
-      "discoveryFailed": "OMP 模型探索失敗：{error}", "workspaceNotInitialized": "OMP 工作區尚未初始化",
-      "safe": "安全", "yolo": "YOLO", "permissionRequest": "OMP 請求使用{tool}的權限。", "tool": "工具"
+      "setup": "設定",
+      "enable": "啟用 OMP",
+      "enableDesc": "啟用 Oh My Pi ACP 提供者。",
+      "cliPath": "CLI 路徑",
+      "cliPathDesc": "此電腦上的 OMP 絕對路徑，也會讓 Obsidian 使用其 Bun 執行環境。",
+      "models": "模型",
+      "noModels": "尚未發現 OMP 模型。請檢查 OMP 登入狀態，然後點擊「探索」。",
+      "catalogFailed": "無法載入 OMP 模型目錄。請檢查 CLI 路徑與登入狀態。",
+      "loadingModels": "正在載入 OMP 模型……",
+      "discoveryFailed": "OMP 模型探索失敗：{error}",
+      "workspaceNotInitialized": "OMP 工作區尚未初始化",
+      "safe": "安全",
+      "yolo": "YOLO",
+      "permissionRequest": "OMP 請求使用{tool}的權限。",
+      "tool": "工具"
     },
-    "cursor": {"setup":"Setup","enable":"Enable Cursor","enableDesc":"Enable Cursor Agent through its ACP CLI.","cliPath":"CLI path","cliPathDesc":"Absolute path to the Cursor Agent CLI on this computer.","models":"Models","noModels":"No Cursor models discovered yet. Run agent login and click Discover.","catalogFailed":"Could not load the Cursor model catalog. Check the CLI path and login state.","loadingModels":"Loading Cursor models...","discoveryFailed":"Cursor model discovery failed: {error}","workspaceNotInitialized":"Cursor workspace is not initialized","agent":"Agent","plan":"Plan","ask":"Ask","permissionRequest":"Cursor requests permission to use {tool}.","tool":"a tool"},
-    "grok": {"cliPathDesc":"Optional absolute path to the Grok CLI. Leave empty to prefer known installs, then PATH. Paste the output of \"which grok\" (or \"where grok\" on Windows)."},
-    "opencode": {"cliPathDesc":"Optional absolute path to the OpenCode CLI. Leave empty to use PATH. Paste the output of \"which opencode\" (or \"where opencode\" on Windows)."},
-    "pi": {"cliPathDesc":"Optional absolute path to the Pi CLI. Leave empty to use PATH. Paste the output of \"which pi\" (or \"where pi\" on Windows)."},
+    "cursor": {
+      "setup": "Setup",
+      "enable": "Enable Cursor",
+      "enableDesc": "Enable Cursor Agent through its ACP CLI.",
+      "cliPath": "CLI path",
+      "cliPathDesc": "Absolute path to the Cursor Agent CLI on this computer.",
+      "models": "Models",
+      "noModels": "No Cursor models discovered yet. Run agent login and click Discover.",
+      "catalogFailed": "Could not load the Cursor model catalog. Check the CLI path and login state.",
+      "loadingModels": "Loading Cursor models...",
+      "discoveryFailed": "Cursor model discovery failed: {error}",
+      "workspaceNotInitialized": "Cursor workspace is not initialized",
+      "agent": "Agent",
+      "plan": "Plan",
+      "ask": "Ask",
+      "permissionRequest": "Cursor requests permission to use {tool}.",
+      "tool": "a tool"
+    },
+    "grok": {
+      "cliPathDesc": "Optional absolute path to the Grok CLI. Leave empty to prefer known installs, then PATH. Paste the output of \"which grok\" (or \"where grok\" on Windows)."
+    },
+    "opencode": {
+      "cliPathDesc": "Optional absolute path to the OpenCode CLI. Leave empty to use PATH. Paste the output of \"which opencode\" (or \"where opencode\" on Windows)."
+    },
+    "pi": {
+      "cliPathDesc": "Optional absolute path to the Pi CLI. Leave empty to use PATH. Paste the output of \"which pi\" (or \"where pi\" on Windows)."
+    },
     "providerReadiness": {
-      "title": "就緒狀態", "desc": "檢查 {provider} 是否可以開始聊天。", "checking": "正在檢查提供者狀態……", "refresh": "重新檢查",
-      "status": { "disabled": "未啟用", "blocked": "需要處理", "attention": "需要注意", "ready": "已就緒" },
-      "check": { "enabled": "提供者已啟用", "cli": "CLI 可用", "models": "模型目錄可用", "selection": "已選擇聊天模型" },
-      "hint": { "enableProvider": "啟用此提供者後才能在聊天中使用。", "configureCli": "設定有效的 CLI 路徑，或讓 Obsidian 可以從 PATH 找到它。", "refreshModels": "檢查提供者的登入或工作階段狀態，然後重新檢查以載入模型。", "selectModel": "在下方至少選擇一個聊天模型。" }
+      "title": "就緒狀態",
+      "desc": "檢查 {provider} 是否可以開始聊天。",
+      "checking": "正在檢查提供者狀態……",
+      "refresh": "重新檢查",
+      "status": {
+        "disabled": "未啟用",
+        "blocked": "需要處理",
+        "attention": "需要注意",
+        "ready": "已就緒"
+      },
+      "check": {
+        "enabled": "提供者已啟用",
+        "cli": "CLI 可用",
+        "models": "模型目錄可用",
+        "selection": "已選擇聊天模型"
+      },
+      "hint": {
+        "enableProvider": "啟用此提供者後才能在聊天中使用。",
+        "configureCli": "設定有效的 CLI 路徑，或讓 Obsidian 可以從 PATH 找到它。",
+        "refreshModels": "檢查提供者的登入或工作階段狀態，然後重新檢查以載入模型。",
+        "selectModel": "在下方至少選擇一個聊天模型。"
+      }
+    },
+    "cliLifecycle": {
+      "label": "{cli} CLI",
+      "checking": "正在檢查 CLI…",
+      "currentVersion": "目前版本",
+      "latestVersion": "最新版本",
+      "notInstalled": "未安裝",
+      "installedButBroken": "已安裝但無法執行",
+      "updateAvailable": "有可用更新",
+      "install": "安裝",
+      "installConfirm": "安裝 {cli}？\n\n命令：{command}",
+      "installDone": "{cli} 安裝成功。",
+      "installFailed": "{cli} 安裝失敗。",
+      "update": "更新",
+      "updateConfirm": "更新 {cli}？\n\n命令：{command}",
+      "updateDone": "{cli} 更新成功。",
+      "updateFailed": "{cli} 更新失敗。",
+      "ready": "已是最新",
+      "checkEnv": "CLI 已安裝但無法執行。請檢查執行環境（Node 版本、PATH 等）。",
+      "probe": {
+        "timedOut": "版本探測超時。",
+        "failedToStart": "無法啟動 CLI 程序。",
+        "outputTooLarge": "版本探測輸出過大。",
+        "notFound": "未找到 CLI 或不在 PATH 中。"
+      },
+      "versionUnchanged": "{cli} 更新後仍為 {version}，指令可能未實際生效。"
     },
     "providerDiagnostics": {
-      "kicker": "疑難排解", "title": "Provider 診斷", "whatHappened": "發生了什麼", "readiness": "就緒檢查",
-      "provider": "Provider", "category": "錯誤類型", "status": "執行狀態", "platform": "平台", "time": "時間",
-      "retry": "重試訊息", "rebuild": "重建工作階段", "details": "查看詳情", "copy": "複製報告", "close": "關閉", "copied": "Provider 診斷報告已複製。", "copyFailed": "無法複製 Provider 診斷報告。",
-      "statusValue": { "idle": "閒置", "starting": "啟動中", "running": "執行中", "failed": "失敗" },
-      "check": { "enabled": "Provider 已啟用", "cli": "CLI 可用", "models": "模型目錄可用", "selection": "已選擇聊天模型" },
-      "checkStatus": { "disabled": "未啟用", "blocked": "受阻", "attention": "需要注意", "ready": "已就緒" },
-      "remediation": { "enableProvider": "啟用 Provider", "configureCli": "設定 CLI", "refreshModels": "重新整理模型", "selectModel": "選擇模型" },
-      "categoryValue": { "unknown": "未知錯誤", "cli-not-found": "找不到 CLI", "cli-start-failed": "CLI 啟動失敗", "session-resume-failed": "工作階段恢復失敗", "model-unavailable": "模型不可用", "permission-denied": "權限不足", "timeout": "請求逾時", "rate-limited": "請求受限", "protocol-error": "通訊協定錯誤", "authentication": "驗證失敗", "not-configured": "未設定", "provider": "Provider 錯誤" }
+      "kicker": "疑難排解",
+      "title": "Provider 診斷",
+      "whatHappened": "發生了什麼",
+      "readiness": "就緒檢查",
+      "provider": "Provider",
+      "category": "錯誤類型",
+      "status": "執行狀態",
+      "platform": "平台",
+      "time": "時間",
+      "retry": "重試訊息",
+      "rebuild": "重建工作階段",
+      "details": "查看詳情",
+      "copy": "複製報告",
+      "close": "關閉",
+      "copied": "Provider 診斷報告已複製。",
+      "copyFailed": "無法複製 Provider 診斷報告。",
+      "statusValue": {
+        "idle": "閒置",
+        "starting": "啟動中",
+        "running": "執行中",
+        "failed": "失敗"
+      },
+      "check": {
+        "enabled": "Provider 已啟用",
+        "cli": "CLI 可用",
+        "models": "模型目錄可用",
+        "selection": "已選擇聊天模型"
+      },
+      "checkStatus": {
+        "disabled": "未啟用",
+        "blocked": "受阻",
+        "attention": "需要注意",
+        "ready": "已就緒"
+      },
+      "remediation": {
+        "enableProvider": "啟用 Provider",
+        "configureCli": "設定 CLI",
+        "refreshModels": "重新整理模型",
+        "selectModel": "選擇模型"
+      },
+      "categoryValue": {
+        "unknown": "未知錯誤",
+        "cli-not-found": "找不到 CLI",
+        "cli-start-failed": "CLI 啟動失敗",
+        "session-resume-failed": "工作階段恢復失敗",
+        "model-unavailable": "模型不可用",
+        "permission-denied": "權限不足",
+        "timeout": "請求逾時",
+        "rate-limited": "請求受限",
+        "protocol-error": "通訊協定錯誤",
+        "authentication": "驗證失敗",
+        "not-configured": "未設定",
+        "provider": "Provider 錯誤"
+      }
     },
     "display": "顯示",
     "conversations": "對話",
@@ -260,8 +382,8 @@
         "modelDesc": "此代理的模型覆寫",
         "tools": "工具",
         "toolsDesc": "允許工具的逗號分隔清單（留空 = 全部）",
-        "disallowedTools": "禁用工具",
-        "disallowedToolsDesc": "要禁用的工具清單，以逗號分隔",
+        "disallowedTools": "停用工具",
+        "disallowedToolsDesc": "要停用的工具清單，以逗號分隔",
         "skills": "技能",
         "skillsDesc": "技能清單，以逗號分隔",
         "prompt": "系統提示詞",
@@ -290,18 +412,18 @@
     "envSnippets": {
       "name": "片段",
       "addBtn": "新增片段",
-      "noSnippets": "尚無保存的環境變數片段。點擊 + 保存當前配置。",
+      "noSnippets": "尚無儲存的環境變數片段。點選 + 儲存目前設定。",
       "nameRequired": "請輸入片段名稱",
       "modal": {
         "titleEdit": "編輯片段",
-        "titleSave": "保存片段",
+        "titleSave": "儲存片段",
         "name": "名稱",
         "namePlaceholder": "此配置的描述性名稱",
         "description": "描述",
         "descPlaceholder": "可選描述",
         "envVars": "環境變數",
         "envVarsPlaceholder": "KEY=VALUE 格式，每行一個（支援 export 前綴）",
-        "save": "保存",
+        "save": "儲存",
         "update": "更新",
         "cancel": "取消"
       }
@@ -459,9 +581,40 @@
       }
     },
     "agentSkills": {
-      "sectionTitle": "Skills", "fixedRoot": "Managed in .agents/skills", "sharedExpectation": "Manage shared skills in .agents/skills/ for compatible providers.", "noSkills": "No shared skills configured. Click + to create one.", "skillBadge": "skill", "diagnosticsTitle": "Skills needing attention", "loadFailed": "Could not load shared skills.", "savedRefreshFailed": "Saved, but provider refresh failed.", "validationFailed": "Invalid skill: {message}", "collisionFailed": "A skill named \"{name}\" already exists.", "saveFailed": "Failed to save shared skill: {message}", "deleteFailed": "Failed to move shared skill to trash: {message}", "staleConflict": "This skill changed elsewhere; refresh before saving.", "created": "Shared skill \"{name}\" created.", "updated": "Shared skill \"{name}\" updated.", "deleted": "Shared skill \"{name}\" moved to trash.",
-      "modal": { "titleEdit": "Edit Shared Skill", "titleAdd": "Add Shared Skill", "name": "Skill name", "nameDesc": "Lowercase letters and numbers separated by single hyphens", "namePlaceholder": "code-reviewer", "description": "Description", "descriptionDesc": "Required portable description used by providers to select the skill", "descriptionPlaceholder": "Reviews code for correctness and maintainability", "instructions": "Instructions", "instructionsDesc": "Required SKILL.md instructions", "instructionsPlaceholder": "Review the supplied code and report actionable findings..." },
-      "delete": { "title": "Delete Shared Skill", "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.", "confirm": "Move to trash" }
+      "sectionTitle": "Skills",
+      "fixedRoot": "Managed in .agents/skills",
+      "sharedExpectation": "Manage shared skills in .agents/skills/ for compatible providers.",
+      "noSkills": "No shared skills configured. Click + to create one.",
+      "skillBadge": "skill",
+      "diagnosticsTitle": "Skills needing attention",
+      "loadFailed": "Could not load shared skills.",
+      "savedRefreshFailed": "Saved, but provider refresh failed.",
+      "validationFailed": "Invalid skill: {message}",
+      "collisionFailed": "A skill named \"{name}\" already exists.",
+      "saveFailed": "Failed to save shared skill: {message}",
+      "deleteFailed": "Failed to move shared skill to trash: {message}",
+      "staleConflict": "This skill changed elsewhere; refresh before saving.",
+      "created": "Shared skill \"{name}\" created.",
+      "updated": "Shared skill \"{name}\" updated.",
+      "deleted": "Shared skill \"{name}\" moved to trash.",
+      "modal": {
+        "titleEdit": "Edit Shared Skill",
+        "titleAdd": "Add Shared Skill",
+        "name": "Skill name",
+        "nameDesc": "Lowercase letters and numbers separated by single hyphens",
+        "namePlaceholder": "code-reviewer",
+        "description": "Description",
+        "descriptionDesc": "Required portable description used by providers to select the skill",
+        "descriptionPlaceholder": "Reviews code for correctness and maintainability",
+        "instructions": "Instructions",
+        "instructionsDesc": "Required SKILL.md instructions",
+        "instructionsPlaceholder": "Review the supplied code and report actionable findings..."
+      },
+      "delete": {
+        "title": "Delete Shared Skill",
+        "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.",
+        "confirm": "Move to trash"
+      }
     },
     "codexSkills": {
       "modal": {

--- a/src/providers/claude/runtime/ClaudeCliMetadata.ts
+++ b/src/providers/claude/runtime/ClaudeCliMetadata.ts
@@ -1,0 +1,11 @@
+import type { CliProviderMetadata } from '../../../core/providers/cli/CliProviderMetadata';
+
+export const claudeCliMetadata: CliProviderMetadata = {
+  binaryName: 'claude',
+  displayName: 'Claude Code',
+  npmPackage: '@anthropic-ai/claude-code',
+  update: {
+    command: 'claude',
+    args: ['update'],
+  },
+};

--- a/src/providers/claude/ui/ClaudeSettingsTab.ts
+++ b/src/providers/claude/ui/ClaudeSettingsTab.ts
@@ -5,6 +5,7 @@ import { assessProviderReadiness } from '../../../core/providers/ProviderReadine
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
 import { t } from '../../../i18n/i18n';
+import { renderCliLifecycleSection } from '../../../shared/settings/CliLifecycleSection';
 import { renderEnvironmentSettingsSection } from '../../../shared/settings/EnvironmentSettingsSection';
 import { renderHostnameCliPathSetting } from '../../../shared/settings/HostnameCliPathSetting';
 import { McpSettingsManager } from '../../../shared/settings/McpSettingsManager';
@@ -19,6 +20,7 @@ import {
   resolveClaudeModelEnvironmentTypePreference,
   resolveClaudeModelSelection,
 } from '../modelOptions';
+import { claudeCliMetadata } from '../runtime/ClaudeCliMetadata';
 import {
   CLAUDE_SAFE_MODES,
   type ClaudeSafeMode,
@@ -409,6 +411,18 @@ export const claudeSettingsTabRenderer: ProviderSettingsTabRenderer = {
 
     const bangBashValidationEl = container.createDiv({
       cls: 'claudian-bang-bash-validation claudian-setting-validation claudian-setting-validation-error claudian-hidden',
+    });
+
+    // --- CLI lifecycle ---
+
+    renderCliLifecycleSection({
+      container: readinessPanel.cliDetail,
+      metadata: claudeCliMetadata,
+      resolveCliPath: () => context.plugin.getResolvedProviderCliPath('claude'),
+      getRuntimeEnvText: () => context.plugin.getActiveEnvironmentVariables('claude'),
+      app: context.plugin.app,
+      onCliChanged: async () => { await readinessPanel.refresh(); },
+      onCheckAgain: () => readinessPanel.refresh(true),
     });
   },
 };

--- a/src/providers/codex/runtime/CodexCliMetadata.ts
+++ b/src/providers/codex/runtime/CodexCliMetadata.ts
@@ -1,0 +1,11 @@
+import type { CliProviderMetadata } from '../../../core/providers/cli/CliProviderMetadata';
+
+export const codexCliMetadata: CliProviderMetadata = {
+  binaryName: 'codex',
+  displayName: 'Codex',
+  npmPackage: '@openai/codex',
+  update: {
+    command: 'codex',
+    args: ['update'],
+  },
+};

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -5,6 +5,7 @@ import { assessProviderReadiness } from '../../../core/providers/ProviderReadine
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
 import { t } from '../../../i18n/i18n';
+import { renderCliLifecycleSection } from '../../../shared/settings/CliLifecycleSection';
 import { renderEnvironmentSettingsSection } from '../../../shared/settings/EnvironmentSettingsSection';
 import { renderHostnameCliPathSetting } from '../../../shared/settings/HostnameCliPathSetting';
 import { renderNativeMcpSettingsSection } from '../../../shared/settings/NativeMcpSettingsSection';
@@ -20,6 +21,7 @@ import { getCodexWorkspaceServices } from '../app/CodexWorkspaceServices';
 import { getCodexModelOptions } from '../modelOptions';
 import { getDefaultCodexModel } from '../models';
 import { isWindowsStyleCliReference } from '../runtime/CodexBinaryLocator';
+import { codexCliMetadata } from '../runtime/CodexCliMetadata';
 import { getCodexProviderSettings, updateCodexProviderSettings } from '../settings';
 import { renderCodexModelPicker } from './CodexModelPicker';
 import { CodexSubagentSettings } from './CodexSubagentSettings';
@@ -355,6 +357,18 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
       documentationUrl: 'https://developers.openai.com/codex/mcp',
       heading: t('settings.mcpServers.name'),
       setupCommand: 'codex mcp',
+    });
+
+    // --- CLI lifecycle ---
+
+    renderCliLifecycleSection({
+      container: readinessPanel.cliDetail,
+      metadata: codexCliMetadata,
+      resolveCliPath: () => context.plugin.getResolvedProviderCliPath('codex'),
+      getRuntimeEnvText: () => context.plugin.getActiveEnvironmentVariables('codex'),
+      app: context.plugin.app,
+      onCliChanged: async () => { await readinessPanel.refresh(); },
+      onCheckAgain: () => readinessPanel.refresh(true),
     });
 
     // --- Environment ---

--- a/src/providers/cursor/runtime/CursorCliMetadata.ts
+++ b/src/providers/cursor/runtime/CursorCliMetadata.ts
@@ -1,0 +1,11 @@
+import type { CliProviderMetadata } from '../../../core/providers/cli/CliProviderMetadata';
+
+/**
+ * Cursor Agent CLI (`agent`). The CLI ships with the Cursor desktop app, so
+ * there is no standalone npm install path; install/update are intentionally
+ * omitted, while version probing still works through the binary name.
+ */
+export const cursorCliMetadata: CliProviderMetadata = {
+  binaryName: 'agent',
+  displayName: 'Cursor',
+};

--- a/src/providers/cursor/ui/CursorSettingsTab.ts
+++ b/src/providers/cursor/ui/CursorSettingsTab.ts
@@ -8,6 +8,7 @@ import type {
   ProviderSettingsTabRenderer,
 } from '../../../core/providers/types';
 import { t } from '../../../i18n/i18n';
+import { renderCliLifecycleSection } from '../../../shared/settings/CliLifecycleSection';
 import { renderHostnameCliPathSetting } from '../../../shared/settings/HostnameCliPathSetting';
 import { renderProviderEnablementSetting } from '../../../shared/settings/ProviderEnablementSetting';
 import {
@@ -20,6 +21,7 @@ import { getHostnameKey } from '../../../utils/env';
 import { normalizeConfiguredCliPath } from '../../../utils/path';
 import { maybeGetCursorWorkspaceServices } from '../app/CursorWorkspaceServices';
 import { normalizeCursorVisibleModels } from '../models';
+import { cursorCliMetadata } from '../runtime/CursorCliMetadata';
 import {
   getCursorProviderSettings,
   updateCursorProviderSettings,
@@ -89,6 +91,15 @@ export const cursorSettingsTabRenderer: ProviderSettingsTabRenderer = {
         ? 'C:\\Users\\you\\.local\\bin\\agent.exe'
         : '/Users/you/.local/bin/agent',
       validate: validateCliPath,
+    });
+    renderCliLifecycleSection({
+      container: readinessPanel.cliDetail,
+      metadata: cursorCliMetadata,
+      resolveCliPath: () => context.plugin.getResolvedProviderCliPath('cursor'),
+      getRuntimeEnvText: () => context.plugin.getActiveEnvironmentVariables('cursor'),
+      app: context.plugin.app,
+      onCliChanged: async () => { await readinessPanel.refresh(); },
+      onCheckAgain: () => readinessPanel.refresh(true),
     });
     new Setting(container).setName(t('settings.cursor.models')).setHeading();
     renderCursorModelPicker(container, context, settings);

--- a/src/providers/grok/runtime/GrokCliMetadata.ts
+++ b/src/providers/grok/runtime/GrokCliMetadata.ts
@@ -1,0 +1,11 @@
+import type { CliProviderMetadata } from '../../../core/providers/cli/CliProviderMetadata';
+
+/**
+ * Grok Build CLI. The official install method is not distributed via a
+ * stable public npm package name, so install/update are intentionally
+ * omitted; version probing still works through the binary name.
+ */
+export const grokCliMetadata: CliProviderMetadata = {
+  binaryName: 'grok',
+  displayName: 'Grok',
+};

--- a/src/providers/grok/ui/GrokSettingsTab.ts
+++ b/src/providers/grok/ui/GrokSettingsTab.ts
@@ -12,6 +12,7 @@ import type {
 } from '../../../core/providers/types';
 import type { ClaudianSettings } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
+import { renderCliLifecycleSection } from '../../../shared/settings/CliLifecycleSection';
 import { renderEnvironmentSettingsSection } from '../../../shared/settings/EnvironmentSettingsSection';
 import { renderHostnameCliPathSetting } from '../../../shared/settings/HostnameCliPathSetting';
 import { renderNativeMcpSettingsSection } from '../../../shared/settings/NativeMcpSettingsSection';
@@ -30,6 +31,7 @@ import { getHostnameKey } from '../../../utils/env';
 import { normalizeConfiguredCliPath } from '../../../utils/path';
 import type { GrokWorkspaceServices } from '../app/GrokWorkspaceServices';
 import type { GrokDiscoveredModel } from '../models';
+import { grokCliMetadata } from '../runtime/GrokCliMetadata';
 import {
   clearCurrentGrokCatalog,
   getGrokProviderSettings,
@@ -197,6 +199,16 @@ export const grokSettingsTabRenderer: ProviderSettingsTabRenderer = {
       plugin: context.plugin,
       renderCustomContextLimits: target => context.renderCustomContextLimits(target, GROK_PROVIDER_ID),
       scope: 'provider:grok',
+    });
+
+    renderCliLifecycleSection({
+      container: readinessPanel.cliDetail,
+      metadata: grokCliMetadata,
+      resolveCliPath: () => context.plugin.getResolvedProviderCliPath(GROK_PROVIDER_ID),
+      getRuntimeEnvText: () => context.plugin.getActiveEnvironmentVariables(GROK_PROVIDER_ID),
+      app: context.plugin.app,
+      onCliChanged: async () => { await readinessPanel.refresh(); },
+      onCheckAgain: () => readinessPanel.refresh(true),
     });
   },
 };

--- a/src/providers/omp/runtime/OmpCliMetadata.ts
+++ b/src/providers/omp/runtime/OmpCliMetadata.ts
@@ -1,0 +1,11 @@
+import type { CliProviderMetadata } from '../../../core/providers/cli/CliProviderMetadata';
+
+/**
+ * OMP (Oh My Pi) CLI. The install method is provider-documented rather than
+ * a stable public npm package, so install/update are intentionally omitted;
+ * version probing still works through the binary name.
+ */
+export const ompCliMetadata: CliProviderMetadata = {
+  binaryName: 'omp',
+  displayName: 'OMP',
+};

--- a/src/providers/omp/ui/OmpSettingsTab.ts
+++ b/src/providers/omp/ui/OmpSettingsTab.ts
@@ -8,6 +8,7 @@ import type {
   ProviderSettingsTabRenderer,
 } from '../../../core/providers/types';
 import { t } from '../../../i18n/i18n';
+import { renderCliLifecycleSection } from '../../../shared/settings/CliLifecycleSection';
 import { renderHostnameCliPathSetting } from '../../../shared/settings/HostnameCliPathSetting';
 import { renderProviderEnablementSetting } from '../../../shared/settings/ProviderEnablementSetting';
 import {
@@ -20,6 +21,7 @@ import { getHostnameKey } from '../../../utils/env';
 import { normalizeConfiguredCliPath } from '../../../utils/path';
 import { maybeGetOmpWorkspaceServices } from '../app/OmpWorkspaceServices';
 import { normalizeOmpVisibleModels } from '../models';
+import { ompCliMetadata } from '../runtime/OmpCliMetadata';
 import {
   getOmpProviderSettings,
   updateOmpProviderSettings,
@@ -89,6 +91,15 @@ export const ompSettingsTabRenderer: ProviderSettingsTabRenderer = {
         ? 'C:\\Users\\you\\.bun\\bin\\omp.exe'
         : '/Users/you/.bun/bin/omp',
       validate: validateCliPath,
+    });
+    renderCliLifecycleSection({
+      container: readinessPanel.cliDetail,
+      metadata: ompCliMetadata,
+      resolveCliPath: () => context.plugin.getResolvedProviderCliPath('omp'),
+      getRuntimeEnvText: () => context.plugin.getActiveEnvironmentVariables('omp'),
+      app: context.plugin.app,
+      onCliChanged: async () => { await readinessPanel.refresh(); },
+      onCheckAgain: () => readinessPanel.refresh(true),
     });
     new Setting(container).setName(t('settings.omp.models')).setHeading();
     renderOmpModelPicker(container, context, settings);

--- a/src/providers/opencode/runtime/OpencodeCliMetadata.ts
+++ b/src/providers/opencode/runtime/OpencodeCliMetadata.ts
@@ -1,0 +1,12 @@
+import type { CliProviderMetadata } from '../../../core/providers/cli/CliProviderMetadata';
+
+export const opencodeCliMetadata: CliProviderMetadata = {
+  binaryName: 'opencode',
+  displayName: 'OpenCode',
+  npmPackage: 'opencode-ai',
+  installerUrl: 'https://opencode.ai/install',
+  update: {
+    command: 'opencode',
+    args: ['upgrade'],
+  },
+};

--- a/src/providers/opencode/ui/OpencodeSettingsTab.ts
+++ b/src/providers/opencode/ui/OpencodeSettingsTab.ts
@@ -8,6 +8,7 @@ import type {
   ProviderSettingsTabRendererContext,
 } from '../../../core/providers/types';
 import { t } from '../../../i18n/i18n';
+import { renderCliLifecycleSection } from '../../../shared/settings/CliLifecycleSection';
 import { renderEnvironmentSettingsSection } from '../../../shared/settings/EnvironmentSettingsSection';
 import { renderHostnameCliPathSetting } from '../../../shared/settings/HostnameCliPathSetting';
 import { renderNativeMcpSettingsSection } from '../../../shared/settings/NativeMcpSettingsSection';
@@ -34,6 +35,7 @@ import {
   type OpencodeDiscoveredModel,
   splitOpencodeModelLabel,
 } from '../models';
+import { opencodeCliMetadata } from '../runtime/OpencodeCliMetadata';
 import {
   getOpencodeProviderSettings,
   normalizeOpencodeVisibleModels,
@@ -204,6 +206,16 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
       desc: 'Extra environment variables passed to OpenCode. `OPENCODE_ENABLE_EXA=1` is enabled by default.',
       placeholder: `${OPENCODE_DEFAULT_ENVIRONMENT_VARIABLES}\nOPENCODE_DB=/path/to/opencode.db`,
       renderCustomContextLimits: (target) => context.renderCustomContextLimits(target, 'opencode'),
+    });
+
+    renderCliLifecycleSection({
+      container: readinessPanel.cliDetail,
+      metadata: opencodeCliMetadata,
+      resolveCliPath: () => context.plugin.getResolvedProviderCliPath('opencode'),
+      getRuntimeEnvText: () => context.plugin.getActiveEnvironmentVariables('opencode'),
+      app: context.plugin.app,
+      onCliChanged: async () => { await readinessPanel.refresh(); },
+      onCheckAgain: () => readinessPanel.refresh(true),
     });
   },
 };

--- a/src/providers/pi/runtime/PiCliMetadata.ts
+++ b/src/providers/pi/runtime/PiCliMetadata.ts
@@ -1,0 +1,11 @@
+import type { CliProviderMetadata } from '../../../core/providers/cli/CliProviderMetadata';
+
+export const piCliMetadata: CliProviderMetadata = {
+  binaryName: 'pi',
+  displayName: 'Pi',
+  // Package migrated from @mariozechner/pi-coding-agent (last published
+  // 0.73.1) to @earendil-works/pi-coding-agent. The registry name drives the
+  // latest-version probe AND the npm install/update commands, so both must
+  // point at the current package. Keep PiSubprocess's PI_PACKAGE_NAME in sync.
+  npmPackage: '@earendil-works/pi-coding-agent',
+};

--- a/src/providers/pi/ui/PiSettingsTab.ts
+++ b/src/providers/pi/ui/PiSettingsTab.ts
@@ -9,6 +9,7 @@ import type {
   ProviderSettingsTabRendererContext,
 } from '../../../core/providers/types';
 import { t } from '../../../i18n/i18n';
+import { renderCliLifecycleSection } from '../../../shared/settings/CliLifecycleSection';
 import { renderEnvironmentSettingsSection } from '../../../shared/settings/EnvironmentSettingsSection';
 import { renderHostnameCliPathSetting } from '../../../shared/settings/HostnameCliPathSetting';
 import { renderProviderEnablementSetting } from '../../../shared/settings/ProviderEnablementSetting';
@@ -27,6 +28,7 @@ import { normalizeConfiguredCliPath } from '../../../utils/path';
 import { maybeGetPiWorkspaceServices } from '../app/PiWorkspaceServices';
 import { sameDiscoveredModels, sameStringList } from '../internal/compareCollections';
 import { decodePiModelId, type PiDiscoveredModel } from '../models';
+import { piCliMetadata } from '../runtime/PiCliMetadata';
 import { PiModelDiscoveryService } from '../runtime/PiModelDiscoveryService';
 import {
   getPiProviderSettings,
@@ -173,6 +175,16 @@ export const piSettingsTabRenderer: ProviderSettingsTabRenderer = {
       placeholder: 'PI_CODING_AGENT_SESSION_DIR=/path/to/sessions',
       plugin: context.plugin,
       scope: 'provider:pi',
+    });
+
+    renderCliLifecycleSection({
+      container: readinessPanel.cliDetail,
+      metadata: piCliMetadata,
+      resolveCliPath: () => context.plugin.getResolvedProviderCliPath('pi'),
+      getRuntimeEnvText: () => context.plugin.getActiveEnvironmentVariables('pi'),
+      app: context.plugin.app,
+      onCliChanged: async () => { await readinessPanel.refresh(); },
+      onCheckAgain: () => readinessPanel.refresh(true),
     });
   },
 };

--- a/src/shared/settings/CliLifecycleSection.ts
+++ b/src/shared/settings/CliLifecycleSection.ts
@@ -1,0 +1,388 @@
+import type { App } from 'obsidian';
+import { Notice } from 'obsidian';
+
+import type { ManagedCommandResult } from '../../core/process/ManagedCommandRunner';
+import { ManagedCommandRunner } from '../../core/process/ManagedCommandRunner';
+import type { CliCommand, CliProviderMetadata } from '../../core/providers/cli/CliProviderMetadata';
+import type { CliVersionInfo } from '../../core/providers/cli/CliProviderMetadata';
+import {
+  resolveCliInstallCommand,
+  resolveCliUpdateCommand,
+} from '../../core/providers/cli/CliProviderMetadata';
+import { isUpdateAvailable } from '../../core/providers/cli/CliVersionUtils';
+import { resolveCliVersionInfo } from '../../core/providers/cli/CliVersionUtils';
+import { t } from '../../i18n/i18n';
+import type { TranslationKey } from '../../i18n/types';
+import { findCliBinaryPath } from '../../utils/cliBinaryLocator';
+import { parseEnvironmentVariables } from '../../utils/env';
+import { buildShellCommand, shellQuote } from '../../utils/shell';
+
+/** Map stable probe error strings from CliVersionUtils to i18n keys. */
+const PROBE_ERROR_KEYS: Readonly<Record<string, TranslationKey>> = {
+  'Version probe timed out': 'settings.cliLifecycle.probe.timedOut',
+  'Failed to start the CLI process': 'settings.cliLifecycle.probe.failedToStart',
+  'Version probe output too large': 'settings.cliLifecycle.probe.outputTooLarge',
+  'CLI not installed or not on PATH': 'settings.cliLifecycle.probe.notFound',
+};
+
+function localizeProbeError(error: string): string {
+  const key = PROBE_ERROR_KEYS[error];
+  return key ? t(key) : error;
+}
+
+export interface CliLifecycleSectionOptions {
+  container: HTMLElement;
+  metadata: CliProviderMetadata;
+  /** Resolve the CLI path for this provider. */
+  resolveCliPath: () => Promise<string | null>;
+  /** Get runtime environment text for the provider. */
+  getRuntimeEnvText: () => string;
+  /** App reference for confirmation modals. */
+  app: App;
+  /** Called after install/update completes (refresh CLI resolvers, etc.). */
+  onCliChanged?: () => Promise<void>;
+  /** Re-run the provider readiness check, rendered as a "Check again" button
+   *  in the same action area as install/update. */
+  onCheckAgain?: () => Promise<void>;
+}
+
+/**
+ * Renders a CLI lifecycle section (version display + install/update buttons)
+ * inside the readiness panel's CLI detail container.
+ *
+ * The section no longer carries its own heading — it renders as a compact
+ * block inside the provider readiness panel, keeping version management
+ * visually merged with the readiness status.
+ *
+ * Usage in a provider settings tab:
+ * ```
+ * renderCliLifecycleSection({
+ *   container: readinessPanel.cliDetail,
+ *   metadata: myCliMetadata,
+ *   resolveCliPath: () => context.plugin.getResolvedProviderCliPath(providerId),
+ *   getRuntimeEnvText: () => context.plugin.getActiveEnvironmentVariables(providerId),
+ *   app: context.plugin.app,
+ *   onCliChanged: async () => { await readinessPanel.refresh(); },
+ *   onCheckAgain: () => readinessPanel.refresh(true),
+ * });
+ * ```
+ */
+export function renderCliLifecycleSection(options: CliLifecycleSectionOptions): void {
+  const { container, metadata, resolveCliPath, getRuntimeEnvText, app } = options;
+
+  const root = container.createDiv({ cls: 'claudian-cli-lifecycle' });
+
+  const labelDiv = root.createDiv({ cls: 'claudian-cli-lifecycle-label' });
+  labelDiv.createSpan({ text: t('settings.cliLifecycle.label', { cli: metadata.displayName }) });
+
+  const statusDiv = root.createDiv({ cls: 'claudian-cli-lifecycle-status' });
+  const actionDiv = root.createDiv({ cls: 'claudian-cli-lifecycle-actions' });
+
+  let loading = false;
+  let currentEnv: Record<string, string> = {};
+
+  const refresh = async (): Promise<void> => {
+    if (loading) return;
+    loading = true;
+    statusDiv.empty?.();
+    actionDiv.empty?.();
+    statusDiv.setText?.(t('settings.cliLifecycle.checking'));
+
+    try {
+      const cliPath = await resolveCliPath();
+      const envText = getRuntimeEnvText();
+      currentEnv = { ...process.env, ...parseEnvironmentVariables(envText) } as Record<string, string>;
+
+      const cliVersionInfo = await resolveCliVersionInfo(cliPath, {
+        binaryName: metadata.binaryName,
+        npmPackage: metadata.npmPackage,
+      }, undefined, currentEnv);
+
+      renderVersionInfo(statusDiv, cliVersionInfo);
+      renderActionButtons(actionDiv, cliVersionInfo, metadata, app, currentEnv, refresh, options.onCliChanged, reprobeVersion, options.onCheckAgain ? handleCheckAgain : undefined);
+    } catch {
+      statusDiv.setText?.(t('common.error'));
+    } finally {
+      loading = false;
+    }
+  };
+
+  /** "Check again" refreshes both the CLI version block and the provider
+   *  readiness panel so the two stay consistent. */
+  const handleCheckAgain = async (): Promise<void> => {
+    await Promise.all([options.onCheckAgain?.(), refresh()]);
+  };
+
+  /** Re-probe the CLI version after a lifecycle action to verify the result. */
+  const reprobeVersion = async (): Promise<CliVersionInfo> => {
+    const cliPath = await resolveCliPath();
+    return resolveCliVersionInfo(cliPath, {
+      binaryName: metadata.binaryName,
+      npmPackage: metadata.npmPackage,
+    }, undefined, currentEnv);
+  };
+
+  void refresh();
+}
+
+function renderVersionInfo(
+  container: HTMLElement,
+  info: CliVersionInfo,
+): void {
+  container.empty?.();
+
+  const currentEl = container.createDiv({ cls: 'claudian-cli-lifecycle-version-item' });
+  currentEl.createSpan({ text: t('settings.cliLifecycle.currentVersion') + ': ' });
+
+  if (info.installedButBroken) {
+    const val = currentEl.createSpan({ cls: 'claudian-cli-lifecycle-version-broken' });
+    val.setText(t('settings.cliLifecycle.installedButBroken'));
+    if (info.error) {
+      val.title = info.error;
+    }
+  } else if (info.version) {
+    currentEl.createSpan({ cls: 'claudian-cli-lifecycle-version-value' }).setText(info.version);
+  } else {
+    currentEl.createSpan({ cls: 'claudian-cli-lifecycle-version-not-installed' }).setText(
+      t('settings.cliLifecycle.notInstalled'),
+    );
+  }
+
+  if (info.latestVersion) {
+    const latestEl = container.createDiv({ cls: 'claudian-cli-lifecycle-version-item' });
+    latestEl.createSpan({ text: t('settings.cliLifecycle.latestVersion') + ': ' });
+    latestEl.createSpan({ cls: 'claudian-cli-lifecycle-version-value' }).setText(info.latestVersion);
+
+    if (info.version && isUpdateAvailable(info.version, info.latestVersion)) {
+      const badge = container.createDiv({ cls: 'claudian-cli-lifecycle-update-badge' });
+      badge.setText(t('settings.cliLifecycle.updateAvailable'));
+    }
+  }
+
+  if (info.error && !info.version && !info.installedButBroken) {
+    container.createDiv({
+      cls: 'claudian-cli-lifecycle-error',
+      text: localizeProbeError(info.error),
+    });
+  }
+}
+
+function renderActionButtons(
+  container: HTMLElement,
+  info: CliVersionInfo,
+  metadata: CliProviderMetadata,
+  app: App,
+  env: Record<string, string>,
+  refresh: () => Promise<void>,
+  onCliChanged?: () => Promise<void>,
+  reprobeVersion?: () => Promise<CliVersionInfo>,
+  onCheckAgain?: () => Promise<void>,
+): void {
+  container.empty?.();
+
+  if (info.installedButBroken) {
+    container.createSpan({
+      cls: 'claudian-cli-lifecycle-hint',
+      text: t('settings.cliLifecycle.checkEnv'),
+    });
+  }
+
+  // Action row: install/update (primary) + "Check again" (secondary) side by side.
+  const row = container.createDiv({ cls: 'claudian-cli-lifecycle-action-row' });
+
+  if (!info.installedButBroken && !info.version) {
+    const installCmd = resolveCliInstallCommand(metadata);
+    if (installCmd) {
+      row.createEl('button', {
+        cls: 'mod-cta',
+        text: t('settings.cliLifecycle.install'),
+      }).addEventListener?.('click', () => {
+        void runLifecycleAction(
+          app,
+          installCmd,
+          'install',
+          metadata.displayName,
+          env,
+          refresh,
+          onCliChanged,
+          reprobeVersion,
+        );
+      });
+    }
+  } else if (!info.installedButBroken && info.version) {
+    if (info.latestVersion && isUpdateAvailable(info.version, info.latestVersion)) {
+      const updateCmd = resolveCliUpdateCommand(metadata);
+      if (updateCmd) {
+        row.createEl('button', {
+          cls: 'mod-cta',
+          text: t('settings.cliLifecycle.update'),
+        }).addEventListener?.('click', () => {
+          void runLifecycleAction(
+            app,
+            updateCmd,
+            'update',
+            metadata.displayName,
+            env,
+            refresh,
+            onCliChanged,
+            reprobeVersion,
+          );
+        });
+      }
+    } else {
+      row.createSpan({
+        cls: 'claudian-cli-lifecycle-ready',
+        text: t('settings.cliLifecycle.ready'),
+      });
+    }
+  }
+
+  if (onCheckAgain) {
+    const checkBtn = row.createEl('button', {
+      cls: 'claudian-cli-lifecycle-check',
+      text: t('settings.providerReadiness.refresh'),
+    });
+    checkBtn.addEventListener?.('click', () => {
+      void (async () => {
+        checkBtn.disabled = true;
+        checkBtn.setText?.(t('settings.providerReadiness.checking'));
+        try {
+          await onCheckAgain();
+        } catch {
+          // Readiness refresh errors are already surfaced by the panel;
+          // keep the button state consistent.
+        } finally {
+          // The action re-renders the action row via refresh(), so this
+          // element may already be detached — resetting it is a no-op then.
+          checkBtn.disabled = false;
+          checkBtn.setText?.(t('settings.providerReadiness.refresh'));
+        }
+      })();
+    });
+  }
+}
+
+/** Resolve a bare binary name to an absolute path so the update command
+ * can find it even when the Electron renderer PATH differs from the shell. */
+function resolveLifecycleCommand(cmd: CliCommand, env: Record<string, string>): CliCommand {
+  const looksLikePath = cmd.command.includes('/') || cmd.command.includes('\\');
+  if (looksLikePath) return cmd;
+  const resolved = findCliBinaryPath(cmd.command, env.PATH);
+  return resolved ? { command: resolved, args: cmd.args } : cmd;
+}
+
+async function runLifecycleAction(
+  app: App,
+  cmd: CliCommand,
+  action: 'install' | 'update',
+  displayName: string,
+  env: Record<string, string>,
+  refresh: () => Promise<void>,
+  onCliChanged?: () => Promise<void>,
+  reprobeVersion?: () => Promise<CliVersionInfo>,
+): Promise<void> {
+  const actionLabel = action === 'install'
+    ? t('settings.cliLifecycle.install')
+    : t('settings.cliLifecycle.update');
+  const confirmMsg = action === 'install'
+    ? t('settings.cliLifecycle.installConfirm', { cli: displayName, command: `${cmd.command} ${cmd.args.join(' ')}` })
+    : t('settings.cliLifecycle.updateConfirm', { cli: displayName, command: `${cmd.command} ${cmd.args.join(' ')}` });
+
+  let confirmed: boolean;
+  try {
+    confirmed = await (await import('../modals/ConfirmModal')).confirm(
+      app,
+      confirmMsg,
+      actionLabel,
+    );
+  } catch {
+    new Notice(`${actionLabel} failed to open confirmation dialog.`);
+    return;
+  }
+  if (!confirmed) return;
+
+  try {
+    const runner = new ManagedCommandRunner();
+    const resolvedCommand = resolveLifecycleCommand(cmd, env);
+
+    /** Run a lifecycle command; returns null when the spawn itself failed
+     *  (ENOENT) so the caller can retry via shell. */
+    const tryRun = async (command: string, args: string[]): Promise<ManagedCommandResult | null> => {
+      const result = await runner.run({
+        command,
+        args,
+        cwd: process.cwd(),
+        env,
+        timeoutMs: 120_000,
+        stdoutLimitBytes: 16_384,
+        captureStderr: true,
+      });
+      return result.termination === 'error' ? null : result;
+    };
+
+    let result = await tryRun(resolvedCommand.command, resolvedCommand.args);
+    if (result === null) {
+      // Fallback: run through user shell so that the login profile PATH
+      // (nvm, homebrew, etc.) is loaded — same approach as cc-switch.
+      const commandLine = `${shellQuote(resolvedCommand.command)} ${resolvedCommand.args.map(shellQuote).join(' ')}`;
+      const shellCmd = buildShellCommand(commandLine);
+      if (shellCmd) {
+        result = await tryRun(shellCmd.command, shellCmd.args);
+      }
+    }
+
+    if (result === null) {
+      new Notice(
+        action === 'install'
+          ? `${t('settings.cliLifecycle.installFailed', { cli: displayName })} (error)`
+          : `${t('settings.cliLifecycle.updateFailed', { cli: displayName })} (error)`,
+      );
+    } else if (result.exitCode !== 0) {
+      const detail = result.termination
+        ? result.termination
+        : (result.stderr?.trim() || result.stdout.trim()).slice(0, 200) || 'unknown error';
+      new Notice(
+        action === 'install'
+          ? `${t('settings.cliLifecycle.installFailed', { cli: displayName })} (${detail})`
+          : `${t('settings.cliLifecycle.updateFailed', { cli: displayName })} (${detail})`,
+      );
+    } else {
+      // Command exited 0 — re-probe to verify the version actually changed.
+      // This mirrors cc-switch's executeRun which re-probes after every action
+      // and reports a soft failure when the version did not move.
+      const after = reprobeVersion ? await reprobeVersion() : null;
+      const updateUnchanged = after
+        && action === 'update'
+        && after.version
+        && after.latestVersion
+        && isUpdateAvailable(after.version, after.latestVersion);
+      const installStillMissing = after
+        && action === 'install'
+        && !after.version;
+
+      if (updateUnchanged) {
+        new Notice(
+          t('settings.cliLifecycle.versionUnchanged', {
+            cli: displayName,
+            version: after?.version ?? '',
+          }),
+        );
+      } else if (installStillMissing) {
+        new Notice(t('settings.cliLifecycle.installFailed', { cli: displayName }));
+      } else {
+        new Notice(
+          action === 'install'
+            ? t('settings.cliLifecycle.installDone', { cli: displayName })
+            : t('settings.cliLifecycle.updateDone', { cli: displayName }),
+        );
+      }
+      await onCliChanged?.();
+    }
+  } catch (error) {
+    new Notice(
+      `${actionLabel} failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  } finally {
+    void refresh();
+  }
+}

--- a/src/shared/settings/ProviderReadinessPanel.ts
+++ b/src/shared/settings/ProviderReadinessPanel.ts
@@ -17,7 +17,15 @@ export interface ProviderReadinessPanelOptions {
 }
 
 export interface ProviderReadinessPanelController {
-  refresh(): Promise<void>;
+  /** Re-run the readiness check and re-render. Pass true to also refresh the
+   *  provider catalog (e.g. re-run model discovery) first. */
+  refresh(refreshCatalog?: boolean): Promise<void>;
+  /** Root container element, for appending related content (e.g. CLI lifecycle). */
+  root: HTMLElement;
+  /** Stable container for CLI lifecycle content, rendered below the checks.
+   *  Unlike `root`, it is not cleared on refresh, so a CLI lifecycle section
+   *  attached here keeps its own state. */
+  cliDetail: HTMLElement;
 }
 
 const MIN_REFRESH_FEEDBACK_MS = 120;
@@ -33,14 +41,7 @@ export function renderProviderReadinessPanel(
 
   const summary = root.createDiv({ cls: 'claudian-provider-readiness-summary' });
   const checks = root.createDiv({ cls: 'claudian-provider-readiness-checks' });
-  const refreshButton = options.onRefresh
-    ? root.createEl('button', {
-      cls: 'claudian-provider-readiness-refresh',
-      text: t('settings.providerReadiness.refresh'),
-    })
-    : null;
-
-  refreshButton?.addEventListener?.('click', () => { void refresh(true); });
+  const cliDetail = root.createDiv({ cls: 'claudian-provider-readiness-cli-detail' });
 
   const renderSnapshot = (snapshot: ProviderReadinessSnapshot): void => {
     summary.setText(t(`settings.providerReadiness.status.${snapshot.status}`));
@@ -52,33 +53,20 @@ export function renderProviderReadinessPanel(
   };
 
   const refresh = async (refreshCatalog = false): Promise<void> => {
-    if (refreshButton) {
-      refreshButton.disabled = true;
-      refreshButton.setAttribute?.('aria-busy', 'true');
-      refreshButton.setText?.(t('settings.providerReadiness.checking'));
-    }
     summary.setText(t('settings.providerReadiness.checking'));
-    try {
-      if (refreshCatalog) {
-        const startedAt = Date.now();
-        await options.onRefresh?.();
-        const remaining = MIN_REFRESH_FEEDBACK_MS - (Date.now() - startedAt);
-        if (remaining > 0) {
-          await new Promise<void>(resolve => window.setTimeout(resolve, remaining));
-        }
-      }
-      renderSnapshot(await options.getSnapshot());
-    } finally {
-      if (refreshButton) {
-        refreshButton.disabled = false;
-        refreshButton.removeAttribute?.('aria-busy');
-        refreshButton.setText?.(t('settings.providerReadiness.refresh'));
+    if (refreshCatalog) {
+      const startedAt = Date.now();
+      await options.onRefresh?.();
+      const remaining = MIN_REFRESH_FEEDBACK_MS - (Date.now() - startedAt);
+      if (remaining > 0) {
+        await new Promise<void>(resolve => window.setTimeout(resolve, remaining));
       }
     }
+    renderSnapshot(await options.getSnapshot());
   };
 
   void refresh();
-  return { refresh };
+  return { refresh, root, cliDetail };
 }
 
 function renderCheck(container: HTMLElement, check: ProviderReadinessCheck): void {

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -61,6 +61,7 @@
 @import "./settings/agent-skills.css";
 @import "./settings/provider-model-picker.css";
 @import "./settings/provider-readiness.css";
+@import "./settings/cli-lifecycle.css";
 @import "./settings/getting-started.css";
 @import "./settings/provider-capability-matrix.css";
 

--- a/src/style/settings/cli-lifecycle.css
+++ b/src/style/settings/cli-lifecycle.css
@@ -1,0 +1,14 @@
+.claudian-cli-lifecycle { display: grid; gap: 4px; }
+.claudian-cli-lifecycle-label { color: var(--text-normal); font-size: var(--font-ui-small); font-weight: var(--font-medium); }
+.claudian-cli-lifecycle-status { display: grid; gap: 4px; color: var(--text-muted); font-size: var(--font-ui-small); }
+.claudian-cli-lifecycle-version-item { display: flex; align-items: center; gap: 6px; }
+.claudian-cli-lifecycle-version-value { color: var(--text-normal); font-family: var(--font-monospace); font-size: var(--font-ui-smaller); }
+.claudian-cli-lifecycle-version-broken { color: var(--text-warning); font-weight: var(--font-medium); }
+.claudian-cli-lifecycle-version-not-installed { color: var(--text-muted); font-style: italic; }
+.claudian-cli-lifecycle-update-badge { display: inline-flex; align-items: center; gap: 4px; margin-top: 2px; padding: 1px 8px; border-radius: 10px; background: var(--background-modifier-success); color: var(--text-success); font-size: var(--font-ui-smaller); font-weight: var(--font-medium); width: fit-content; }
+.claudian-cli-lifecycle-error { color: var(--text-error); font-size: var(--font-ui-smaller); white-space: pre-wrap; }
+.claudian-cli-lifecycle-actions { margin-top: 6px; }
+.claudian-cli-lifecycle-hint { color: var(--text-warning); font-size: var(--font-ui-smaller); margin-bottom: 6px; }
+.claudian-cli-lifecycle-ready { color: var(--text-muted); font-size: var(--font-ui-small); }
+.claudian-cli-lifecycle-action-row { display: flex; align-items: center; justify-content: flex-end; gap: 8px; }
+.claudian-cli-lifecycle-check { font-size: var(--font-ui-small); }

--- a/src/style/settings/provider-readiness.css
+++ b/src/style/settings/provider-readiness.css
@@ -4,7 +4,7 @@
 .claudian-provider-readiness-summary[data-status="blocked"] { color: var(--text-error); }
 .claudian-provider-readiness-summary[data-status="attention"] { color: var(--text-warning); }
 .claudian-provider-readiness-checks { display: grid; gap: 6px; margin: 0 12px; }
-.claudian-provider-readiness-refresh { display: block; margin: 10px 12px 0 auto; }
+.claudian-provider-readiness-cli-detail { margin: 10px 12px 0; }
 .claudian-provider-readiness-check { display: flex; align-items: center; gap: 8px; color: var(--text-muted); font-size: var(--font-ui-small); }
 .claudian-provider-readiness-check-icon { width: 18px; color: var(--text-faint); text-align: center; }
 .claudian-provider-readiness-check[data-status="ready"] .claudian-provider-readiness-check-icon { color: var(--text-success); }

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -1,0 +1,51 @@
+import * as path from 'path';
+
+const VALID_SHELLS = new Set(['sh', 'bash', 'zsh', 'fish', 'dash']);
+
+/**
+ * Get the user's preferred shell path, validated against allowed shells.
+ * Falls back to /bin/zsh on macOS, /bin/bash on Linux.
+ */
+export function getUserShell(): string {
+  const envShell = process.env.SHELL?.trim();
+  if (envShell && envShell.startsWith('/')) {
+    const basename = path.basename(envShell);
+    if (VALID_SHELLS.has(basename)) {
+      return envShell;
+    }
+  }
+  return process.platform === 'darwin' ? '/bin/zsh' : '/bin/bash';
+}
+
+/**
+ * Build a shell command that loads the user's login profile (e.g., `.zshrc`,
+ * `.bashrc`) so that the correct PATH (nvm, homebrew, etc.) is available.
+ *
+ * Returns `{ command, args }` suitable for `ManagedCommandRunner.run()`.
+ * Returns `null` on Windows (where shell fallback should use `cmd /C`).
+ */
+export function buildShellCommand(
+  commandLine: string,
+  shell?: string,
+): { command: string; args: string[] } | null {
+  if (process.platform === 'win32') {
+    // On Windows, use cmd /C as the shell fallback.
+    return { command: 'cmd', args: ['/C', commandLine] };
+  }
+
+  const resolvedShell = shell ?? getUserShell();
+  const basename = path.basename(resolvedShell);
+  const flag = basename === 'sh' || basename === 'dash' ? '-c' : '-lic';
+  return { command: resolvedShell, args: [flag, commandLine] };
+}
+
+/**
+ * Quote a single argument for shell injection.
+ * Uses single quotes when the string contains special characters.
+ */
+export function shellQuote(s: string): string {
+  if (/^[A-Za-z0-9_./~@%+-]+$/.test(s)) {
+    return s;
+  }
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}

--- a/tests/unit/core/process/ManagedCommandRunner.test.ts
+++ b/tests/unit/core/process/ManagedCommandRunner.test.ts
@@ -58,6 +58,30 @@ describe('ManagedCommandRunner', () => {
     });
   });
 
+  it('collects stderr when captureStderr is enabled', async () => {
+    const pending = runCommand({ captureStderr: true });
+    proc.stdout.emit('data', 'version 1.2.3');
+    proc.stderr.emit('data', Buffer.from('warning: ignored'));
+    proc.emit('close', 0, null);
+
+    await expect(pending).resolves.toEqual({
+      exitCode: 0,
+      stdout: 'version 1.2.3',
+      stderr: 'warning: ignored',
+    });
+  });
+
+  it('does not expose stderr when captureStderr is disabled', async () => {
+    const pending = runCommand();
+    proc.stderr.emit('data', 'should not be captured');
+    proc.emit('close', 0, null);
+
+    await expect(pending).resolves.toEqual({
+      exitCode: 0,
+      stdout: '',
+    });
+  });
+
   it('aborts before spawning when the signal is already cancelled', async () => {
     const controller = new AbortController();
     controller.abort();

--- a/tests/unit/core/providers/cli/CliProviderMetadata.test.ts
+++ b/tests/unit/core/providers/cli/CliProviderMetadata.test.ts
@@ -1,0 +1,105 @@
+import {
+  type CliProviderMetadata,
+  resolveCliInstallCommand,
+  resolveCliInstallerUrl,
+  resolveCliUpdateCommand,
+} from '@/core/providers/cli/CliProviderMetadata';
+
+const baseMetadata: CliProviderMetadata = {
+  binaryName: 'claude',
+  displayName: 'Claude',
+};
+
+describe('resolveCliInstallCommand', () => {
+  it('falls back to npm install -g when only an npm package is known', () => {
+    expect(resolveCliInstallCommand({ ...baseMetadata, npmPackage: '@anthropic-ai/claude-code' }))
+      .toEqual({ command: 'npm', args: ['install', '-g', '@anthropic-ai/claude-code@latest'] });
+  });
+
+  it('returns null when no npm package or install command is defined', () => {
+    expect(resolveCliInstallCommand(baseMetadata)).toBeNull();
+  });
+
+  it('prefers an explicit install command over the npm fallback', () => {
+    const metadata: CliProviderMetadata = {
+      ...baseMetadata,
+      npmPackage: '@anthropic-ai/claude-code',
+      install: { command: 'claude', args: ['install'] },
+    };
+    expect(resolveCliInstallCommand(metadata)).toEqual({ command: 'claude', args: ['install'] });
+  });
+
+  it('prefers a platform override over the generic install command', () => {
+    const platform = process.platform;
+    const metadata: CliProviderMetadata = {
+      ...baseMetadata,
+      npmPackage: 'pkg',
+      install: { command: 'npm', args: ['install', '-g', 'pkg'] },
+      platform: {
+        [platform]: { install: { command: 'npm.cmd', args: ['install', '-g', 'pkg'] } },
+      },
+    };
+    const result = resolveCliInstallCommand(metadata);
+    expect(result).toEqual({ command: 'npm.cmd', args: ['install', '-g', 'pkg'] });
+  });
+});
+
+describe('resolveCliUpdateCommand', () => {
+  it('falls back to npm install -g @latest when only an npm package is known', () => {
+    expect(resolveCliUpdateCommand({ ...baseMetadata, npmPackage: '@openai/codex' }))
+      .toEqual({ command: 'npm', args: ['install', '-g', '@openai/codex@latest'] });
+  });
+
+  it('returns null when no npm package or update command is defined', () => {
+    expect(resolveCliUpdateCommand(baseMetadata)).toBeNull();
+  });
+
+  it('prefers an explicit update command over the npm fallback', () => {
+    const metadata: CliProviderMetadata = {
+      ...baseMetadata,
+      npmPackage: '@anthropic-ai/claude-code',
+      update: { command: 'claude', args: ['update'] },
+    };
+    expect(resolveCliUpdateCommand(metadata)).toEqual({ command: 'claude', args: ['update'] });
+  });
+
+  it('prefers a platform override over the generic update command', () => {
+    const platform = process.platform;
+    const metadata: CliProviderMetadata = {
+      ...baseMetadata,
+      update: { command: 'claude', args: ['update'] },
+      platform: {
+        [platform]: { update: { command: 'claude.cmd', args: ['update'] } },
+      },
+    };
+    const result = resolveCliUpdateCommand(metadata);
+    expect(result).toEqual({ command: 'claude.cmd', args: ['update'] });
+  });
+});
+
+describe('resolveCliInstallerUrl', () => {
+  it('returns null when no installer URL is defined', () => {
+    expect(resolveCliInstallerUrl(baseMetadata)).toBeNull();
+  });
+
+  it('returns the generic installer URL', () => {
+    const metadata: CliProviderMetadata = {
+      ...baseMetadata,
+      installerUrl: 'https://example.com/install',
+    };
+    expect(resolveCliInstallerUrl(metadata)).toBe('https://example.com/install');
+  });
+
+  it('prefers a platform override installer URL', () => {
+    const platform = process.platform;
+    const metadata: CliProviderMetadata = {
+      ...baseMetadata,
+      installerUrl: 'https://example.com/install',
+      platform: {
+        [platform]: { installerUrl: 'https://example.com/mac' },
+      },
+    };
+    const result = resolveCliInstallerUrl(metadata);
+    expect(result).toBe('https://example.com/mac');
+  });
+});

--- a/tests/unit/core/providers/cli/CliVersionUtils.test.ts
+++ b/tests/unit/core/providers/cli/CliVersionUtils.test.ts
@@ -1,0 +1,81 @@
+import {
+  compareVersions,
+  extractVersion,
+  isUpdateAvailable,
+} from '@/core/providers/cli/CliVersionUtils';
+
+describe('compareVersions', () => {
+  it('compares equal versions as 0', () => {
+    expect(compareVersions('1.2.3', '1.2.3')).toBe(0);
+  });
+
+  it('orders by major version', () => {
+    expect(compareVersions('2.0.0', '1.9.9')).toBeGreaterThan(0);
+    expect(compareVersions('1.9.9', '2.0.0')).toBeLessThan(0);
+  });
+
+  it('orders by minor and patch', () => {
+    expect(compareVersions('1.2.3', '1.2.4')).toBeLessThan(0);
+    expect(compareVersions('1.3.0', '1.2.9')).toBeGreaterThan(0);
+  });
+
+  it('treats prerelease as older than release', () => {
+    expect(compareVersions('1.2.3-beta.1', '1.2.3')).toBeLessThan(0);
+    expect(compareVersions('1.2.3', '1.2.3-beta.1')).toBeGreaterThan(0);
+  });
+
+  it('compares numeric prerelease identifiers numerically', () => {
+    expect(compareVersions('1.2.3-beta.2', '1.2.3-beta.10')).toBeLessThan(0);
+  });
+
+  it('compares prerelease identifiers lexically for non-numeric', () => {
+    expect(compareVersions('1.2.3-alpha', '1.2.3-beta')).toBeLessThan(0);
+  });
+
+  it('returns 0 when either version cannot be parsed', () => {
+    expect(compareVersions('not-a-version', '1.2.3')).toBe(0);
+    expect(compareVersions('1.2.3', '')).toBe(0);
+  });
+});
+
+describe('isUpdateAvailable', () => {
+  it('is true when latest is greater than current', () => {
+    expect(isUpdateAvailable('1.2.3', '1.2.4')).toBe(true);
+    expect(isUpdateAvailable('1.2.3', '2.0.0')).toBe(true);
+  });
+
+  it('is false when versions are equal or current is newer', () => {
+    expect(isUpdateAvailable('1.2.3', '1.2.3')).toBe(false);
+    expect(isUpdateAvailable('1.2.4', '1.2.3')).toBe(false);
+  });
+
+  it('is false when either version is missing', () => {
+    expect(isUpdateAvailable(null, '1.2.3')).toBe(false);
+    expect(isUpdateAvailable('1.2.3', null)).toBe(false);
+    expect(isUpdateAvailable(undefined, undefined)).toBe(false);
+    expect(isUpdateAvailable('', '1.2.3')).toBe(false);
+  });
+
+  it('does not report a prerelease-only lead as an update', () => {
+    expect(isUpdateAvailable('1.2.3-next.1', '1.2.3')).toBe(false);
+  });
+});
+
+describe('extractVersion', () => {
+  it('extracts a bare version', () => {
+    expect(extractVersion('1.2.3')).toBe('1.2.3');
+  });
+
+  it('extracts a version from prefixed output', () => {
+    expect(extractVersion('grok 2.1.156')).toBe('2.1.156');
+    expect(extractVersion('claude version 1.0.45\nCopyright 2024')).toBe('1.0.45');
+  });
+
+  it('extracts a version with a prerelease tag', () => {
+    expect(extractVersion('codex 0.12.0-next.3')).toBe('0.12.0-next.3');
+  });
+
+  it('returns the trimmed raw output when no version is found', () => {
+    expect(extractVersion('  unknown  ')).toBe('unknown');
+  });
+});

--- a/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
+++ b/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
@@ -147,6 +147,8 @@ jest.mock('@/providers/codex/ui/CodexModelPicker', () => ({
 jest.mock('@/shared/settings/ProviderReadinessPanel', () => ({
   renderProviderReadinessPanel: jest.fn(() => ({
     refresh: mockRefreshProviderReadiness,
+    root: { createDiv: jest.fn(() => createElement()), createEl: jest.fn(() => createElement()) },
+    cliDetail: { createDiv: jest.fn(() => createElement()) },
   })),
 }));
 

--- a/tests/unit/providers/grok/ui/GrokSettingsTab.test.ts
+++ b/tests/unit/providers/grok/ui/GrokSettingsTab.test.ts
@@ -116,6 +116,7 @@ interface MockElement {
   appendText(value: string): void;
   createDiv(options?: { cls?: string; text?: string }): MockElement;
   createEl(tag: string, options?: { cls?: string; href?: string; text?: string }): MockElement;
+  createSpan(options?: { cls?: string; text?: string }): MockElement;
   setText(value: string): void;
   toggleClass(cls: string, force: boolean): void;
 }
@@ -144,6 +145,11 @@ function createElement(
     },
     createEl(childTag, childOptions) {
       const child = createElement(childTag, childOptions);
+      element.children.push(child);
+      return child;
+    },
+    createSpan(childOptions) {
+      const child = createElement('span', childOptions);
       element.children.push(child);
       return child;
     },

--- a/tests/unit/shared/settings/ProviderReadinessPanel.test.ts
+++ b/tests/unit/shared/settings/ProviderReadinessPanel.test.ts
@@ -46,12 +46,12 @@ describe('renderProviderReadinessPanel', () => {
     ]);
   });
 
-  it('shows checking feedback while a refresh is in flight', async () => {
+  it('shows checking feedback in the summary while a refresh is in flight', async () => {
     const container = document.createElement('div');
     let finishRefresh!: () => void;
     const onRefresh = jest.fn(() => new Promise<void>(resolve => { finishRefresh = resolve; }));
 
-    renderProviderReadinessPanel({
+    const controller = renderProviderReadinessPanel({
       container,
       providerName: 'Test',
       getSnapshot: async () => ({ status: 'ready', checks: [] }),
@@ -59,20 +59,18 @@ describe('renderProviderReadinessPanel', () => {
     });
     await new Promise<void>(resolve => setTimeout(resolve, 0));
 
-    const button = container.querySelector<HTMLButtonElement>('.claudian-provider-readiness-refresh');
-    expect(button).not.toBeNull();
-    button?.click();
+    const summary = container.querySelector<HTMLElement>('.claudian-provider-readiness-summary');
+    expect(summary?.textContent).toBe('Ready');
+
+    void controller.refresh(true);
     await new Promise<void>(resolve => setTimeout(resolve, 0));
 
-    expect(button?.disabled).toBe(true);
-    expect(button?.textContent).toBe('Checking provider readiness…');
-    expect(button?.getAttribute('aria-busy')).toBe('true');
+    expect(summary?.textContent).toBe('Checking provider readiness…');
 
     finishRefresh();
     await new Promise<void>(resolve => setTimeout(resolve, 140));
 
-    expect(button?.disabled).toBe(false);
-    expect(button?.textContent).toBe('Check again');
-    expect(button?.getAttribute('aria-busy')).toBeNull();
+    expect(summary?.textContent).toBe('Ready');
+    expect(onRefresh).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

Adds CLI lifecycle management (version probe, update detection, install/update) for all seven built-in providers, merged into the provider readiness panel so status and CLI management live in one place.

## Changes

- **CLI metadata** (`src/core/providers/cli/`): provider-neutral `CliProviderMetadata` (binary name, npm package, install/update commands) + `CliVersionUtils` with a three-attempt probe fallback chain: direct spawn → PATH lookup (`findCliBinaryPath`) → login-shell fallback (`$SHELL -lic "<binary> --version"`, mirroring cc-switch).
- **Robust probing**: exit 127 (missing Node/env dependency) is non-final so the fallback chain continues; probing runs even when the resolver returns null (stale fnm multishell paths). The npm package name drives both the latest-version probe and install/update.
- **ManagedCommandRunner**: optional `captureStderr` to surface failure details from lifecycle commands.
- **UI merge**: `CliLifecycleSection` renders inside the readiness panel's stable `cliDetail` container — label, current/latest version, update badge, and a right-aligned action row with install/update + "Check again" (refreshes CLI version and readiness snapshot in parallel, with a disabled "Checking…" state).
- **Pi package migration**: `@mariozechner/pi-coding-agent` (stuck at 0.73.1) → `@earendil-works/pi-coding-agent` (current 0.84.x).
- **i18n**: `settings.cliLifecycle.*` added across all 10 locales; unused `desc`/`installing`/`updating` keys removed.

## Verification

- `npx tsc --noEmit` ✓
- ESLint: 0 errors (5 pre-existing warnings) ✓
- Jest: 420 suites / 7128 tests passed ✓
- Production build ✓

## Test plan

- Probe fallback simulated end-to-end: direct spawn fails (127) → shell fallback resolves `pi --version` = 0.84.4 ✓
- Settings UI: install/update + Check again buttons side by side, right-aligned ✓
