### PR TITLE
feat: manage provider CLI lifecycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Provider capabilities are intentionally different. The plugin exposes controls o
 - Single-panel and dual-pane layouts with vault navigation and session management.
 - Inline editing with a word-level diff preview.
 - Slash commands, skills, `@` mentions, instruction mode, and Mermaid rendering.
-- Model discovery, readiness diagnostics, provider-specific permissions and planning controls where available.
+- Model discovery, readiness diagnostics, and CLI version management, with provider-specific permissions and planning controls where available.
 - File and folder attachments from Obsidian or your desktop as clickable context chips.
 - External-file access boundaries and approval-aware write handling.
 - Internationalized UI with 10 locales, including Simplified and Traditional Chinese.
@@ -63,12 +63,13 @@ Then enable the plugin under **Settings → Community plugins**.
 ## Quick start
 
 1. Open **Settings → Oh My Claudian** and choose a provider tab.
-2. Enable the provider, check its **Readiness** panel, and select a chat model.
-3. Open the chat sidebar from the ribbon icon or command palette and send a message.
+2. Enable the provider and check its **Readiness** panel. If its CLI is missing, select **Install**, review the official command, and confirm it. Claudian rechecks the CLI when installation finishes.
+3. Sign in through the provider's own CLI when required, then select a chat model.
+4. Open the chat sidebar from the ribbon icon or command palette and send a message.
 
 Use `/` for commands and skills, `@` to reference vault files or provider resources, and drag files or folders into the composer to attach them. Select note text and use the inline-edit command to preview and apply changes.
 
-Each provider CLI is installed, authenticated, and configured outside the plugin. If Obsidian cannot find a CLI, leave automatic detection enabled first; otherwise set the provider's executable path in its settings tab. OMP and Cursor require separate CLI login, for example `agent login` for Cursor Agent.
+Installation still runs on your machine and requires your confirmation; the plugin does not download or execute a CLI silently. If automatic detection cannot find an already-installed CLI, set its executable path in the provider settings. Authentication and account setup remain provider-native—for example, run `agent login` for Cursor Agent.
 
 ## Safety and privacy
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Provider capabilities are intentionally different. The plugin exposes controls o
 - Single-panel and dual-pane layouts with vault navigation and session management.
 - Inline editing with a word-level diff preview.
 - Slash commands, skills, `@` mentions, instruction mode, and Mermaid rendering.
-- Model discovery, readiness diagnostics, and CLI version management, with provider-specific permissions and planning controls where available.
+- Model discovery, readiness diagnostics, and provider-aware CLI lifecycle management: discovery, health checks, version comparison, install, update, and post-action verification.
 - File and folder attachments from Obsidian or your desktop as clickable context chips.
 - External-file access boundaries and approval-aware write handling.
 - Internationalized UI with 10 locales, including Simplified and Traditional Chinese.
@@ -63,13 +63,14 @@ Then enable the plugin under **Settings → Community plugins**.
 ## Quick start
 
 1. Open **Settings → Oh My Claudian** and choose a provider tab.
-2. Enable the provider and check its **Readiness** panel. If its CLI is missing, select **Install**, review the official command, and confirm it. Claudian rechecks the CLI when installation finishes.
-3. Sign in through the provider's own CLI when required, then select a chat model.
-4. Open the chat sidebar from the ribbon icon or command palette and send a message.
+2. Enable the provider and check its **Readiness** panel. It discovers the configured or PATH CLI, checks whether it runs correctly, and shows the installed version and the latest version when the provider publishes one.
+3. Use the lifecycle action offered for that provider: install a missing CLI, update an outdated CLI, or correct its executable path. Every install or update shows its command for confirmation and rechecks the CLI afterward.
+4. Sign in through the provider's own CLI when required, then select a chat model.
+5. Open the chat sidebar from the ribbon icon or command palette and send a message.
 
 Use `/` for commands and skills, `@` to reference vault files or provider resources, and drag files or folders into the composer to attach them. Select note text and use the inline-edit command to preview and apply changes.
 
-Installation still runs on your machine and requires your confirmation; the plugin does not download or execute a CLI silently. If automatic detection cannot find an already-installed CLI, set its executable path in the provider settings. Authentication and account setup remain provider-native—for example, run `agent login` for Cursor Agent.
+CLI lifecycle actions run on your machine and require confirmation; the plugin does not download, update, or execute a CLI silently. Available actions depend on each Provider's official distribution and version metadata. If automatic discovery cannot find an installed CLI, set its executable path in the provider settings. Authentication and account setup remain provider-native—for example, run `agent login` for Cursor Agent.
 
 ## Safety and privacy
 

--- a/src/providers/cursor/runtime/CursorCliMetadata.ts
+++ b/src/providers/cursor/runtime/CursorCliMetadata.ts
@@ -1,11 +1,19 @@
 import type { CliProviderMetadata } from '../../../core/providers/cli/CliProviderMetadata';
 
-/**
- * Cursor Agent CLI (`agent`). The CLI ships with the Cursor desktop app, so
- * there is no standalone npm install path; install/update are intentionally
- * omitted, while version probing still works through the binary name.
- */
+/** Cursor Agent CLI (`agent`) lifecycle metadata. */
 export const cursorCliMetadata: CliProviderMetadata = {
   binaryName: 'agent',
   displayName: 'Cursor',
+  install: {
+    command: 'bash',
+    args: ['-lc', 'curl -fsSL https://cursor.com/install | bash'],
+  },
+  platform: {
+    win32: {
+      install: {
+        command: 'powershell',
+        args: ['-NoProfile', '-Command', "irm 'https://cursor.com/install?win32=true' | iex"],
+      },
+    },
+  },
 };

--- a/src/providers/grok/runtime/GrokCliMetadata.ts
+++ b/src/providers/grok/runtime/GrokCliMetadata.ts
@@ -1,11 +1,19 @@
 import type { CliProviderMetadata } from '../../../core/providers/cli/CliProviderMetadata';
 
-/**
- * Grok Build CLI. The official install method is not distributed via a
- * stable public npm package name, so install/update are intentionally
- * omitted; version probing still works through the binary name.
- */
+/** Grok Build CLI lifecycle metadata. */
 export const grokCliMetadata: CliProviderMetadata = {
   binaryName: 'grok',
   displayName: 'Grok',
+  install: {
+    command: 'bash',
+    args: ['-lc', 'curl -fsSL https://x.ai/cli/install.sh | bash'],
+  },
+  platform: {
+    win32: {
+      install: {
+        command: 'powershell',
+        args: ['-NoProfile', '-Command', "irm 'https://x.ai/cli/install.ps1' | iex"],
+      },
+    },
+  },
 };

--- a/src/providers/omp/runtime/OmpCliMetadata.ts
+++ b/src/providers/omp/runtime/OmpCliMetadata.ts
@@ -1,11 +1,19 @@
 import type { CliProviderMetadata } from '../../../core/providers/cli/CliProviderMetadata';
 
-/**
- * OMP (Oh My Pi) CLI. The install method is provider-documented rather than
- * a stable public npm package, so install/update are intentionally omitted;
- * version probing still works through the binary name.
- */
+/** OMP (Oh My Pi) CLI lifecycle metadata. */
 export const ompCliMetadata: CliProviderMetadata = {
   binaryName: 'omp',
   displayName: 'OMP',
+  install: {
+    command: 'bash',
+    args: ['-lc', 'curl -fsSL https://omp.sh/install | bash'],
+  },
+  platform: {
+    win32: {
+      install: {
+        command: 'powershell',
+        args: ['-NoProfile', '-Command', "irm 'https://omp.sh/install.ps1' | iex"],
+      },
+    },
+  },
 };

--- a/tests/unit/core/providers/cli/CliProviderMetadata.test.ts
+++ b/tests/unit/core/providers/cli/CliProviderMetadata.test.ts
@@ -4,6 +4,9 @@ import {
   resolveCliInstallerUrl,
   resolveCliUpdateCommand,
 } from '@/core/providers/cli/CliProviderMetadata';
+import { cursorCliMetadata } from '@/providers/cursor/runtime/CursorCliMetadata';
+import { grokCliMetadata } from '@/providers/grok/runtime/GrokCliMetadata';
+import { ompCliMetadata } from '@/providers/omp/runtime/OmpCliMetadata';
 
 const baseMetadata: CliProviderMetadata = {
   binaryName: 'claude',
@@ -14,6 +17,17 @@ describe('resolveCliInstallCommand', () => {
   it('falls back to npm install -g when only an npm package is known', () => {
     expect(resolveCliInstallCommand({ ...baseMetadata, npmPackage: '@anthropic-ai/claude-code' }))
       .toEqual({ command: 'npm', args: ['install', '-g', '@anthropic-ai/claude-code@latest'] });
+  });
+
+  it.each([
+    ['Cursor', cursorCliMetadata, 'https://cursor.com/install'],
+    ['Grok', grokCliMetadata, 'https://x.ai/cli/install.sh'],
+    ['OMP', ompCliMetadata, 'https://omp.sh/install'],
+  ])('uses the official installer for %s when the CLI is missing', (_name, metadata, installerUrl) => {
+    expect(resolveCliInstallCommand(metadata)).toEqual({
+      command: 'bash',
+      args: ['-lc', `curl -fsSL ${installerUrl} | bash`],
+    });
   });
 
   it('returns null when no npm package or install command is defined', () => {


### PR DESCRIPTION
## Why
Cursor, Grok, and OMP could be detected as missing in their Readiness panels, but had no in-app recovery action. Users had to leave Claudian to install the CLI and then return to retry setup.

## What changed
- Add provider-owned official installer commands for Cursor, Grok, and OMP on macOS/Linux and Windows.
- Reuse the shared CLI lifecycle UI: users review and confirm the command before it runs, then Claudian rechecks readiness afterward.
- Update the README to describe the complete lifecycle already provided by the settings UI: discovery, health checks, version information, install/update actions where supported, path repair, and post-action verification.

## Verification
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test`
- `pnpm run build`