### PR TITLE
chore: release v2.5.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "oh-my-claudian",
   "name": "Oh My Claudian",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "minAppVersion": "1.7.2",
   "description": "Embeds coding agents as AI collaborators in your vault, including Oh My Pi support.",
   "author": "Lee",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudian",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "packageManager": "pnpm@10.34.5",
   "description": "Oh My Claudian - provider-backed coding agents embedded in the Obsidian sidebar",
   "main": "main.js",


### PR DESCRIPTION
## Summary
- bump the plugin package and manifest versions from 2.5.2 to 2.5.3

## Verification
- pnpm run typecheck
- pnpm run build