### PR TITLE
perf: defer collapsed stored tool content

### DIFF
--- a/src/features/chat/rendering/ToolCallRenderer.ts
+++ b/src/features/chat/rendering/ToolCallRenderer.ts
@@ -1174,13 +1174,24 @@ export function renderStoredToolCall(
     setGenericToolHeaderRight(statusEl, toolCall);
   }
 
-  renderToolContent(content, toolCall);
+  let contentRendered = false;
+  const renderContentOnce = () => {
+    if (contentRendered) return;
+    renderToolContent(content, toolCall);
+    contentRendered = true;
+  };
+  const deferContent = toolCall.status !== 'running'
+    && toolCall.name !== TOOL_ASK_USER_QUESTION
+    && toolCall.name !== TOOL_TODO_WRITE;
+  if (!deferContent || options.initiallyExpanded) renderContentOnce();
 
   const state = { isExpanded: false };
   const todoStatusEl = toolCall.name === TOOL_TODO_WRITE ? statusEl : null;
   setupCollapsible(toolEl, header, content, state, {
     initiallyExpanded: options.initiallyExpanded ?? false,
-    onToggle: createTodoToggleHandler(currentTaskEl, todoStatusEl),
+    onToggle: createTodoToggleHandler(currentTaskEl, todoStatusEl, (expanded) => {
+      if (expanded) renderContentOnce();
+    }),
     baseAriaLabel: getToolLabel(toolCall.name, toolCall.input)
   });
 

--- a/src/features/chat/rendering/WriteEditRenderer.ts
+++ b/src/features/chat/rendering/WriteEditRenderer.ts
@@ -237,24 +237,32 @@ export function renderStoredWriteEdit(
   // Content
   const contentEl = wrapperEl.createDiv({ cls: 'claudian-write-edit-content' });
 
-  // Render diff if available
-  const row = contentEl.createDiv({ cls: 'claudian-write-edit-diff-row' });
+  let contentRendered = false;
+  const renderContentOnce = () => {
+    if (contentRendered) return;
+    const row = contentEl.createDiv({ cls: 'claudian-write-edit-diff-row' });
 
-  if (toolCall.diffData && toolCall.diffData.diffLines.length > 0) {
-    const diffEl = row.createDiv({ cls: 'claudian-write-edit-diff' });
-    renderDiffContent(diffEl, toolCall.diffData.diffLines);
-  } else if (isError && toolCall.result) {
-    const errorEl = row.createDiv({ cls: 'claudian-write-edit-error' });
-    errorEl.setText(toolCall.result);
-  } else {
-    const doneEl = row.createDiv({ cls: 'claudian-write-edit-done-text' });
-    doneEl.setText(isError ? 'ERROR' : 'DONE');
-  }
+    if (toolCall.diffData && toolCall.diffData.diffLines.length > 0) {
+      const diffEl = row.createDiv({ cls: 'claudian-write-edit-diff' });
+      renderDiffContent(diffEl, toolCall.diffData.diffLines);
+    } else if (isError && toolCall.result) {
+      const errorEl = row.createDiv({ cls: 'claudian-write-edit-error' });
+      errorEl.setText(toolCall.result);
+    } else {
+      const doneEl = row.createDiv({ cls: 'claudian-write-edit-done-text' });
+      doneEl.setText(isError ? 'ERROR' : 'DONE');
+    }
+    contentRendered = true;
+  };
+  if (toolCall.status === 'running' || options.initiallyExpanded) renderContentOnce();
 
   // Setup collapsible behavior (handles click, keyboard, ARIA, CSS)
   const state = { isExpanded: false };
   setupCollapsible(wrapperEl, headerEl, contentEl, state, {
     initiallyExpanded: options.initiallyExpanded ?? false,
+    onToggle: (expanded) => {
+      if (expanded) renderContentOnce();
+    },
     baseAriaLabel,
   });
 

--- a/tests/unit/features/chat/rendering/ToolCallRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/ToolCallRenderer.test.ts
@@ -204,12 +204,66 @@ describe('ToolCallRenderer', () => {
       });
 
       const toolEl = renderStoredToolCall(parentEl, toolCall);
+      (toolEl.querySelector('.claudian-tool-header') as HTMLElement).click();
       const lines = toolEl.querySelectorAll('.claudian-tool-line');
 
       expect(lines).toHaveLength(3);
       for (const line of lines) {
         expect(line.hasClass('claudian-tool-line-wrap')).toBe(true);
       }
+    });
+
+    it('defers completed tool content until the card is expanded', () => {
+      const parentEl = createMockEl();
+      const toolCall = createToolCall({
+        status: 'completed',
+        result: 'stored output',
+      });
+
+      const toolEl = renderStoredToolCall(parentEl, toolCall);
+      const content = toolEl.querySelector('.claudian-tool-content');
+      const header = toolEl.querySelector('.claudian-tool-header') as HTMLElement;
+
+      expect(content?.children).toHaveLength(0);
+      header.click();
+      expect(content?.querySelector('.claudian-tool-line')?.textContent).toBe('stored output');
+    });
+
+    it('renders stored content immediately when requested expanded', () => {
+      const parentEl = createMockEl();
+      const toolCall = createToolCall({
+        status: 'completed',
+        result: 'stored output',
+      });
+
+      const toolEl = renderStoredToolCall(parentEl, toolCall, { initiallyExpanded: true });
+      expect(toolEl.querySelector('.claudian-tool-content')?.querySelector('.claudian-tool-line')?.textContent)
+        .toBe('stored output');
+    });
+
+    it('keeps running stored tool content eager', () => {
+      const parentEl = createMockEl();
+      const toolCall = createToolCall({
+        status: 'running',
+        result: 'partial output',
+      });
+
+      const toolEl = renderStoredToolCall(parentEl, toolCall);
+      expect(toolEl.querySelector('.claudian-tool-content')?.querySelector('.claudian-tool-line')?.textContent)
+        .toBe('partial output');
+    });
+
+    it('keeps interactive question content eager after restore', () => {
+      const parentEl = createMockEl();
+      const toolCall = createToolCall({
+        name: 'AskUserQuestion',
+        status: 'completed',
+        input: { questions: [{ question: 'Color?' }] },
+        result: '"Color?"="Blue"',
+      });
+
+      const toolEl = renderStoredToolCall(parentEl, toolCall);
+      expect(toolEl.querySelector('.claudian-ask-review-a-text')?.textContent).toBe('Blue');
     });
 
     it('should show error status icon', () => {
@@ -647,6 +701,7 @@ describe('ToolCallRenderer', () => {
       });
 
       const toolEl = renderStoredToolCall(parentEl, toolCall);
+      (toolEl.querySelector('.claudian-tool-header') as HTMLElement).click();
       const lines = Array.from(toolEl.querySelectorAll('.claudian-tool-line')).map(line => line.textContent);
 
       expect(lines).toContain('Query: obsidian plugin API');
@@ -667,6 +722,7 @@ describe('ToolCallRenderer', () => {
       });
 
       const toolEl = renderStoredToolCall(parentEl, toolCall);
+      (toolEl.querySelector('.claudian-tool-header') as HTMLElement).click();
       const links = toolEl.querySelectorAll('.claudian-tool-link');
       const lines = Array.from(toolEl.querySelectorAll('.claudian-tool-line')).map(line => line.textContent);
 
@@ -697,6 +753,7 @@ describe('ToolCallRenderer', () => {
       });
 
       const toolEl = renderStoredToolCall(parentEl, toolCall);
+      (toolEl.querySelector('.claudian-tool-header') as HTMLElement).click();
       const headers = Array.from(toolEl.querySelectorAll('.claudian-tool-patch-header')).map(el => el.textContent);
       const statusEl = toolEl.querySelector('.claudian-tool-status');
       const diffTexts = Array.from(toolEl.querySelectorAll('.claudian-diff-text')).map(el => el.textContent);
@@ -783,6 +840,7 @@ describe('ToolCallRenderer', () => {
       });
 
       const toolEl = renderStoredToolCall(parentEl, toolCall);
+      (toolEl.querySelector('.claudian-tool-header') as HTMLElement).click();
       const headers = Array.from(toolEl.querySelectorAll('.claudian-tool-patch-header')).map(el => el.textContent);
       const statusEl = toolEl.querySelector('.claudian-tool-status');
       const diffTexts = Array.from(toolEl.querySelectorAll('.claudian-diff-text')).map(el => el.textContent);
@@ -901,6 +959,7 @@ describe('ToolCallRenderer', () => {
       });
 
       const toolEl = renderStoredToolCall(parentEl, toolCall);
+      (toolEl.querySelector('.claudian-tool-header') as HTMLElement).click();
       const lines = Array.from(toolEl.querySelectorAll('.claudian-tool-line')).map(el => el.textContent);
 
       expect(lines).toContain('src/main.ts');

--- a/tests/unit/features/chat/rendering/WriteEditRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/WriteEditRenderer.test.ts
@@ -285,6 +285,41 @@ describe('WriteEditRenderer', () => {
       expect(block.hasClass('error')).toBe(true);
     });
 
+    it('defers completed diff content until the card is expanded', () => {
+      const parentEl = createMockEl();
+      const toolCall = createToolCall({
+        status: 'completed',
+        diffData: createDiffData(),
+      });
+
+      const block = renderStoredWriteEdit(parentEl, toolCall);
+      const content = block.querySelector('.claudian-write-edit-content');
+      const header = block.querySelector('.claudian-write-edit-header') as HTMLElement;
+
+      expect(content?.children).toHaveLength(0);
+      header.click();
+      expect(content?.querySelector('.claudian-diff-text')).toBeDefined();
+    });
+
+    it('renders stored diff content immediately when requested expanded', () => {
+      const parentEl = createMockEl();
+      const toolCall = createToolCall({
+        status: 'completed',
+        diffData: createDiffData(),
+      });
+
+      const block = renderStoredWriteEdit(parentEl, toolCall, { initiallyExpanded: true });
+      expect(block.querySelector('.claudian-diff-text')).toBeDefined();
+    });
+
+    it('keeps running stored edit content eager', () => {
+      const parentEl = createMockEl();
+      const toolCall = createToolCall({ status: 'running' });
+
+      const block = renderStoredWriteEdit(parentEl, toolCall);
+      expect(block.querySelector('.claudian-write-edit-content')?.children).toHaveLength(1);
+    });
+
     it('should render diff stats from stored diffData', () => {
       const parentEl = createMockEl();
       const toolCall = createToolCall({


### PR DESCRIPTION
## Problem

Restoring completed conversations eagerly rendered every collapsed Bash, Read, search, patch, and Edit body. Long transcripts paid the full rendering cost before the user expanded anything.

## Fix

Defer stored tool and Edit body rendering until expansion. Running tools, interactive questions, task previews, and explicitly initially-expanded cards remain eager. Content is materialized at most once and existing header summaries and diff statistics remain available immediately.

## Verification

- Chat rendering tests: 462 passed
- Full test suite: 7249 passed
- Typecheck: passed
- Lint: passed with 9 existing warnings
- Production build: passed