### PR TITLE
Fix active non-Markdown linked content with excluded tags

### DIFF
--- a/src/features/chat/ui/FileContext.ts
+++ b/src/features/chat/ui/FileContext.ts
@@ -541,7 +541,11 @@ export class FileContextManager {
     if (excludedTags.length === 0) return 'not-excluded';
 
     const cache = this.app.metadataCache.getFileCache(file);
-    if (!cache) return 'unknown';
+    // Non-Markdown vault files do not carry note tags when Obsidian has no
+    // metadata cache entry for them. Keep Markdown fail-closed until its cache
+    // resolves, but allow PDFs, canvases, bases, and images to follow the
+    // active editor even when their cache is unavailable.
+    if (!cache) return file.extension.toLocaleLowerCase() === 'md' ? 'unknown' : 'not-excluded';
 
     const fileTags: string[] = [];
 

--- a/tests/unit/features/chat/ui/FileContextManager.test.ts
+++ b/tests/unit/features/chat/ui/FileContextManager.test.ts
@@ -754,6 +754,23 @@ describe('FileContextManager', () => {
   });
 
   describe('metadata-driven current note refresh', () => {
+    it.each(['pdf', 'canvas', 'base', 'png'])('auto-attaches a %s active file when metadata is unavailable', (extension) => {
+        const filePath = `slides/lecture.${extension}`;
+        const app = createMockApp({
+          files: [filePath],
+          activeFilePath: filePath,
+        });
+        const manager = new FileContextManager(
+          app, containerEl as any, inputEl,
+          createMockCallbacks({ excludedTags: ['private'] })
+        );
+
+        manager.autoAttachActiveFile();
+
+        expect(manager.getCurrentNotePath()).toBe(filePath);
+        manager.destroy();
+      });
+
     it('delays auto-attach until the active note metadata resolves', () => {
       const fileCacheByPath = new Map<string, any>();
       const app = createMockApp({


### PR DESCRIPTION
## Problem
When excluded tags are configured, an active PDF, canvas, base, or image can have no metadata cache entry. The current fail-closed check then treats it as unknown and does not auto-link it, even though these files cannot provide note tags in that state.

## Fix
Keep Markdown files fail-closed until metadata resolves. Treat non-Markdown files without a metadata cache as eligible for active-file linking, while still evaluating tags whenever metadata is available.

## Scope
This is the local adaptation of upstream issue #1282. Non-Markdown active-file linking already exists locally; this fixes the metadata-cache edge case only.

## Verification
- FileContextManager tests: 52 passed
- Typecheck: passed
- Lint: passed with 9 existing warnings
- Production build: passed