### PR TITLE
fix: surface silent compact completion

### DIFF
--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -542,6 +542,21 @@ export class InputController {
       ));
       didEnqueueToSdk = result.accepted;
       planCompleted = result.planCompleted;
+      if (isCompact && result.status === 'completed') {
+        const compactMessage = this.activeStreamingAssistantMessage ?? assistantMsg;
+        const hasCompactBoundary = compactMessage.contentBlocks?.some(
+          block => block.type === 'context_compacted',
+        ) === true;
+        const hasCompactOutput = compactMessage.content.trim().length > 0
+          || this.deps.state.currentTextContent.trim().length > 0
+          || (compactMessage.toolCalls?.length ?? 0) > 0;
+        if (!hasCompactBoundary && !hasCompactOutput) {
+          hadExecutionError = true;
+          await streamController.appendText(
+            '\n\n**Error:** Compaction finished without a confirmation. Please try again.',
+          );
+        }
+      }
       shouldReportReviewableSettlement = result.status === 'completed'
         || (result.status === 'error' && result.accepted);
       if (shouldReportReviewableSettlement) {

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -274,6 +274,55 @@ describe('InputController coordinator execution', () => {
     expect(fixture.deps.conversationController.save).toHaveBeenCalledTimes(2);
   });
 
+  it('reports a completed compact turn that has no compaction confirmation', async () => {
+    const fixture = createFixture();
+    fixture.input.value = '/compact';
+
+    await fixture.controller.sendMessage();
+
+    expect(fixture.deps.streamController.appendText).toHaveBeenCalledWith(
+      '\n\n**Error:** Compaction finished without a confirmation. Please try again.',
+    );
+  });
+
+  it('does not report an error when compact emits its confirmation block', async () => {
+    const fixture = createFixture();
+    fixture.coordinator.execute.mockImplementationOnce(async (submission: ChatTurnSubmission) => {
+      submission.messages?.assistant.contentBlocks?.push({ type: 'context_compacted' });
+      return {
+        accepted: true,
+        planCompleted: false,
+        status: 'completed',
+      };
+    });
+    fixture.input.value = '/compact';
+
+    await fixture.controller.sendMessage();
+
+    expect(fixture.deps.streamController.appendText).not.toHaveBeenCalledWith(
+      '\n\n**Error:** Compaction finished without a confirmation. Please try again.',
+    );
+  });
+
+  it('does not report an error when compact has streamed assistant output', async () => {
+    const fixture = createFixture();
+    fixture.coordinator.execute.mockImplementationOnce(async () => {
+      fixture.state.currentTextContent = 'Provider summary';
+      return {
+        accepted: true,
+        planCompleted: false,
+        status: 'completed',
+      };
+    });
+    fixture.input.value = '/compact';
+
+    await fixture.controller.sendMessage();
+
+    expect(fixture.deps.streamController.appendText).not.toHaveBeenCalledWith(
+      '\n\n**Error:** Compaction finished without a confirmation. Please try again.',
+    );
+  });
+
   it('notifies composer observers after clearing a sent message', async () => {
     const fixture = createFixture();
     fixture.input.value = '@notes/plan.md review this';


### PR DESCRIPTION
## Problem

A completed /compact execution could return without a compaction boundary or assistant output. Claudian then returned to idle with no success or failure feedback.

## Fix

Validate compact completion at the input controller boundary. A compact turn is accepted as confirmed when it emits context_compacted or actual assistant/tool output. A completed empty turn now appends a visible error and suppresses the normal completion duration, so it is no longer silently treated as success. Streamed text is checked from the live text buffer before it is finalized into the message.

## Scope

This covers the deterministic silent-completion symptom. Third-party endpoint latency or missing SDK events still requires a provider-side trace.

## Verification

- Claude compact/event/controller tests: passed
- Full test suite: 7245 passed
- Typecheck: passed
- Lint: passed with 9 existing warnings
- Production build: passed