### PR TITLE
fix: sync upstream 2.2.6 polish fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,9 +69,16 @@
     "@babel/core": "7.29.7",
     "@hono/node-server": "2.0.11",
     "body-parser": "2.3.0",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.6",
     "hono": "4.12.34",
     "ip-address": "10.3.1",
-    "js-yaml": "4.3.1"
+    "js-yaml": "4.3.1",
+    "qs": "6.16.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "fast-uri": "3.1.6",
+      "qs": "6.16.0"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-uri: 3.1.6
+  qs: 6.16.0
+
 importers:
 
   .:
@@ -1724,8 +1728,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
@@ -2633,8 +2637,8 @@ packages:
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   range-parser@1.3.0:
@@ -4313,7 +4317,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4481,7 +4485,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -5148,7 +5152,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.3.0
       router: 2.2.0
       send: 1.2.1
@@ -5167,7 +5171,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fb-watchman@2.0.2:
     dependencies:
@@ -6270,7 +6274,7 @@ snapshots:
 
   pure-rand@7.0.1: {}
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1

--- a/src/features/chat/ui/ComposerContextTray.ts
+++ b/src/features/chat/ui/ComposerContextTray.ts
@@ -210,6 +210,7 @@ export class ComposerContextTray {
     contentEl.createSpan({ cls: 'claudian-context-chip-label', text: item.label });
 
     if (item.onRemove) {
+      chipEl.addClass('claudian-context-chip--removable');
       const removeButton = chipEl.createEl('button', {
         cls: 'claudian-context-chip-remove',
         text: '\u00D7',

--- a/src/providers/pi/runtime/PiCliMetadata.ts
+++ b/src/providers/pi/runtime/PiCliMetadata.ts
@@ -5,7 +5,8 @@ export const piCliMetadata: CliProviderMetadata = {
   displayName: 'Pi',
   // Package migrated from @mariozechner/pi-coding-agent (last published
   // 0.73.1) to @earendil-works/pi-coding-agent. The registry name drives the
-  // latest-version probe AND the npm install/update commands, so both must
-  // point at the current package. Keep PiSubprocess's PI_PACKAGE_NAME in sync.
+  // latest-version probe and the npm install command, so it must point at
+  // the current package. Keep PiSubprocess's PI_PACKAGE_NAME in sync.
   npmPackage: '@earendil-works/pi-coding-agent',
+  update: { command: 'pi', args: ['update'] },
 };

--- a/src/style/components/code.css
+++ b/src/style/components/code.css
@@ -70,6 +70,15 @@ body.theme-light .claudian-message-content pre {
   font-size: 13px;
 }
 
+.claudian-container .claudian-message-content :not(pre) > code {
+  background-color: var(--code-background, var(--background-secondary));
+  color: var(--code-normal, var(--text-normal));
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+
 /* Clickable language label - positioned outside scroll area */
 .claudian-code-wrapper .claudian-code-lang-label {
   position: absolute;

--- a/src/style/components/context-tray.css
+++ b/src/style/components/context-tray.css
@@ -78,6 +78,10 @@
   background: var(--background-modifier-hover);
 }
 
+.claudian-context-chip--file:not(.claudian-context-chip--removable) {
+  padding-right: 10px;
+}
+
 .claudian-context-chip-main {
   display: flex;
   align-items: center;

--- a/src/style/components/messages.css
+++ b/src/style/components/messages.css
@@ -89,6 +89,11 @@
   text-align: start;
 }
 
+body.mod-windows .claudian-message-assistant {
+  content-visibility: visible;
+  contain-intrinsic-size: none;
+}
+
 .claudian-message-content {
   line-height: 1.5;
   user-select: text;

--- a/tests/unit/core/providers/cli/CliProviderMetadata.test.ts
+++ b/tests/unit/core/providers/cli/CliProviderMetadata.test.ts
@@ -7,6 +7,7 @@ import {
 import { cursorCliMetadata } from '@/providers/cursor/runtime/CursorCliMetadata';
 import { grokCliMetadata } from '@/providers/grok/runtime/GrokCliMetadata';
 import { ompCliMetadata } from '@/providers/omp/runtime/OmpCliMetadata';
+import { piCliMetadata } from '@/providers/pi/runtime/PiCliMetadata';
 
 const baseMetadata: CliProviderMetadata = {
   binaryName: 'claude',
@@ -59,6 +60,10 @@ describe('resolveCliInstallCommand', () => {
 });
 
 describe('resolveCliUpdateCommand', () => {
+  it('uses Pi native self-update instead of the npm fallback', () => {
+    expect(resolveCliUpdateCommand(piCliMetadata)).toEqual({ command: 'pi', args: ['update'] });
+  });
+
   it('falls back to npm install -g @latest when only an npm package is known', () => {
     expect(resolveCliUpdateCommand({ ...baseMetadata, npmPackage: '@openai/codex' }))
       .toEqual({ command: 'npm', args: ['install', '-g', '@openai/codex@latest'] });

--- a/tests/unit/features/chat/ui/ComposerContextTray.test.ts
+++ b/tests/unit/features/chat/ui/ComposerContextTray.test.ts
@@ -7,6 +7,19 @@ jest.mock('obsidian', () => ({
 }));
 
 describe('ComposerContextTray', () => {
+  it('marks a chip as removable only while its removal action is available', () => {
+    const containerEl = createMockEl();
+    const tray = new ComposerContextTray(containerEl as unknown as HTMLElement);
+    const item = { id: 'linked-content', kind: 'file' as const, label: 'Draft.md' };
+
+    tray.setItems('files', [{ ...item, onRemove: jest.fn() }]);
+    expect(containerEl.querySelector('.claudian-context-chip')?.hasClass('claudian-context-chip--removable')).toBe(true);
+
+    tray.setItems('files', [item]);
+    expect(containerEl.querySelector('.claudian-context-chip')?.hasClass('claudian-context-chip--removable')).toBe(false);
+    tray.destroy();
+  });
+
   it('owns empty-state visibility and renders slots in semantic order', () => {
     const containerEl = createMockEl();
     const tray = new ComposerContextTray(containerEl as unknown as HTMLElement);

--- a/tests/unit/providers/codex/runtime/CodexLaunchSpecBuilder.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexLaunchSpecBuilder.test.ts
@@ -1,6 +1,22 @@
+import type * as ChildProcess from 'child_process';
+
 import { buildCodexLaunchSpec } from '@/providers/codex/runtime/CodexLaunchSpecBuilder';
 
+const childProcess = jest.requireActual<typeof ChildProcess>('child_process');
+
 describe('buildCodexLaunchSpec', () => {
+  let execFileSyncSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    execFileSyncSpy = jest.spyOn(childProcess, 'execFileSync').mockImplementation(() => {
+      throw Object.assign(new Error('spawnSync wsl.exe ENOENT'), { code: 'ENOENT' });
+    });
+  });
+
+  afterEach(() => {
+    execFileSyncSpy.mockRestore();
+  });
+
   it('builds a native Windows launch spec with a direct codex executable', () => {
     const spec = buildCodexLaunchSpec({
       settings: {
@@ -93,6 +109,26 @@ describe('buildCodexLaunchSpec', () => {
     expect(spec.pathMapper.toHostPath('/home/user/.codex/sessions')).toBe(
       '\\\\wsl$\\Ubuntu\\home\\user\\.codex\\sessions',
     );
+  });
+
+  it('uses the native WSL default when the injected resolver returns no distro', () => {
+    execFileSyncSpy.mockReturnValue(Buffer.from(
+      '  NAME              STATE           VERSION\r\n'
+      + '* Ubuntu-24.04      Running         2\r\n'
+      + '  Debian            Stopped         2\r\n',
+      'utf16le',
+    ));
+
+    const spec = buildCodexLaunchSpec({
+      settings: { providerConfigs: { codex: { installationMethod: 'wsl' } } },
+      resolvedCliCommand: 'codex',
+      hostVaultPath: 'C:\\repo',
+      env: {},
+      hostPlatform: 'win32',
+      resolveDefaultWslDistro: () => undefined,
+    });
+
+    expect(spec.target.distroName).toBe('Ubuntu-24.04');
   });
 
   it('fails fast when the workspace path cannot be represented inside WSL', () => {

--- a/tests/unit/style/components/code.test.ts
+++ b/tests/unit/style/components/code.test.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+describe('Chat code styles', () => {
+  it('gives inline code a readable surface without styling code inside a block', () => {
+    const css = readFileSync(path.resolve('src/style/components/code.css'), 'utf8');
+
+    expect(css).toMatch(/\.claudian-container \.claudian-message-content :not\(pre\) > code\s*{[\s\S]*background-color:\s*var\(--code-background, var\(--background-secondary\)\);[\s\S]*padding:\s*0\.1em 0\.35em;/);
+  });
+});

--- a/tests/unit/style/components/messages.test.ts
+++ b/tests/unit/style/components/messages.test.ts
@@ -33,4 +33,10 @@ describe('Message styles', () => {
     expect(assistantRule).toContain('content-visibility: auto;');
     expect(assistantRule).toContain('contain-intrinsic-size: auto 23.5rem;');
   });
+
+  it('disables assistant layout isolation on Windows only', () => {
+    const css = readFileSync(path.resolve('src/style/components/messages.css'), 'utf8');
+
+    expect(css).toMatch(/body\.mod-windows \.claudian-message-assistant\s*{[^}]*content-visibility:\s*visible;[^}]*contain-intrinsic-size:\s*none;/);
+  });
 });


### PR DESCRIPTION
## Summary
- adapt the context tray removable state without CSS :has()
- fix Windows assistant message layout isolation and inline code styling
- add Codex WSL launch-spec test isolation
- update fast-uri and qs security overrides for pnpm

## Verification
- pnpm run typecheck
- pnpm run lint (existing warnings only)
- pnpm run test
- pnpm run build