### PR TITLE
chore(style): remove dead sidebar footer height variable

### DIFF
--- a/src/style/components/history.css
+++ b/src/style/components/history.css
@@ -3,8 +3,6 @@
 }
 
 .claudian-session-sidebar {
-  --claudian-sidebar-surface-footer-height: 40px;
-
   position: relative;
   display: none;
   flex: 0 0 var(--claudian-session-sidebar-width, 240px);

--- a/tests/unit/style/components/history.test.ts
+++ b/tests/unit/style/components/history.test.ts
@@ -5,9 +5,7 @@ describe('Session history styles', () => {
   it('keeps the sidebar surface switcher visible at the top', () => {
     const css = readFileSync(path.resolve('src/style/components/history.css'), 'utf8');
 
-    expect(css).toMatch(
-      /\.claudian-session-sidebar\s*{[^}]*--claudian-sidebar-surface-footer-height:\s*40px;/,
-    );
+    expect(css).not.toMatch(/--claudian-sidebar-surface-footer-height:/);
     expect(css).toMatch(
       /\.claudian-sidebar-surface-switcher\s*{[^}]*position:\s*relative;[^}]*flex:\s*0 0 auto;[^}]*background:\s*var\(--background-primary\);/,
     );


### PR DESCRIPTION
## Summary

Removes the dead `--claudian-sidebar-surface-footer-height` CSS variable from `history.css`.

The variable has had no consumers since the sidebar surface switcher became an in-flow top header (PR #53, commit `7ca78e49`). It was a leftover from the old absolute-positioned hover-reveal footer that both Oh My Claudian and upstream #1081 removed.

## Changes

- `src/style/components/history.css` — drop the `--claudian-sidebar-surface-footer-height: 40px` declaration
- `tests/unit/style/components/history.test.ts` — replace the assertion that the variable exists with an absence check, so the dead variable cannot silently return

## Verification

- `npx jest tests/unit/style/` — 8 suites / 20 tests passed
- eslint clean on the changed test file
- `node scripts/build-css.mjs` regenerates `styles.css` without the variable (not tracked)
