### PR TITLE
chore: release v2.5.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "packageManager": "pnpm@10.34.5",
   "description": "Oh My Claudian - provider-backed coding agents embedded in the Obsidian sidebar",
   "main": "main.js",


### PR DESCRIPTION
## Summary

Release **v2.5.2** — bumps `manifest.json` and `package.json` to `2.5.2`.

## Changes since v2.5.1

| PR | Change |
| --- | --- |
| #134 | CLI lifecycle install/update buttons now show a loading state; the "Update available" badge uses the warning scheme and shows the target version |
| #133 | Ported 6 upstream fixes: Pi terminal-error preservation (#1196), Pi pushed-commands probe fallback (#1162), architecture-test Windows path normalization (#1226), Windows session/path fixes (#1197 partial), composer reflow on keystroke (#1215), native-accessible UI actions (#1214) |
| #132 | CLI lifecycle management: version scan, install/update, readiness-panel integration for all built-in providers |
| #131 | Docs: clarified supported providers |

## Verification

- Full check: typecheck clean, lint 0 errors, 420 suites / 7132 tests passed, build OK (ran before merge of #134)
- PR #134 changes verified: locales key alignment test + settings tests + build
