### PR TITLE
test: stabilize Windows Pi fixture startup

### DIFF
--- a/tests/integration/providers/pi/PiSubprocess.windows.test.ts
+++ b/tests/integration/providers/pi/PiSubprocess.windows.test.ts
@@ -3,6 +3,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { PiSubprocess } from '@/providers/pi/runtime/PiSubprocess';
+import { findNodeExecutable, getEnhancedPath } from '@/utils/env';
 
 const describeOnWindows = process.platform === 'win32' ? describe : describe.skip;
 
@@ -47,12 +48,16 @@ describeOnWindows('PiSubprocess Windows argv integration', () => {
       });
       subprocess.start();
 
-      await expect(readFirstLine(subprocess)).resolves.toEqual(expectedArgs);
+      await expect(readFirstLine(subprocess, {
+        fixture: cliPath,
+        node: findNodeExecutable(getEnhancedPath(process.env.PATH, commandPath)),
+        runner: process.execPath,
+      })).resolves.toEqual(expectedArgs);
     } finally {
       await subprocess?.shutdown();
       await fs.rm(npmPrefix, { force: true, recursive: true });
     }
-  }, 20_000);
+  }, 45_000);
 });
 
 function createWindowsCommandShim(commandPath: string, targetPath: string): string {
@@ -78,13 +83,19 @@ function createWindowsCommandShim(commandPath: string, targetPath: string): stri
   ].join('\r\n');
 }
 
-function readFirstLine(subprocess: PiSubprocess): Promise<unknown> {
+function readFirstLine(subprocess: PiSubprocess, launch: Record<string, unknown>): Promise<unknown> {
   return new Promise((resolve, reject) => {
     let buffered = '';
+    // Allow for slow Node startup on hosted Windows runners.
     const timeout = window.setTimeout(() => {
       cleanup();
-      reject(new Error('Timed out waiting for the Pi argv fixture'));
-    }, 10_000);
+      reject(new Error(`Timed out waiting for the Pi argv fixture: ${JSON.stringify({
+        ...launch,
+        alive: subprocess.isAlive(),
+        stdout: buffered,
+        stderr: subprocess.getStderrSnapshot(),
+      })}`));
+    }, 30_000);
     const onData = (chunk: Buffer | string): void => {
       buffered += chunk.toString();
       const newlineIndex = buffered.indexOf('\n');


### PR DESCRIPTION
## Problem
The required Windows provider-runtime job intermittently times out while waiting for the Pi argv fixture to start. The fixture itself is intentionally tiny, but hosted Windows Node startup can exceed the previous 10-second read timeout.

## Fix
- Increase the fixture read timeout to 30 seconds and the Jest test timeout to 45 seconds.
- Include the resolved fixture, Node executable, runner, process liveness, stdout, and stderr snapshot in timeout errors.

This is the focused local adaptation of upstream commit 74fe112c (issue #1274). It keeps the release version PR separate.

## Verification
- Windows-only suite is skipped on macOS as expected
- Typecheck: passed
- Lint: passed with 9 existing warnings