### PR TITLE
fix: collapse replayed work fragments

### DIFF
--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -290,6 +290,7 @@ export class MessageRenderer {
     for (let i = 0; i < messages.length; i++) {
       this.renderStoredMessage(messages[i], messages, i);
     }
+    this.collapseStoredWorkFragments(messages);
 
     this.scrollToBottom();
     return newWelcomeEl;
@@ -316,10 +317,72 @@ export class MessageRenderer {
       for (let index = 0; index < messages.length; index++) {
         this.renderStoredMessage(messages[index], messages, index);
       }
+      this.collapseStoredWorkFragments(messages);
     } finally {
       this.messagesEl = mainMessagesEl;
       this.suppressConversationActions = previousSuppress;
     }
+  }
+
+  /**
+   * Claude transcript replay can split one completed turn into assistant
+   * fragments: thought/tool-only messages followed by a separate final answer.
+   * Rejoin only adjacent work-only fragments at render time so replay keeps the
+   * same completed-work disclosure as the live, single-message path.
+   */
+  private collapseStoredWorkFragments(messages: ChatMessage[]): void {
+    for (let answerIndex = 0; answerIndex < messages.length; answerIndex++) {
+      const answer = messages[answerIndex];
+      if (!this.isStoredFinalAnswer(answer)) continue;
+
+      const workMessages: ChatMessage[] = [];
+      for (let index = answerIndex - 1; index >= 0; index--) {
+        const candidate = messages[index];
+        if (!this.isStoredWorkOnlyFragment(candidate)) break;
+        workMessages.unshift(candidate);
+      }
+      if (workMessages.length === 0) continue;
+
+      const answerEl = this.messagesEl.querySelector<HTMLElement>(
+        `[data-message-id="${answer.id}"]`,
+      );
+      const answerContentEl = answerEl?.querySelector<HTMLElement>('.claudian-message-content');
+      if (!answerContentEl) continue;
+
+      const workEls: HTMLElement[] = [];
+      for (const workMessage of workMessages) {
+        const workMessageEl = this.messagesEl.querySelector<HTMLElement>(
+          `[data-message-id="${workMessage.id}"]`,
+        );
+        const workContentEl = workMessageEl?.querySelector<HTMLElement>('.claudian-message-content');
+        if (!workMessageEl || !workContentEl || workContentEl.children.length === 0) continue;
+
+        const firstAnswerChild = answerContentEl.firstElementChild;
+        for (const child of Array.from(workContentEl.children) as HTMLElement[]) {
+          answerContentEl.insertBefore(child, firstAnswerChild);
+          workEls.push(child);
+        }
+        workMessageEl.remove();
+      }
+
+      if (workEls.length > 0) {
+        this.finalizeCompletedWork(answer);
+      }
+    }
+  }
+
+  private isStoredFinalAnswer(message: ChatMessage): boolean {
+    if (message.role !== 'assistant' || message.isInterrupt) return false;
+    if (message.content.trim().length > 0) return true;
+    return message.contentBlocks?.some(
+      block => block.type === 'text' && block.content.trim().length > 0,
+    ) ?? false;
+  }
+
+  private isStoredWorkOnlyFragment(message: ChatMessage): boolean {
+    if (message.role !== 'assistant' || message.isInterrupt) return false;
+    if (message.contentBlocks?.some(block => block.type === 'context_compacted')) return false;
+    return !this.isStoredFinalAnswer(message);
   }
 
   renderStoredMessage(msg: ChatMessage, allMessages?: ChatMessage[], index?: number): void {

--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -290,7 +290,6 @@ export class MessageRenderer {
     for (let i = 0; i < messages.length; i++) {
       this.renderStoredMessage(messages[i], messages, i);
     }
-    this.collapseStoredWorkFragments(messages);
 
     this.scrollToBottom();
     return newWelcomeEl;
@@ -317,72 +316,10 @@ export class MessageRenderer {
       for (let index = 0; index < messages.length; index++) {
         this.renderStoredMessage(messages[index], messages, index);
       }
-      this.collapseStoredWorkFragments(messages);
     } finally {
       this.messagesEl = mainMessagesEl;
       this.suppressConversationActions = previousSuppress;
     }
-  }
-
-  /**
-   * Claude transcript replay can split one completed turn into assistant
-   * fragments: thought/tool-only messages followed by a separate final answer.
-   * Rejoin only adjacent work-only fragments at render time so replay keeps the
-   * same completed-work disclosure as the live, single-message path.
-   */
-  private collapseStoredWorkFragments(messages: ChatMessage[]): void {
-    for (let answerIndex = 0; answerIndex < messages.length; answerIndex++) {
-      const answer = messages[answerIndex];
-      if (!this.isStoredFinalAnswer(answer)) continue;
-
-      const workMessages: ChatMessage[] = [];
-      for (let index = answerIndex - 1; index >= 0; index--) {
-        const candidate = messages[index];
-        if (!this.isStoredWorkOnlyFragment(candidate)) break;
-        workMessages.unshift(candidate);
-      }
-      if (workMessages.length === 0) continue;
-
-      const answerEl = this.messagesEl.querySelector<HTMLElement>(
-        `[data-message-id="${answer.id}"]`,
-      );
-      const answerContentEl = answerEl?.querySelector<HTMLElement>('.claudian-message-content');
-      if (!answerContentEl) continue;
-
-      const workEls: HTMLElement[] = [];
-      for (const workMessage of workMessages) {
-        const workMessageEl = this.messagesEl.querySelector<HTMLElement>(
-          `[data-message-id="${workMessage.id}"]`,
-        );
-        const workContentEl = workMessageEl?.querySelector<HTMLElement>('.claudian-message-content');
-        if (!workMessageEl || !workContentEl || workContentEl.children.length === 0) continue;
-
-        const firstAnswerChild = answerContentEl.firstElementChild;
-        for (const child of Array.from(workContentEl.children) as HTMLElement[]) {
-          answerContentEl.insertBefore(child, firstAnswerChild);
-          workEls.push(child);
-        }
-        workMessageEl.remove();
-      }
-
-      if (workEls.length > 0) {
-        this.finalizeCompletedWork(answer);
-      }
-    }
-  }
-
-  private isStoredFinalAnswer(message: ChatMessage): boolean {
-    if (message.role !== 'assistant' || message.isInterrupt) return false;
-    if (message.content.trim().length > 0) return true;
-    return message.contentBlocks?.some(
-      block => block.type === 'text' && block.content.trim().length > 0,
-    ) ?? false;
-  }
-
-  private isStoredWorkOnlyFragment(message: ChatMessage): boolean {
-    if (message.role !== 'assistant' || message.isInterrupt) return false;
-    if (message.contentBlocks?.some(block => block.type === 'context_compacted')) return false;
-    return !this.isStoredFinalAnswer(message);
   }
 
   renderStoredMessage(msg: ChatMessage, allMessages?: ChatMessage[], index?: number): void {
@@ -473,7 +410,7 @@ export class MessageRenderer {
     const activeStatuses = contentEl.querySelectorAll<HTMLElement>('.claudian-completed-work-status');
     this.removeCompletedWorkStatuses(activeStatuses);
     const existingWork = contentEl.querySelectorAll<HTMLElement>('.claudian-completed-work');
-    if (msg.isInterrupt || msg.contentBlocks?.some(block => block.type === 'context_compacted')) return;
+    if (msg.isInterrupt) return;
     if (existingWork.length > 0) {
       this.unwrapCompletedWork(contentEl, existingWork);
     }

--- a/src/providers/claude/history/ClaudeHistoryStore.ts
+++ b/src/providers/claude/history/ClaudeHistoryStore.ts
@@ -172,6 +172,7 @@ async function assembleSDKChatMessages(
   const pathContext = options?.pathContext;
 
   const filteredEntries = filterActiveBranch(entries, resumeAtMessageId);
+  const manualCompactBoundaryIds = collectManualCompactBoundaryIds(filteredEntries);
   const realUserMessageIds = new Set(
     filteredEntries
       .filter(isRealUserInput)
@@ -212,9 +213,14 @@ async function assembleSDKChatMessages(
     normalizeTaskToolCalls(chatMsg, taskToolNormalizer, toolUseResults);
 
     if (chatMsg.role === 'assistant') {
-      // context_compacted must not merge with previous assistant (it's a standalone separator)
+      // A compact boundary can arrive between tool/thinking output and the final
+      // answer of the same user turn. Keep it as an ordered content block rather
+      // than flushing the turn into separate assistant messages.
       const isCompactBoundary = chatMsg.contentBlocks?.some(b => b.type === 'context_compacted');
-      if (isCompactBoundary) {
+      const isManualCompactBoundary = isCompactBoundary
+        && !!sdkMsg.uuid
+        && manualCompactBoundaryIds.has(sdkMsg.uuid);
+      if (isCompactBoundary && (isManualCompactBoundary || !pendingAssistant)) {
         flushPendingAssistant(true);
         chatMessages.push(chatMsg);
       } else if (pendingAssistant) {
@@ -290,6 +296,52 @@ async function assembleSDKChatMessages(
   applyTranscriptDurationFallback(chatMessages, realUserMessageIds);
 
   return chatMessages;
+}
+
+/**
+ * Manual `/compact` records its boundary after the command by timestamp, but
+ * the JSONL append order can be the reverse. Preserve that explicit command
+ * boundary as its own message; automatic compaction stays inside its turn.
+ */
+function collectManualCompactBoundaryIds(entries: SDKNativeMessage[]): Set<string> {
+  const orderedEntries = entries
+    .map((entry, index) => ({ entry, index, timestamp: parseSDKTimestamp(entry.timestamp) }))
+    .sort((left, right) => left.timestamp - right.timestamp || left.index - right.index);
+  const boundaryIds = new Set<string>();
+  let awaitingManualCompactBoundary = false;
+
+  for (const { entry } of orderedEntries) {
+    if (entry.type === 'user' && !isSystemInjectedMessage(entry)) {
+      awaitingManualCompactBoundary = isManualCompactCommand(entry);
+      continue;
+    }
+    if (entry.type === 'system' && entry.subtype === 'compact_boundary') {
+      if (awaitingManualCompactBoundary && entry.uuid) {
+        boundaryIds.add(entry.uuid);
+      }
+      awaitingManualCompactBoundary = false;
+    }
+  }
+
+  return boundaryIds;
+}
+
+function isManualCompactCommand(entry: SDKNativeMessage): boolean {
+  const content = entry.message?.content;
+  const text = typeof content === 'string'
+    ? content
+    : content
+      ?.filter((block): block is { type: 'text'; text: string } => (
+        block.type === 'text' && typeof block.text === 'string'
+      ))
+      .map(block => block.text)
+      .join('\n') ?? '';
+  return /<command-name>\s*\/compact\s*<\/command-name>/i.test(text);
+}
+
+function parseSDKTimestamp(value: string | undefined): number {
+  const timestamp = value ? new Date(value).getTime() : Number.NaN;
+  return Number.isFinite(timestamp) ? timestamp : Number.MAX_SAFE_INTEGER;
 }
 
 function isRealUserInput(entry: SDKNativeMessage): boolean {

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -149,7 +149,7 @@ describe('MessageRenderer', () => {
       expect(contentEl.contains(thinkingEl)).toBe(true);
     });
 
-    it('keeps compacted turns expanded', () => {
+    it('collapses compacted work while keeping its boundary in history', () => {
       const messagesEl = createMockEl();
       const { renderer } = createRenderer(messagesEl);
       const messageEl = messagesEl.createDiv({
@@ -158,6 +158,7 @@ describe('MessageRenderer', () => {
       });
       const contentEl = messageEl.createDiv({ cls: 'claudian-message-content' });
       contentEl.createDiv({ cls: 'claudian-tool-call' });
+      contentEl.createDiv({ cls: 'claudian-compact-boundary' });
       contentEl.createDiv({ cls: 'claudian-text-block', text: 'Final answer' });
       const querySelector = messagesEl.querySelector.bind(messagesEl);
       messagesEl.querySelector = jest.fn((selector: string) =>
@@ -168,62 +169,10 @@ describe('MessageRenderer', () => {
         contentBlocks: [{ type: 'context_compacted' }, { type: 'text', content: 'Final answer' }],
       } as ChatMessage);
 
-      expect(contentEl.querySelector('.claudian-completed-work')).toBeNull();
-    });
-
-    it('folds replayed work-only assistant fragments into the following final answer', () => {
-      const messagesEl = createMockEl();
-      const { renderer } = createRenderer(messagesEl);
-      (renderStoredThinkingBlock as jest.Mock).mockImplementation(
-        (parent: HTMLElement, content: string) => parent.createDiv({
-          cls: 'claudian-thinking-block',
-          text: content,
-        }),
-      );
-      const messages: ChatMessage[] = [
-        { id: 'user-1', role: 'user', content: 'Review this', timestamp: 1 },
-        {
-          id: 'work-1',
-          role: 'assistant',
-          content: '',
-          timestamp: 2,
-          contentBlocks: [{ type: 'thinking', content: 'I will inspect the resume.' }],
-        },
-        {
-          id: 'answer-1',
-          role: 'assistant',
-          content: 'Candidate should proceed.',
-          timestamp: 3,
-          durationSeconds: 24,
-          contentBlocks: [{ type: 'text', content: 'Candidate should proceed.' }],
-        },
-      ];
-      const createDiv = messagesEl.createDiv.bind(messagesEl);
-      messagesEl.createDiv = (options: { cls?: string; text?: string; attr?: Record<string, string> }) => {
-        const element = createDiv(options);
-        for (const [name, value] of Object.entries(options.attr ?? {})) {
-          element.setAttribute(name, value);
-        }
-        return element;
-      };
-      const querySelector = messagesEl.querySelector.bind(messagesEl);
-      messagesEl.querySelector = jest.fn((selector: string) => {
-        const messageId = selector.match(/^\[data-message-id="(.+)"\]$/)?.[1];
-        if (messageId) {
-          return messagesEl.children.find((child: any) => child.dataset.messageId === messageId) ?? null;
-        }
-        return querySelector(selector);
-      });
-
-      renderer.renderMessages(messages, () => 'Hello');
-
-      const answerEl = messagesEl.querySelector('[data-message-id="answer-1"]') as HTMLElement | null;
-      const workEl = answerEl?.querySelector('.claudian-completed-work');
+      const workEl = contentEl.querySelector('.claudian-completed-work');
       expect(workEl).toBeTruthy();
-      expect(workEl?.querySelector('.claudian-completed-work-history')?.children[0].textContent)
-        .toContain('I will inspect the resume.');
-      expect(answerEl?.querySelector('.claudian-message-content')?.children)
-        .toContainEqual(expect.objectContaining({ className: 'claudian-text-block' }));
+      expect(workEl?.querySelector('.claudian-completed-work-history')?.children)
+        .toContainEqual(expect.objectContaining({ className: 'claudian-compact-boundary' }));
     });
 
   });

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -171,6 +171,61 @@ describe('MessageRenderer', () => {
       expect(contentEl.querySelector('.claudian-completed-work')).toBeNull();
     });
 
+    it('folds replayed work-only assistant fragments into the following final answer', () => {
+      const messagesEl = createMockEl();
+      const { renderer } = createRenderer(messagesEl);
+      (renderStoredThinkingBlock as jest.Mock).mockImplementation(
+        (parent: HTMLElement, content: string) => parent.createDiv({
+          cls: 'claudian-thinking-block',
+          text: content,
+        }),
+      );
+      const messages: ChatMessage[] = [
+        { id: 'user-1', role: 'user', content: 'Review this', timestamp: 1 },
+        {
+          id: 'work-1',
+          role: 'assistant',
+          content: '',
+          timestamp: 2,
+          contentBlocks: [{ type: 'thinking', content: 'I will inspect the resume.' }],
+        },
+        {
+          id: 'answer-1',
+          role: 'assistant',
+          content: 'Candidate should proceed.',
+          timestamp: 3,
+          durationSeconds: 24,
+          contentBlocks: [{ type: 'text', content: 'Candidate should proceed.' }],
+        },
+      ];
+      const createDiv = messagesEl.createDiv.bind(messagesEl);
+      messagesEl.createDiv = (options: { cls?: string; text?: string; attr?: Record<string, string> }) => {
+        const element = createDiv(options);
+        for (const [name, value] of Object.entries(options.attr ?? {})) {
+          element.setAttribute(name, value);
+        }
+        return element;
+      };
+      const querySelector = messagesEl.querySelector.bind(messagesEl);
+      messagesEl.querySelector = jest.fn((selector: string) => {
+        const messageId = selector.match(/^\[data-message-id="(.+)"\]$/)?.[1];
+        if (messageId) {
+          return messagesEl.children.find((child: any) => child.dataset.messageId === messageId) ?? null;
+        }
+        return querySelector(selector);
+      });
+
+      renderer.renderMessages(messages, () => 'Hello');
+
+      const answerEl = messagesEl.querySelector('[data-message-id="answer-1"]') as HTMLElement | null;
+      const workEl = answerEl?.querySelector('.claudian-completed-work');
+      expect(workEl).toBeTruthy();
+      expect(workEl?.querySelector('.claudian-completed-work-history')?.children[0].textContent)
+        .toContain('I will inspect the resume.');
+      expect(answerEl?.querySelector('.claudian-message-content')?.children)
+        .toContainEqual(expect.objectContaining({ className: 'claudian-text-block' }));
+    });
+
   });
 
   // ============================================

--- a/tests/unit/utils/sdkSession.test.ts
+++ b/tests/unit/utils/sdkSession.test.ts
@@ -1142,6 +1142,32 @@ describe('sdkSession', () => {
       });
     });
 
+    it('keeps one assistant turn intact when compaction occurs before its final answer', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockFsPromises.readFile.mockResolvedValue([
+        '{"type":"user","uuid":"u1","timestamp":"2024-01-15T10:00:00Z","message":{"content":"Review the resume"}}',
+        '{"type":"assistant","uuid":"a1","timestamp":"2024-01-15T10:00:01Z","message":{"content":[{"type":"thinking","thinking":"I will inspect the experience."}]}}',
+        '{"type":"system","subtype":"compact_boundary","uuid":"c1","timestamp":"2024-01-15T10:00:02Z"}',
+        '{"type":"assistant","uuid":"a2","timestamp":"2024-01-15T10:00:05Z","message":{"content":[{"type":"text","text":"Candidate should proceed."}]}}',
+        '{"type":"system","subtype":"turn_duration","uuid":"duration-1","parentUuid":"a2","timestamp":"2024-01-15T10:00:05.100Z","durationMs":5000}',
+      ].join('\n'));
+
+      const result = await loadSDKSessionMessages('/Users/test/vault', 'session-compact-turn');
+
+      expect(result.messages).toHaveLength(2);
+      expect(result.messages[1]).toMatchObject({
+        role: 'assistant',
+        content: 'Candidate should proceed.',
+        durationSeconds: 5,
+        assistantMessageId: 'a2',
+      });
+      expect(result.messages[1].contentBlocks?.map(block => block.type)).toEqual([
+        'thinking',
+        'context_compacted',
+        'text',
+      ]);
+    });
+
     it('sorts messages by timestamp ascending', async () => {
       mockExistsSync.mockReturnValue(true);
       mockFsPromises.readFile.mockResolvedValue([


### PR DESCRIPTION
## Problem
Claude history replay treated every compaction boundary as a hard assistant-message split. When automatic compaction happened between thinking or tool work and the final answer, one logical completed turn rendered as separate messages and could not use the completed-work disclosure.

## Fix
Keep automatic compaction boundaries as ordered content blocks in the pending Claude assistant turn. The final answer, duration, thinking, tools, and compaction marker are therefore restored as one message. Explicit manual /compact boundaries remain standalone, identified from transcript timestamps.

## Verification
- Focused Claude SDK history and MessageRenderer tests: 256 passing
- Typecheck: passing
- Lint: passing with 9 existing warnings
- Production build: passing