### PR TITLE
fix: honor custom context limits

### DIFF
--- a/src/core/providers/modelSelection.ts
+++ b/src/core/providers/modelSelection.ts
@@ -72,3 +72,21 @@ export function toProviderRuntimeModelId(
   const decoded = decodeProviderModelSelectionId(value);
   return decoded && decoded.providerId === providerId ? decoded.modelId : value;
 }
+
+/** Resolves a user-defined limit whether it was stored under a raw or namespaced model id. */
+export function resolveProviderCustomContextLimit(
+  providerId: ProviderId,
+  model: string,
+  customLimits?: Record<string, number>,
+): number | undefined {
+  if (!customLimits) return undefined;
+
+  const selectedModel = model.trim();
+  const runtimeModel = toProviderRuntimeModelId(providerId, selectedModel).trim();
+  const namespacedModel = encodeProviderModelSelectionId(providerId, runtimeModel);
+  for (const candidate of new Set([selectedModel, runtimeModel, namespacedModel])) {
+    const limit = customLimits[candidate];
+    if (Number.isFinite(limit) && limit > 0) return limit;
+  }
+  return undefined;
+}

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -7,6 +7,7 @@ import {
   getProviderSettingsSnapshotWithModel,
   resolveConversationModel,
 } from '../../core/providers/conversationModel';
+import { resolveProviderCustomContextLimit } from '../../core/providers/modelSelection';
 import { ProviderRegistry } from '../../core/providers/ProviderRegistry';
 import { ProviderSettingsCoordinator } from '../../core/providers/ProviderSettingsCoordinator';
 import { type AppTabManagerState, DEFAULT_CHAT_PROVIDER_ID, type ProviderId } from '../../core/providers/types';
@@ -202,7 +203,16 @@ export class ClaudianView extends ItemView {
       );
 
       if (tab.state.usage) {
-        tab.state.usage = recalculateUsageForModel(tab.state.usage, model, contextWindow);
+        tab.state.usage = recalculateUsageForModel(
+          tab.state.usage,
+          model,
+          contextWindow,
+          resolveProviderCustomContextLimit(
+            providerId,
+            model,
+            providerSettings.customContextLimits,
+          ),
+        );
       }
 
       tab.ui.modelSelector?.updateDisplay();

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -4,6 +4,7 @@ import type {
   ChatRewindConflict,
   ChatRewindMode,
 } from '../../../core/execution';
+import { resolveProviderCustomContextLimit } from '../../../core/providers/modelSelection';
 import type { ProviderIconSvg, TitleGenerationService } from '../../../core/providers/types';
 import type {
   ChatMessage,
@@ -42,6 +43,7 @@ import type { ImageContextManager } from '../ui/ImageContext';
 import type { ExternalContextSelector, McpServerSelector } from '../ui/InputToolbar';
 import type { ScopePreview } from '../ui/ScopePreview';
 import type { StatusPanel } from '../ui/StatusPanel';
+import { recalculateUsageForModel } from '../utils/usageInfo';
 
 function runConversationAction(action: () => Promise<void>, failureMessage: string): void {
   void action().catch(() => {
@@ -661,7 +663,23 @@ export class ConversationController {
 
     state.currentConversationId = conversation.id;
     state.messages = [...conversation.messages];
-    state.usage = conversation.usage ?? null;
+    const persistedUsage = conversation.usage ?? null;
+    const usageModel = conversation.selectedModel ?? persistedUsage?.model;
+    const customContextLimit = usageModel
+      ? resolveProviderCustomContextLimit(
+          conversation.providerId,
+          usageModel,
+          plugin.settings.customContextLimits,
+        )
+      : undefined;
+    state.usage = persistedUsage && usageModel && customContextLimit
+      ? recalculateUsageForModel(
+          persistedUsage,
+          usageModel,
+          customContextLimit,
+          customContextLimit,
+        )
+      : persistedUsage;
     state.autoScrollEnabled = plugin.settings.enableAutoScroll ?? true;
     state.hasPendingConversationSave = false;
 

--- a/src/features/chat/controllers/StreamController.ts
+++ b/src/features/chat/controllers/StreamController.ts
@@ -5,6 +5,7 @@ import type {
   ProviderExecutionEvent,
 } from '../../../core/execution';
 import { resolveConversationModel } from '../../../core/providers/conversationModel';
+import { resolveProviderCustomContextLimit } from '../../../core/providers/modelSelection';
 import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import {
@@ -81,6 +82,7 @@ import type { SubagentManager } from '../services/SubagentManager';
 import type { AsyncSubagentCompletion } from '../services/SubagentManager';
 import type { ChatState } from '../state/ChatState';
 import type { FileContextManager } from '../ui/FileContext';
+import { recalculateUsageForModel } from '../utils/usageInfo';
 import { StreamingRenderCoordinator } from './StreamingRenderCoordinator';
 
 export interface StreamControllerDeps {
@@ -332,9 +334,24 @@ export class StreamController {
     if (state.ignoreUsageUpdates) return;
 
     const activeModel = this.getActiveProviderModel();
-    const nextUsage = activeModel && !usage.model
+    const reportedUsage = activeModel && !usage.model
       ? { ...usage, model: activeModel }
       : usage;
+    const customContextLimit = activeModel
+      ? resolveProviderCustomContextLimit(
+          this.getActiveProviderId(),
+          activeModel,
+          this.deps.plugin.settings.customContextLimits,
+        )
+      : undefined;
+    const nextUsage = activeModel && customContextLimit
+      ? recalculateUsageForModel(
+          reportedUsage,
+          activeModel,
+          customContextLimit,
+          customContextLimit,
+        )
+      : reportedUsage;
     const previousHighest = this.highestContextUsage;
     const isSameContext = previousHighest
       && previousHighest.model === nextUsage.model

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -17,6 +17,7 @@ import {
   resolveNewConversationModel,
 } from '../../../core/providers/conversationModel';
 import { getEnabledProviderForModel, getProviderForModel } from '../../../core/providers/modelRouting';
+import { resolveProviderCustomContextLimit } from '../../../core/providers/modelSelection';
 import {
   createProviderDiagnosticError,
   createProviderDiagnosticReport,
@@ -1342,7 +1343,16 @@ function initializeInputToolbar(
           providerSettings.customContextLimits,
           providerSettings,
         );
-        tab.state.usage = recalculateUsageForModel(currentUsage, normalizedModel, newContextWindow);
+        tab.state.usage = recalculateUsageForModel(
+          currentUsage,
+          normalizedModel,
+          newContextWindow,
+          resolveProviderCustomContextLimit(
+            boundProvider,
+            normalizedModel,
+            providerSettings.customContextLimits,
+          ),
+        );
       }
     },
     onModeChange: async (mode: string) => {

--- a/src/features/chat/utils/usageInfo.ts
+++ b/src/features/chat/utils/usageInfo.ts
@@ -10,11 +10,18 @@ export function recalculateUsageForModel(
   usage: UsageInfo,
   model: string,
   fallbackContextWindow: number,
+  explicitContextWindow?: number,
 ): UsageInfo {
-  const preserveAuthoritativeWindow = usage.contextWindowIsAuthoritative === true
+  const validExplicitContextWindow = Number.isFinite(explicitContextWindow)
+    && explicitContextWindow! > 0
+    ? explicitContextWindow
+    : undefined;
+  const preserveAuthoritativeWindow = validExplicitContextWindow === undefined
+    && usage.contextWindowIsAuthoritative === true
     && usage.contextWindow > 0
     && usage.model === model;
-  const contextWindow = preserveAuthoritativeWindow ? usage.contextWindow : fallbackContextWindow;
+  const contextWindow = validExplicitContextWindow
+    ?? (preserveAuthoritativeWindow ? usage.contextWindow : fallbackContextWindow);
 
   return {
     ...usage,

--- a/src/features/settings/ClaudianSettings.ts
+++ b/src/features/settings/ClaudianSettings.ts
@@ -152,6 +152,8 @@ export class ClaudianSettingTab extends PluginSettingTab {
   private activeTab: SettingsTabId = 'general';
   private refreshTitleModelOptions: (() => void) | null = null;
   private displayGeneration = 0;
+  private customContextLimitRefreshTimer: number | null = null;
+  private readonly pendingCustomContextLimitRefreshProviders = new Set<ProviderId>();
   private readonly agentSkillCoordinator: AgentSkillManagementCoordinator;
 
   constructor(app: App, plugin: FeatureHost & Plugin) {
@@ -741,6 +743,21 @@ export class ClaudianSettingTab extends PluginSettingTab {
     this.refreshTitleModelOptions?.();
   }
 
+  private scheduleCustomContextLimitRefresh(providerId: ProviderId): void {
+    this.pendingCustomContextLimitRefreshProviders.add(providerId);
+    if (this.customContextLimitRefreshTimer !== null) {
+      window.clearTimeout(this.customContextLimitRefreshTimer);
+    }
+    this.customContextLimitRefreshTimer = window.setTimeout(() => {
+      this.customContextLimitRefreshTimer = null;
+      const providers = Array.from(this.pendingCustomContextLimitRefreshProviders);
+      this.pendingCustomContextLimitRefreshProviders.clear();
+      for (const pendingProviderId of providers) {
+        this.notifyProviderModelOptionsChanged(pendingProviderId);
+      }
+    }, 150);
+  }
+
   private refreshDualPaneLayouts(): void {
     for (const view of this.plugin.getAllViews()) {
       view.refreshDualPaneLayout();
@@ -904,6 +921,7 @@ export class ClaudianSettingTab extends PluginSettingTab {
             settings.customContextLimits[modelId] = parseContextLimit(trimmed)!;
           }
         });
+        this.scheduleCustomContextLimitRefresh(providerId);
       };
 
       inputEl.addEventListener('input', () => {

--- a/src/providers/codex/ui/CodexChatUIConfig.ts
+++ b/src/providers/codex/ui/CodexChatUIConfig.ts
@@ -1,3 +1,4 @@
+import { resolveProviderCustomContextLimit } from '../../../core/providers/modelSelection';
 import {
   DEFAULT_REASONING_VALUE,
   formatReasoningValueLabel,
@@ -124,8 +125,9 @@ export const codexChatUIConfig: ProviderChatUIConfig = {
       : DEFAULT_REASONING_VALUE;
   },
 
-  getContextWindowSize(): number {
-    return DEFAULT_CONTEXT_WINDOW;
+  getContextWindowSize(model: string, customLimits?: Record<string, number>): number {
+    return resolveProviderCustomContextLimit('codex', model, customLimits)
+      ?? DEFAULT_CONTEXT_WINDOW;
   },
 
   isDefaultModel(model: string): boolean {

--- a/tests/unit/core/providers/modelSelection.test.ts
+++ b/tests/unit/core/providers/modelSelection.test.ts
@@ -3,6 +3,7 @@ import {
   encodeProviderModelSelectionId,
   getProviderModelSelectionPrefix,
   isProviderModelSelectionId,
+  resolveProviderCustomContextLimit,
   toProviderRuntimeModelId,
 } from '@/core/providers/modelSelection';
 
@@ -143,6 +144,37 @@ describe('model selection namespacing', () => {
 
     it('returns an empty string unchanged', () => {
       expect(toProviderRuntimeModelId('claude', '')).toBe('');
+    });
+  });
+
+  describe('resolveProviderCustomContextLimit', () => {
+    it('resolves raw and namespaced keys for the owning provider', () => {
+      expect(resolveProviderCustomContextLimit(
+        'codex',
+        'openai-codex/my-custom-model',
+        { 'my-custom-model': 1_000_000 },
+      )).toBe(1_000_000);
+      expect(resolveProviderCustomContextLimit(
+        'codex',
+        'my-custom-model',
+        { 'openai-codex/my-custom-model': 500_000 },
+      )).toBe(500_000);
+    });
+
+    it('prefers the exact key and ignores invalid limits', () => {
+      expect(resolveProviderCustomContextLimit(
+        'codex',
+        'openai-codex/my-custom-model',
+        {
+          'openai-codex/my-custom-model': 750_000,
+          'my-custom-model': 1_000_000,
+        },
+      )).toBe(750_000);
+      expect(resolveProviderCustomContextLimit(
+        'codex',
+        'openai-codex/my-custom-model',
+        { 'my-custom-model': 0 },
+      )).toBeUndefined();
     });
   });
 

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -558,6 +558,38 @@ describe('ConversationController', () => {
   });
 
   describe('loadActive with existing conversation', () => {
+    it('applies a custom context limit when restoring persisted usage', async () => {
+      const model = 'openai-codex/my-custom-model';
+      deps.state.currentConversationId = 'codex-conv';
+      deps.plugin.settings.customContextLimits = { 'my-custom-model': 1_000_000 };
+      (deps.plugin.getConversationById as jest.Mock).mockResolvedValue({
+        id: 'codex-conv',
+        messages: [{ id: '1', role: 'user', content: 'test', timestamp: Date.now() }],
+        providerId: 'codex',
+        selectedModel: model,
+        sessionId: 'session-1',
+        usage: {
+          model,
+          inputTokens: 0,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          contextWindow: 200_000,
+          contextWindowIsAuthoritative: true,
+          contextTokens: 200_000,
+          percentage: 98,
+        },
+      });
+
+      await controller.loadActive();
+
+      expect(deps.state.usage).toMatchObject({
+        model,
+        contextWindow: 1_000_000,
+        contextWindowIsAuthoritative: false,
+        percentage: 20,
+      });
+    });
+
     it('should restore currentNote when conversation has one', async () => {
       const fileContextManager = deps.getFileContextManager()!;
       deps.state.currentConversationId = 'conv-with-note';

--- a/tests/unit/features/chat/controllers/StreamController.test.ts
+++ b/tests/unit/features/chat/controllers/StreamController.test.ts
@@ -1556,6 +1556,39 @@ describe('StreamController - Text Content', () => {
       expect(deps.state.usage).toEqual(usage);
     });
 
+    it('applies a custom context limit to live usage chunks', async () => {
+      const msg = createTestMessage();
+      const model = 'opencode/kimi-for-coding/k3';
+      Object.assign(deps.plugin.settings, {
+        customContextLimits: { [model]: 1_048_576 },
+      });
+      deps.state.currentConversationId = 'opencode-conv';
+      deps.plugin.getConversationSync = jest.fn().mockReturnValue({
+        id: 'opencode-conv',
+        messages: [],
+        providerId: 'opencode',
+        selectedModel: model,
+        sessionId: 'session-1',
+      });
+      deps.getProviderId = () => 'opencode';
+      const usage = createMockUsage({
+        model,
+        contextWindow: 200_000,
+        contextWindowIsAuthoritative: true,
+        contextTokens: 195_654,
+        percentage: 98,
+      });
+
+      await controller.handleStreamChunk({ type: 'usage', usage, sessionId: 'session-1' }, msg);
+
+      expect(deps.state.usage).toMatchObject({
+        model,
+        contextWindow: 1_048_576,
+        contextWindowIsAuthoritative: false,
+        percentage: 19,
+      });
+    });
+
     it('should not update usage when ignoreUsageUpdates is true', async () => {
       const msg = createTestMessage();
       deps.state.ignoreUsageUpdates = true;

--- a/tests/unit/features/chat/utils/usageInfo.test.ts
+++ b/tests/unit/features/chat/utils/usageInfo.test.ts
@@ -53,5 +53,30 @@ describe('usageInfo', () => {
         percentage: 50,
       });
     });
+
+    it('lets an explicit custom limit override an authoritative runtime window', () => {
+      const usage = {
+        model: 'opencode/kimi-for-coding/k3',
+        inputTokens: 0,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        contextWindow: 200_000,
+        contextWindowIsAuthoritative: true,
+        contextTokens: 195_654,
+        percentage: 98,
+      };
+
+      expect(recalculateUsageForModel(
+        usage,
+        usage.model,
+        1_048_576,
+        1_048_576,
+      )).toEqual({
+        ...usage,
+        contextWindow: 1_048_576,
+        contextWindowIsAuthoritative: false,
+        percentage: 19,
+      });
+    });
   });
 });

--- a/tests/unit/features/settings/ClaudianSettings.test.ts
+++ b/tests/unit/features/settings/ClaudianSettings.test.ts
@@ -46,4 +46,30 @@ describe('ClaudianSettingTab model option updates', () => {
       expect.any(Function),
     );
   });
+
+  it('debounces context-limit refreshes per provider', () => {
+    jest.useFakeTimers();
+    try {
+      const notifyProviderChatOptionsChanged = jest.fn();
+      const plugin = {
+        notifyProviderChatOptionsChanged,
+        notifyAgentSkillsChanged: jest.fn(),
+        storage: { getAdapter: jest.fn(() => ({})) },
+      };
+      const tab = new ClaudianSettingTab({} as any, plugin as any);
+
+      (tab as any).scheduleCustomContextLimitRefresh('codex');
+      (tab as any).scheduleCustomContextLimitRefresh('codex');
+      (tab as any).scheduleCustomContextLimitRefresh('opencode');
+
+      jest.advanceTimersByTime(149);
+      expect(notifyProviderChatOptionsChanged).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(1);
+      expect(notifyProviderChatOptionsChanged).toHaveBeenCalledTimes(2);
+      expect(notifyProviderChatOptionsChanged).toHaveBeenCalledWith('codex');
+      expect(notifyProviderChatOptionsChanged).toHaveBeenCalledWith('opencode');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });

--- a/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
+++ b/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
@@ -514,6 +514,12 @@ describe('CodexChatUIConfig', () => {
     it('should return 200000 for all models', () => {
       expect(codexChatUIConfig.getContextWindowSize(TEST_CODEX_MODEL)).toBe(200_000);
     });
+
+    it('uses a configured raw-keyed limit for a namespaced custom model', () => {
+      expect(codexChatUIConfig.getContextWindowSize('openai-codex/my-custom-model', {
+        'my-custom-model': 1_000_000,
+      })).toBe(1_000_000);
+    });
   });
 
   describe('applyModelDefaults', () => {


### PR DESCRIPTION
## Summary
- resolve custom context limits for both raw and provider-namespaced model IDs
- let explicit user limits override provider-reported context windows during live streaming, conversation restore, settings refresh, and model switches
- make Codex honor configured context limits and debounce selector refreshes after limit edits

## Verification
- pnpm run typecheck
- pnpm run lint (existing warnings only)
- pnpm run test
- pnpm run build