### PR TITLE
Sync upstream engineering fixes (#1222 #1189 #1244 #1240 #1247 #1100)

### DIFF
--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -501,6 +501,7 @@ export class InputController {
     let shouldReportReviewableSettlement = false;
     let currentReviewableSettlementReporter: (() => void) | null = null;
     let didCancelThisTurn = false;
+    let hadExecutionError = false;
     let planApprovalInvalidated = false;
     let scheduledContinuation = false;
     let continuationStaysInCurrentController = false;
@@ -565,6 +566,7 @@ export class InputController {
         );
         wasInvalidated = true;
       } else if (result.status === 'error' && result.error) {
+        hadExecutionError = true;
         await streamController.appendText(`\n\n**Error:** ${result.error.message}`);
       }
     } catch (error) {
@@ -579,6 +581,7 @@ export class InputController {
         this.deps.onDiagnosticError?.(error);
         this.reportDeferredReviewableSettlement();
       } else {
+        hadExecutionError = true;
         shouldReportReviewableSettlement = true;
         const errorMsg = stringifyDiagnosticError(error);
         await streamController.appendText(`\n\n**Error:** ${errorMsg}`);
@@ -606,9 +609,9 @@ export class InputController {
             }
           }
           this.finishStreamingState(streamController);
-          // Capture response duration before resetting state (skip for interrupted responses and compaction)
+          // Capture response duration before resetting state (skip for interrupted responses, errors, and compaction)
           const hasCompactBoundary = finalAssistantMsg.contentBlocks?.some(b => b.type === 'context_compacted');
-          if (!didCancelThisTurn && !hasCompactBoundary) {
+          if (!didCancelThisTurn && !hadExecutionError && !hasCompactBoundary) {
             const durationSeconds = state.responseStartTime
               ? Math.floor((performance.now() - state.responseStartTime) / 1000)
               : 0;

--- a/src/providers/claude/execution/ClaudeInteractionHandler.ts
+++ b/src/providers/claude/execution/ClaudeInteractionHandler.ts
@@ -19,7 +19,7 @@ import {
   TOOL_EXIT_PLAN_MODE,
 } from '../../../core/tools/toolNames';
 import type { PermissionMode } from '../../../core/types/settings';
-import { buildPermissionUpdates } from '../security/ClaudePermissionUpdates';
+import { buildPersistentPermissionUpdates } from '../security/ClaudePermissionUpdates';
 
 export interface ClaudeExecutionInteractionDeps {
   readonly interactionPort: ProviderInteractionPort;
@@ -201,10 +201,9 @@ export class ClaudeInteractionHandler {
         return {
           behavior: 'allow',
           updatedInput: input,
-          updatedPermissions: buildPermissionUpdates(
+          updatedPermissions: buildPersistentPermissionUpdates(
             toolName,
             input,
-            decision,
             options.suggestions,
           ),
         };

--- a/src/providers/claude/modelTiers.ts
+++ b/src/providers/claude/modelTiers.ts
@@ -51,7 +51,7 @@ export const CLAUDE_MODEL_TIER_DEFINITIONS = [
   },
   {
     id: 'fable',
-    label: 'Fable 5 ($$$)',
+    label: 'Fable ($$$)',
     agentLabel: 'Fable',
     description: "Anthropic's most capable model — premium pricing above Opus",
     environmentKey: 'ANTHROPIC_DEFAULT_FABLE_MODEL',

--- a/src/providers/claude/security/ClaudePermissionUpdates.ts
+++ b/src/providers/claude/security/ClaudePermissionUpdates.ts
@@ -1,38 +1,29 @@
-import type { PermissionUpdate, PermissionUpdateDestination } from '@anthropic-ai/claude-agent-sdk';
+import type { PermissionUpdate } from '@anthropic-ai/claude-agent-sdk';
 
 import { getActionPattern } from '../../../core/security/approvalRules';
 
-export function buildPermissionUpdates(
+export function buildPersistentPermissionUpdates(
   toolName: string,
   input: Record<string, unknown>,
-  decision: 'allow' | 'allow-always',
   suggestions?: PermissionUpdate[]
 ): PermissionUpdate[] {
-  const destination: PermissionUpdateDestination =
-    decision === 'allow-always' ? 'projectSettings' : 'session';
-
   const processed: PermissionUpdate[] = [];
   let hasRuleUpdate = false;
 
   if (suggestions) {
     for (const suggestion of suggestions) {
       if (suggestion.type === 'addRules' || suggestion.type === 'replaceRules') {
-        if (decision === 'allow-always') {
-          const scopedRules = suggestion.rules.filter(hasNonEmptyRuleScope);
-          if (scopedRules.length === 0) {
-            continue;
-          }
-          hasRuleUpdate = true;
-          processed.push({
-            ...suggestion,
-            rules: scopedRules,
-            behavior: 'allow',
-            destination,
-          });
-        } else {
-          hasRuleUpdate = true;
-          processed.push({ ...suggestion, behavior: 'allow', destination });
+        const scopedRules = suggestion.rules.filter(hasNonEmptyRuleScope);
+        if (scopedRules.length === 0) {
+          continue;
         }
+        hasRuleUpdate = true;
+        processed.push({
+          ...suggestion,
+          rules: scopedRules,
+          behavior: 'allow',
+          destination: 'projectSettings',
+        });
       } else {
         processed.push(suggestion);
       }
@@ -41,7 +32,7 @@ export function buildPermissionUpdates(
 
   if (!hasRuleUpdate) {
     const pattern = getActionPattern(toolName, input);
-    if (decision === 'allow-always' && !isNonEmptyDerivedScope(pattern)) {
+    if (!isNonEmptyDerivedScope(pattern)) {
       return [];
     }
     const ruleValue: { toolName: string; ruleContent?: string } = { toolName };
@@ -53,7 +44,7 @@ export function buildPermissionUpdates(
       type: 'addRules',
       behavior: 'allow',
       rules: [ruleValue],
-      destination,
+      destination: 'projectSettings',
     });
   }
 

--- a/src/providers/codex/runtime/CodexBinaryLocator.ts
+++ b/src/providers/codex/runtime/CodexBinaryLocator.ts
@@ -60,6 +60,17 @@ export function findCodexBinaryPath(
     return userLocalBinary;
   }
 
+  // The unified ChatGPT desktop app bundles a codex CLI. Treat it as a
+  // legacy-location fallback (after user-local installs) but prefer it over
+  // generic PATH auto-detection so the bundled binary is not shadowed.
+  const unifiedAppBinary = findCodexBinaryInDirs(
+    getChatGptAppCodexDirs(platform),
+    platform,
+  );
+  if (unifiedAppBinary) {
+    return unifiedAppBinary;
+  }
+
   return findCliBinaryPath('codex', additionalPath, platform);
 }
 
@@ -107,6 +118,18 @@ function getUserLocalCodexBinaryDirs(platform: NodeJS.Platform): string[] {
   }
 
   return [path.join(getHomeDir(), '.local', 'bin')];
+}
+
+function getChatGptAppCodexDirs(platform: NodeJS.Platform): string[] {
+  if (platform !== 'darwin') {
+    return [];
+  }
+
+  const home = getHomeDir();
+  return [
+    path.join(home, 'Applications', 'ChatGPT.app', 'Contents', 'Resources'),
+    '/Applications/ChatGPT.app/Contents/Resources',
+  ];
 }
 
 function getHomeDir(): string {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -117,6 +117,7 @@ function getExtraBinaryPaths(): string[] {
 
     // User bin (if exists)
     if (home) {
+      paths.push(path.join(home, 'bin'));
       paths.push(path.join(home, '.local', 'bin'));
       paths.push(path.join(home, '.bun', 'bin'));
       paths.push(path.join(home, '.opencode', 'bin'));
@@ -156,6 +157,7 @@ function getExtraBinaryPaths(): string[] {
     }
 
     if (home) {
+      paths.push(path.join(home, 'bin'));
       paths.push(path.join(home, '.local', 'bin'));
       paths.push(path.join(home, '.bun', 'bin'));
       paths.push(path.join(home, '.opencode', 'bin'));

--- a/src/utils/imageEmbed.ts
+++ b/src/utils/imageEmbed.ts
@@ -10,6 +10,7 @@
 import type { App, TFile } from 'obsidian';
 
 import { escapeHtml } from './html';
+import { transformMarkdownSegments } from './markdownSegments';
 import { getVaultFileByPath } from './obsidianCompat';
 
 const IMAGE_EXTENSIONS = new Set([
@@ -117,23 +118,31 @@ export function replaceImageEmbedsWithHtml(
   // Reset lastIndex to avoid issues with global regex
   IMAGE_EMBED_PATTERN.lastIndex = 0;
 
-  return markdown.replace(
-    IMAGE_EMBED_PATTERN,
-    (match, imagePath: string, altText: string | undefined) => {
-      try {
-        if (!isImagePath(imagePath)) {
-          return match;
-        }
-
-        const file = resolveImageFile(app, imagePath, normalizedOptions);
-        if (!file) {
-          return createFallbackHtml(match);
-        }
-
-        return createImageHtml(app, file, altText);
-      } catch {
-        return createFallbackHtml(match);
+  return transformMarkdownSegments(markdown, {
+    wikilink: (wikilink, { embedded }) => {
+      if (!embedded) {
+        return wikilink;
       }
-    }
-  );
+
+      return wikilink.replace(
+        IMAGE_EMBED_PATTERN,
+        (match, imagePath: string, altText: string | undefined) => {
+          try {
+            if (!isImagePath(imagePath)) {
+              return match;
+            }
+
+            const file = resolveImageFile(app, imagePath, normalizedOptions);
+            if (!file) {
+              return createFallbackHtml(match);
+            }
+
+            return createImageHtml(app, file, altText);
+          } catch {
+            return createFallbackHtml(match);
+          }
+        }
+      );
+    },
+  });
 }

--- a/src/utils/markdownSegments.ts
+++ b/src/utils/markdownSegments.ts
@@ -33,11 +33,16 @@ interface MarkdownSegment {
   fence?: MarkdownFenceOpening;
   rawHtml?: boolean;
   sealed?: boolean;
+  wikilink?: MarkdownWikilink;
 }
 
 export interface MarkdownFenceOpening {
   info: string;
   infoStart: number;
+}
+
+export interface MarkdownWikilink {
+  embedded: boolean;
 }
 
 interface InlineContinuation {
@@ -262,6 +267,18 @@ function appendFenceOpeningSegment(
       infoStart,
     },
     sealed: true,
+  });
+}
+
+function appendWikilinkSegment(
+  segments: MarkdownSegment[],
+  text: string,
+  embedded: boolean,
+): void {
+  segments.push({
+    text,
+    transformable: false,
+    wikilink: { embedded },
   });
 }
 
@@ -554,14 +571,20 @@ function splitInlineMarkdown(
       continue;
     }
 
-    if (char === '[') {
-      const wikilinkEnd = findWikilinkEnd(line, index);
+    const embeddedWikilink = char === '!' && line.startsWith('![[', index);
+    if (embeddedWikilink || char === '[') {
+      const wikilinkStart = embeddedWikilink ? index + 1 : index;
+      const wikilinkEnd = findWikilinkEnd(line, wikilinkStart);
       if (wikilinkEnd !== null) {
         appendSegment(segments, line.slice(segmentStart, index), true);
-        appendSegment(segments, line.slice(index, wikilinkEnd + 1), false);
+        appendWikilinkSegment(
+          segments,
+          line.slice(index, wikilinkEnd + 1),
+          embeddedWikilink,
+        );
         segmentStart = wikilinkEnd + 1;
         index = wikilinkEnd;
-      } else if (!isBackslashEscaped(line, index)) {
+      } else if (char === '[' && !isBackslashEscaped(line, index)) {
         bracketDepth += 1;
       }
       continue;
@@ -836,6 +859,7 @@ interface MarkdownTransforms {
   fence?: (opener: string, fence: MarkdownFenceOpening) => string;
   text?: (text: string) => string;
   rawHtml?: (text: string) => string;
+  wikilink?: (wikilink: string, metadata: MarkdownWikilink) => string;
 }
 
 /** Applies targeted transforms while preserving protected Markdown syntax. */
@@ -847,6 +871,9 @@ export function transformMarkdownSegments(
     .map(segment => {
       if (segment.fence) {
         return transforms.fence?.(segment.text, segment.fence) ?? segment.text;
+      }
+      if (segment.wikilink) {
+        return transforms.wikilink?.(segment.text, segment.wikilink) ?? segment.text;
       }
       if (segment.rawHtml) {
         return transforms.rawHtml?.(segment.text) ?? segment.text;

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -131,7 +131,7 @@ function createFixture(overrides: Record<string, unknown> = {}) {
     renderer: {
       addMessage: jest.fn().mockImplementation(() => {
         const el = createMockEl();
-        el.querySelector = jest.fn().mockReturnValue(createMockEl());
+        el.createDiv({ cls: 'claudian-message-content' });
         return el;
       }),
       appendInterruptIndicator: jest.fn(),
@@ -1558,6 +1558,86 @@ describe('InputController coordinator execution', () => {
     await fixture.controller.sendMessage({ content: 'finish this' });
 
     expect(onReviewableSettlement).toHaveBeenCalledTimes(1);
+  });
+
+  it('stores and renders response duration footer on ordinary success when elapsed time exceeds one second', async () => {
+    let currentTime = 1000;
+    const nowSpy = jest.spyOn(performance, 'now').mockImplementation(() => currentTime);
+    try {
+      const fixture = createFixture();
+      fixture.coordinator.execute.mockImplementationOnce(async () => {
+        currentTime += 1500;
+        return { accepted: true, planCompleted: false, status: 'completed' };
+      });
+
+      await fixture.controller.sendMessage({ content: 'test request' });
+
+      const assistantMessage = fixture.state.messages[1];
+      expect(assistantMessage.durationSeconds).toBe(1);
+      expect(assistantMessage.durationFlavorWord).toBeDefined();
+
+      const assistantMsgEl = jest.mocked(fixture.deps.renderer.addMessage).mock.results.at(-1)?.value;
+      expect(assistantMsgEl?.querySelector('.claudian-response-footer')).not.toBeNull();
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('suppresses response duration and DOM footer on normalized execution errors when elapsed time exceeds one second', async () => {
+    let currentTime = 1000;
+    const nowSpy = jest.spyOn(performance, 'now').mockImplementation(() => currentTime);
+    try {
+      const fixture = createFixture();
+      fixture.coordinator.execute.mockImplementationOnce(async () => {
+        currentTime += 1500;
+        return {
+          accepted: true,
+          error: new Error('Model overloaded'),
+          planCompleted: false,
+          status: 'error',
+        };
+      });
+
+      await fixture.controller.sendMessage({ content: 'test request' });
+
+      expect(fixture.deps.streamController.appendText).toHaveBeenCalledWith(
+        '\n\n**Error:** Model overloaded',
+      );
+      const assistantMessage = fixture.state.messages[1];
+      expect(assistantMessage.durationSeconds).toBeUndefined();
+      expect(assistantMessage.durationFlavorWord).toBeUndefined();
+
+      const assistantMsgEl = jest.mocked(fixture.deps.renderer.addMessage).mock.results.at(-1)?.value;
+      expect(assistantMsgEl?.querySelector('.claudian-response-footer')).toBeNull();
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('suppresses response duration and DOM footer on catch-path rejections when elapsed time exceeds one second', async () => {
+    let currentTime = 1000;
+    const nowSpy = jest.spyOn(performance, 'now').mockImplementation(() => currentTime);
+    try {
+      const fixture = createFixture();
+      fixture.coordinator.execute.mockImplementationOnce(async () => {
+        currentTime += 1500;
+        throw new Error('stream failed');
+      });
+
+      await fixture.controller.sendMessage({ content: 'test request' });
+
+      expect(fixture.deps.streamController.appendText).toHaveBeenCalledWith(
+        '\n\n**Error:** stream failed',
+      );
+      const assistantMessage = fixture.state.messages[1];
+      expect(assistantMessage.durationSeconds).toBeUndefined();
+      expect(assistantMessage.durationFlavorWord).toBeUndefined();
+
+      const assistantMsgEl = jest.mocked(fixture.deps.renderer.addMessage).mock.results.at(-1)?.value;
+      expect(assistantMsgEl?.querySelector('.claudian-response-footer')).toBeNull();
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it('reports a terminal accepted error as reviewable', async () => {

--- a/tests/unit/providers/claude/execution/ClaudeInteractionHandler.test.ts
+++ b/tests/unit/providers/claude/execution/ClaudeInteractionHandler.test.ts
@@ -108,6 +108,33 @@ describe('createClaudeExecutionCanUseTool', () => {
       });
   });
 
+  it('does not persist provider suggestions for an allow-once decision', async () => {
+    const port = createPort();
+    port.requestApproval.mockResolvedValue({
+      interactionId: 'claude:session-local:native-tool-1',
+      decision: 'allow',
+    });
+    const handler = createHandler(port);
+    const input = { command: 'ls /external/path' };
+    const suggestions = [{
+      type: 'addRules' as const,
+      behavior: 'allow' as const,
+      rules: [{ toolName: 'Bash', ruleContent: 'ls *' }],
+      destination: 'session' as const,
+    }];
+
+    const result = await handler('Bash', input, {
+      ...nativeOptions,
+      suggestions,
+    });
+
+    expect(result).toEqual({
+      behavior: 'allow',
+      updatedInput: input,
+    });
+    expect(result && 'updatedPermissions' in result).toBe(false);
+  });
+
   it('routes direct edits outside the vault through the approval flow', async () => {
     const port = createPort();
     const handler = createHandler(port, jest.fn(), '/vault');

--- a/tests/unit/providers/claude/security/ClaudePermissionUpdates.test.ts
+++ b/tests/unit/providers/claude/security/ClaudePermissionUpdates.test.ts
@@ -1,19 +1,14 @@
-import { buildPermissionUpdates } from '@/providers/claude/security/ClaudePermissionUpdates';
+import { buildPersistentPermissionUpdates } from '@/providers/claude/security/ClaudePermissionUpdates';
 
-describe('buildPermissionUpdates', () => {
-  it('constructs allow rule for allow decision', () => {
-    const updates = buildPermissionUpdates('Bash', { command: 'git status' }, 'allow');
+describe('buildPersistentPermissionUpdates', () => {
+  it('constructs a project allow rule from the action', () => {
+    const updates = buildPersistentPermissionUpdates('Bash', { command: 'git status' });
     expect(updates).toEqual([{
       type: 'addRules',
       behavior: 'allow',
       rules: [{ toolName: 'Bash', ruleContent: 'git status' }],
-      destination: 'session',
+      destination: 'projectSettings',
     }]);
-  });
-
-  it('uses projectSettings destination for always decisions', () => {
-    const updates = buildPermissionUpdates('Bash', { command: 'git status' }, 'allow-always');
-    expect(updates[0].destination).toBe('projectSettings');
   });
 
   it('uses SDK suggestions when available', () => {
@@ -23,7 +18,7 @@ describe('buildPermissionUpdates', () => {
       rules: [{ toolName: 'Bash', ruleContent: 'git *' }],
       destination: 'session' as const,
     }];
-    const updates = buildPermissionUpdates('Bash', { command: 'git status' }, 'allow-always', suggestions);
+    const updates = buildPersistentPermissionUpdates('Bash', { command: 'git status' }, suggestions);
     expect(updates).toEqual([{
       type: 'addRules',
       behavior: 'allow',
@@ -33,23 +28,17 @@ describe('buildPermissionUpdates', () => {
   });
 
   it('falls back to constructed rule when no addRules suggestions', () => {
-    const updates = buildPermissionUpdates('Bash', { command: 'ls' }, 'allow', []);
+    const updates = buildPersistentPermissionUpdates('Bash', { command: 'ls' }, []);
     expect(updates).toEqual([{
       type: 'addRules',
       behavior: 'allow',
       rules: [{ toolName: 'Bash', ruleContent: 'ls' }],
-      destination: 'session',
+      destination: 'projectSettings',
     }]);
   });
 
-  it('omits ruleContent when pattern is null (missing file_path)', () => {
-    const updates = buildPermissionUpdates('Read', {}, 'allow');
-    expect(updates).toEqual([{
-      type: 'addRules',
-      behavior: 'allow',
-      rules: [{ toolName: 'Read' }],
-      destination: 'session',
-    }]);
+  it('does not persist an unscoped fallback rule', () => {
+    expect(buildPersistentPermissionUpdates('Read', {})).toEqual([]);
   });
 
   it('includes addDirectories suggestions without overriding destination', () => {
@@ -66,7 +55,7 @@ describe('buildPermissionUpdates', () => {
         destination: 'session' as const,
       },
     ];
-    const updates = buildPermissionUpdates('Read', { file_path: '/external/path/file.md' }, 'allow-always', suggestions);
+    const updates = buildPersistentPermissionUpdates('Read', { file_path: '/external/path/file.md' }, suggestions);
     expect(updates).toHaveLength(2);
     expect(updates[0]).toEqual({
       type: 'addRules',
@@ -89,7 +78,7 @@ describe('buildPermissionUpdates', () => {
         destination: 'session' as const,
       },
     ];
-    const updates = buildPermissionUpdates('Bash', { command: 'ls' }, 'allow-always', suggestions);
+    const updates = buildPersistentPermissionUpdates('Bash', { command: 'ls' }, suggestions);
     expect(updates).toHaveLength(2);
     expect(updates[0]).toEqual({
       type: 'addRules',
@@ -112,7 +101,7 @@ describe('buildPermissionUpdates', () => {
         destination: 'session' as const,
       },
     ];
-    const updates = buildPermissionUpdates('Bash', { command: 'echo hi' }, 'allow-always', suggestions);
+    const updates = buildPersistentPermissionUpdates('Bash', { command: 'echo hi' }, suggestions);
     expect(updates).toHaveLength(2);
     expect(updates[0]).toEqual({
       type: 'addRules',
@@ -135,7 +124,7 @@ describe('buildPermissionUpdates', () => {
         destination: 'session' as const,
       },
     ];
-    const updates = buildPermissionUpdates('Read', { file_path: '/new/dir/file.md' }, 'allow', suggestions);
+    const updates = buildPersistentPermissionUpdates('Read', { file_path: '/new/dir/file.md' }, suggestions);
     expect(updates).toHaveLength(2);
     expect(updates[0].type).toBe('addRules');
     expect(updates[1].type).toBe('addDirectories');
@@ -150,7 +139,7 @@ describe('buildPermissionUpdates', () => {
         destination: 'session' as const,
       },
     ];
-    const updates = buildPermissionUpdates('Bash', { command: 'git status' }, 'allow-always', suggestions);
+    const updates = buildPersistentPermissionUpdates('Bash', { command: 'git status' }, suggestions);
     expect(updates).toHaveLength(1);
     expect(updates[0]).toEqual({
       type: 'replaceRules',
@@ -169,13 +158,13 @@ describe('buildPermissionUpdates', () => {
         destination: 'session' as const,
       },
     ];
-    const updates = buildPermissionUpdates('Bash', { command: 'git status' }, 'allow', suggestions);
+    const updates = buildPersistentPermissionUpdates('Bash', { command: 'git status' }, suggestions);
     expect(updates).toHaveLength(2);
     expect(updates[0].type).toBe('addRules');
     expect(updates[0]).toMatchObject({
       behavior: 'allow',
       rules: [{ toolName: 'Bash', ruleContent: 'git status' }],
-      destination: 'session',
+      destination: 'projectSettings',
     });
     expect(updates[1].type).toBe('removeRules');
   });
@@ -189,7 +178,7 @@ describe('buildPermissionUpdates', () => {
         destination: 'session' as const,
       },
     ];
-    const updates = buildPermissionUpdates('Bash', { command: 'git status' }, 'allow-always', suggestions);
+    const updates = buildPersistentPermissionUpdates('Bash', { command: 'git status' }, suggestions);
     const removeEntry = updates.find(u => u.type === 'removeRules');
     expect(removeEntry).toBeDefined();
     expect(removeEntry!.behavior).toBe('deny');
@@ -197,9 +186,9 @@ describe('buildPermissionUpdates', () => {
   });
 
   it('returns no persistent update when neither suggestions nor fallback have a non-empty scope', () => {
-    expect(buildPermissionUpdates('Read', {}, 'allow-always')).toEqual([]);
-    expect(buildPermissionUpdates('Bash', { command: '   ' }, 'allow-always')).toEqual([]);
-    expect(buildPermissionUpdates('UnknownTool', {}, 'allow-always')).toEqual([]);
+    expect(buildPersistentPermissionUpdates('Read', {})).toEqual([]);
+    expect(buildPersistentPermissionUpdates('Bash', { command: '   ' })).toEqual([]);
+    expect(buildPersistentPermissionUpdates('UnknownTool', {})).toEqual([]);
   });
 
   it('ignores whitespace-only suggested scopes for persistent approval', () => {
@@ -210,7 +199,7 @@ describe('buildPermissionUpdates', () => {
       destination: 'session' as const,
     }];
 
-    expect(buildPermissionUpdates('Read', {}, 'allow-always', suggestions)).toEqual([]);
+    expect(buildPersistentPermissionUpdates('Read', {}, suggestions)).toEqual([]);
   });
 
   it('preserves the exact non-empty provider suggestion for persistent approval', () => {
@@ -221,7 +210,7 @@ describe('buildPermissionUpdates', () => {
       destination: 'session' as const,
     }];
 
-    expect(buildPermissionUpdates('Bash', {}, 'allow-always', suggestions)).toEqual([{
+    expect(buildPersistentPermissionUpdates('Bash', {}, suggestions)).toEqual([{
       type: 'addRules',
       behavior: 'allow',
       rules: [{ toolName: 'Bash', ruleContent: 'git *' }],

--- a/tests/unit/providers/codex/runtime/CodexBinaryLocator.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexBinaryLocator.test.ts
@@ -74,6 +74,44 @@ describe('CodexBinaryLocator', () => {
 
     expect(findCodexBinaryPath(explicitDir, 'darwin')).toBe(explicitBinary);
   });
+
+  it('prefers the macOS Codex app bundle over the unified ChatGPT app fallback', () => {
+    process.env.HOME = tempDir;
+    const codexAppDir = path.join(tempDir, 'Applications', 'Codex.app', 'Contents', 'Resources');
+    const chatGptAppDir = path.join(tempDir, 'Applications', 'ChatGPT.app', 'Contents', 'Resources');
+    const appBinary = path.join(codexAppDir, 'codex');
+    fs.mkdirSync(codexAppDir, { recursive: true });
+    fs.mkdirSync(chatGptAppDir, { recursive: true });
+    fs.writeFileSync(appBinary, '');
+    fs.writeFileSync(path.join(chatGptAppDir, 'codex'), '');
+
+    expect(findCodexBinaryPath('', 'darwin')).toBe(appBinary);
+  });
+
+  it('falls back to the unified macOS ChatGPT app bundle', () => {
+    process.env.HOME = tempDir;
+    process.env.PATH = '';
+    const appDir = path.join(tempDir, 'Applications', 'ChatGPT.app', 'Contents', 'Resources');
+    const appBinary = path.join(appDir, 'codex');
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(appBinary, '');
+
+    expect(findCodexBinaryPath('', 'darwin')).toBe(appBinary);
+  });
+
+  it('prefers a user-local Codex binary over the ChatGPT app fallback', () => {
+    process.env.HOME = tempDir;
+    process.env.PATH = '';
+    const localDir = path.join(tempDir, '.local', 'bin');
+    const localBinary = path.join(localDir, 'codex');
+    const appDir = path.join(tempDir, 'Applications', 'ChatGPT.app', 'Contents', 'Resources');
+    fs.mkdirSync(localDir, { recursive: true });
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(localBinary, '');
+    fs.writeFileSync(path.join(appDir, 'codex'), '');
+
+    expect(findCodexBinaryPath('', 'darwin')).toBe(localBinary);
+  });
   });
 
   it('prefers the current process PATH before a user-local Codex binary', () => {

--- a/tests/unit/utils/env.test.ts
+++ b/tests/unit/utils/env.test.ts
@@ -252,6 +252,14 @@ describe('getEnhancedPath', () => {
 
       expect(segments).toContain(path.join('/mock/home', '.opencode', 'bin'));
     });
+
+    it('includes the user bin path from HOME', () => {
+      process.env.HOME = '/mock/home';
+      const result = getEnhancedPath();
+      const segments = result.split(SEP);
+
+      expect(segments).toContain(path.join('/mock/home', 'bin'));
+    });
   });
 
   describe('Unix environment variable paths', () => {

--- a/tests/unit/utils/imageEmbed.test.ts
+++ b/tests/unit/utils/imageEmbed.test.ts
@@ -68,6 +68,67 @@ describe('replaceImageEmbedsWithHtml', () => {
       expect(result).toContain('image');
       expect(result).toContain('<img');
     });
+
+    it('replaces image embeds in text but preserves image embed syntax in inline code', () => {
+      const app = createMockApp(new Map([
+        ['visible.png', 'app://local/visible.png'],
+        ['literal.png', 'app://local/literal.png'],
+      ]));
+
+      const result = replaceImageEmbedsWithHtml(
+        'Visible ![[visible.png]] and `literal ![[literal.png]]`',
+        app
+      );
+
+      expect(result).toBe(
+        'Visible <span class="claudian-embedded-image"><img src="app://local/visible.png" alt="visible" loading="lazy"></span> and `literal ![[literal.png]]`'
+      );
+    });
+  });
+
+  describe('code syntax', () => {
+    it('preserves image embed syntax in backtick and tilde fences', () => {
+      const app = createMockApp(new Map([
+        ['visible.png', 'app://local/visible.png'],
+        ['backtick.png', 'app://local/backtick.png'],
+        ['tilde.png', 'app://local/tilde.png'],
+      ]));
+      const markdown = [
+        '![[visible.png]]',
+        '',
+        '```md',
+        '![[backtick.png]]',
+        '```',
+        '',
+        '~~~md',
+        '![[tilde.png]]',
+        '~~~',
+      ].join('\n');
+
+      const result = replaceImageEmbedsWithHtml(markdown, app);
+
+      expect(result).toContain('src="app://local/visible.png"');
+      expect(result).toContain('```md\n![[backtick.png]]\n```');
+      expect(result).toContain('~~~md\n![[tilde.png]]\n~~~');
+      expect(result).not.toContain('src="app://local/backtick.png"');
+      expect(result).not.toContain('src="app://local/tilde.png"');
+    });
+
+    it('preserves image embed syntax in indented code', () => {
+      const app = createMockApp(new Map([
+        ['visible.png', 'app://local/visible.png'],
+        ['literal.png', 'app://local/literal.png'],
+      ]));
+
+      const result = replaceImageEmbedsWithHtml(
+        '![[visible.png]]\n\n    ![[literal.png]]',
+        app
+      );
+
+      expect(result).toContain('src="app://local/visible.png"');
+      expect(result).toContain('\n\n    ![[literal.png]]');
+      expect(result).not.toContain('src="app://local/literal.png"');
+    });
   });
 
   describe('alt text and dimensions', () => {


### PR DESCRIPTION
## Summary

Ports six upstream Claudian engineering fixes (security/portability/regression) from `YishenTu/claudian`, each as a focused commit with mirrored tests. No product-direction or collaboration/hosted/LAN features are imported.

## Fixes

| PR | Commit | Description |
| --- | --- | --- |
| #1222 | `8dfaf92c` | Include `~/bin` in extra binary search paths on Windows and Unix (CLIs installed to `~/bin` were missed under Obsidian's minimal PATH) |
| #1189 | `ff2abb17` | Suppress response-duration footer on execution errors / catch-path rejections (was showing misleading elapsed time) |
| #1244 | `159b5a2d` | Detect codex CLI bundled in the unified ChatGPT macOS app — fallback after user-local, before generic detection; OMC's runtime-PATH precedence preserved |
| #1240 | `69339674` | Drop version from the Fable tier label (`Fable 5` → `Fable`) to match other family labels |
| #1247 | `5c3fba37` | Preserve image embeds inside inline code, fenced blocks, and indented code (route replacement through `transformMarkdownSegments`) |
| #1100 | `95623d6d` + `082ca708` | Keep allow-once approvals invocation-scoped — handler was already safe; added regression test and renamed `buildPermissionUpdates` → `buildPersistentPermissionUpdates` so allow-once→session persistence is unrepresentable |

## Verification

- `pnpm run typecheck` passed
- `pnpm run lint` 0 errors
- `pnpm run test` 7145 tests / 420 suites passed
- `pnpm run build` passed (esbuild compiles cleanly; vault copy skipped in sandbox)
