### PR TITLE
Fix OpenCode SQLite history restoration

### DIFF
--- a/src/providers/opencode/history/OpencodeConversationHistoryService.ts
+++ b/src/providers/opencode/history/OpencodeConversationHistoryService.ts
@@ -33,7 +33,7 @@ export class OpencodeConversationHistoryService implements ProviderConversationH
     const state = getOpencodeState(conversation.providerState);
     const databasePath = resolveOpencodeDatabasePathHint(state.databasePath, pathContext);
     if (!databasePath) return null;
-    return loadOpencodeSessionModel(conversation.sessionId, { databasePath });
+    return loadOpencodeSessionModel(conversation.sessionId, { databasePath }, pathContext?.environment);
   }
 
   async hydrateConversationHistory(
@@ -69,7 +69,11 @@ export class OpencodeConversationHistoryService implements ProviderConversationH
       return;
     }
 
-    const messages = await loadOpencodeSessionMessages(sessionId, { databasePath: databasePath ?? undefined });
+    const messages = await loadOpencodeSessionMessages(
+      sessionId,
+      { databasePath: databasePath ?? undefined },
+      pathContext?.environment,
+    );
     if (messages.length === 0) {
       this.hydratedKeys.delete(conversation.id);
       return;

--- a/src/providers/opencode/history/OpencodeHistoryStore.ts
+++ b/src/providers/opencode/history/OpencodeHistoryStore.ts
@@ -20,6 +20,7 @@ import type { OpencodeProviderState } from '../types';
 import {
   loadOpencodeSessionRows,
   type StoredRow,
+  type StoredSessionRows,
 } from './OpencodeSqliteReader';
 
 export { OPENCODE_MESSAGE_ROW_SQL } from './OpencodeSqliteReader';
@@ -39,17 +40,20 @@ const OPENCODE_HYDRATION_DIAGNOSTIC_ID_PREFIX = 'opencode-hydration-error';
 export async function loadOpencodeSessionMessages(
   sessionId: string,
   providerState?: OpencodeProviderState,
+  environment: NodeJS.ProcessEnv = process.env,
 ): Promise<ChatMessage[]> {
-  const databasePath = resolveExistingOpencodeDatabasePath(providerState?.databasePath);
+  const databasePath = resolveExistingOpencodeDatabasePath(providerState?.databasePath, environment);
   if (!databasePath || databasePath === ':memory:' || !fs.existsSync(databasePath)) {
     return [];
   }
 
-  const rows = await loadOpencodeSessionRows(databasePath, sessionId);
-  if (!rows) {
+  let rows: StoredSessionRows;
+  try {
+    rows = await loadOpencodeSessionRows(databasePath, sessionId, { environment });
+  } catch (error) {
     return [createOpencodeHydrationDiagnosticMessage({
       databasePath,
-      reason: 'Could not read OpenCode session rows from SQLite.',
+      reason: formatUnknownError(error),
       sessionId,
     })];
   }
@@ -63,13 +67,14 @@ export async function loadOpencodeSessionMessages(
 export async function loadOpencodeSessionModel(
   sessionId: string,
   providerState?: OpencodeProviderState,
+  environment: NodeJS.ProcessEnv = process.env,
 ): Promise<string | null> {
-  const databasePath = resolveExistingOpencodeDatabasePath(providerState?.databasePath);
+  const databasePath = resolveExistingOpencodeDatabasePath(providerState?.databasePath, environment);
   if (!databasePath || databasePath === ':memory:' || !fs.existsSync(databasePath)) {
     return null;
   }
 
-  const rows = await loadOpencodeSessionRows(databasePath, sessionId);
+  const rows = await loadOpencodeSessionRows(databasePath, sessionId, { environment }).catch(() => null);
   let rawModelId: string | null = null;
   for (const row of rows?.messageRows ?? []) {
     const data = parseJsonObject(row.data);
@@ -297,7 +302,11 @@ function createOpencodeHydrationDiagnosticMessage(params: {
     ...(params.messageId ? [`messageId: ${params.messageId}`] : []),
     `reason: ${params.reason}`,
   ];
-  const content = detailLines.join('\n');
+  const details = detailLines.join('\n');
+  const fenceLength = (details.match(/`+/g) ?? [])
+    .reduce((length, run) => Math.max(length, run.length + 1), 3);
+  const fence = '`'.repeat(fenceLength);
+  const content = `${fence}text\n${details}\n${fence}`;
 
   return {
     assistantMessageId: undefined,

--- a/src/providers/opencode/history/OpencodeSqliteReader.ts
+++ b/src/providers/opencode/history/OpencodeSqliteReader.ts
@@ -1,7 +1,6 @@
-import { spawn as defaultSpawn } from 'node:child_process';
+import { type ChildProcess, spawn as defaultSpawn, type SpawnOptions } from 'node:child_process';
 
-import { ManagedCommandRunner } from '../../../core/process/ManagedCommandRunner';
-import { findNodeExecutable } from '../../../utils/env';
+import { findNodeExecutables } from '../../../utils/env';
 
 export type StoredRow = Record<string, unknown>;
 
@@ -11,7 +10,7 @@ export interface StoredSessionRows {
 }
 
 interface SqliteModule {
-  DatabaseSync: new (location: string, options?: Record<string, unknown>) => {
+  DatabaseSync: new (location: string, options: { readOnly: boolean }) => {
     close(): void;
     prepare(sql: string): {
       all(...params: unknown[]): StoredRow[];
@@ -19,10 +18,13 @@ interface SqliteModule {
   };
 }
 
+type SpawnSqliteProcess = (command: string, args: string[], options: SpawnOptions) => ChildProcess;
+
 export interface OpencodeSqliteReaderDependencies {
-  findNodeExecutable?: () => string | null;
+  environment?: NodeJS.ProcessEnv;
+  findNodeExecutables?: () => string[];
   requireSqliteModule?: () => SqliteModule | null;
-  spawn?: typeof defaultSpawn;
+  spawn?: SpawnSqliteProcess;
 }
 
 export const OPENCODE_SQLITE_QUERY_MAX_BUFFER = 100 * 1024 * 1024;
@@ -34,7 +36,7 @@ const { DatabaseSync } = require('node:sqlite');
 const [databasePath, sessionId, messageSql, partSql] = process.argv.slice(1);
 let db;
 try {
-  db = new DatabaseSync(databasePath, { readonly: true });
+  db = new DatabaseSync(databasePath, { readOnly: true });
   const messageRows = db.prepare(messageSql).all(sessionId);
   const partRows = db.prepare(partSql).all(sessionId);
   process.stdout.write(JSON.stringify({ messageRows, partRows }));
@@ -47,57 +49,79 @@ export async function loadOpencodeSessionRows(
   databasePath: string,
   sessionId: string,
   dependencies: OpencodeSqliteReaderDependencies = {},
-): Promise<StoredSessionRows | null> {
-  const resolvedDependencies = resolveDependencies(dependencies);
+): Promise<StoredSessionRows> {
+  const spawn = dependencies.spawn ?? defaultSpawn;
+  const environment = dependencies.environment ?? process.env;
+  const errors: string[] = [];
 
-  const viaCurrentProcess = loadSessionRowsWithCurrentProcessSqlite(
-    databasePath,
-    sessionId,
-    resolvedDependencies.requireSqliteModule,
-  );
-  if (viaCurrentProcess) {
-    return viaCurrentProcess;
+  try {
+    const sqlite = (dependencies.requireSqliteModule ?? requireSqliteModule)();
+    if (!sqlite) throw new Error('node:sqlite is unavailable.');
+    const db = new sqlite.DatabaseSync(databasePath, { readOnly: true });
+    try {
+      return {
+        messageRows: db.prepare(OPENCODE_MESSAGE_ROW_SQL).all(sessionId),
+        partRows: db.prepare(OPENCODE_PART_ROW_SQL).all(sessionId),
+      };
+    } finally {
+      db.close();
+    }
+  } catch (error) {
+    errors.push(`Obsidian SQLite: ${formatError(error)}`);
   }
 
-  const viaNodeProcess = await loadSessionRowsWithNodeProcess(
-    databasePath,
-    sessionId,
-    resolvedDependencies.findNodeExecutable,
-    resolvedDependencies.spawn,
-  );
-  if (viaNodeProcess) {
-    return viaNodeProcess;
+  const nodePaths = dependencies.findNodeExecutables?.() ?? findNodeExecutables(environment.PATH);
+  if (nodePaths.length === 0) errors.push('Node.js: no executable found.');
+  for (const nodePath of nodePaths) {
+    try {
+      const stdout = await runBufferedChild(nodePath, [
+        '-e',
+        OPENCODE_SQLITE_CHILD_SCRIPT,
+        databasePath,
+        sessionId,
+        OPENCODE_MESSAGE_ROW_SQL,
+        OPENCODE_PART_ROW_SQL,
+      ], spawn, environment);
+      const rows = parseStoredSessionRows(stdout);
+      if (!rows) throw new Error('Invalid SQLite query output.');
+      return rows;
+    } catch (error) {
+      errors.push(`Node.js (${nodePath}): ${formatError(error)}`);
+    }
   }
 
-  return loadSessionRowsWithSqliteCli(
-    databasePath,
-    sessionId,
-    resolvedDependencies.spawn,
-  );
-}
+  try {
+    const escapedSessionId = escapeSqlLiteral(sessionId);
+    const messageRows = await runSqlite3JsonQuery(
+      databasePath,
+      buildOpencodeMessageRowsSql(`'${escapedSessionId}'`),
+      spawn,
+      environment,
+    );
+    const partRows = await runSqlite3JsonQuery(
+      databasePath,
+      buildOpencodePartRowsSql(`'${escapedSessionId}'`),
+      spawn,
+      environment,
+    );
+    return { messageRows, partRows };
+  } catch (error) {
+    errors.push(`sqlite3: ${formatError(error)}`);
+  }
 
-function resolveDependencies(
-  dependencies: OpencodeSqliteReaderDependencies,
-): Required<OpencodeSqliteReaderDependencies> {
-  return {
-    findNodeExecutable,
-    requireSqliteModule,
-    spawn: defaultSpawn,
-    ...dependencies,
-  };
+  throw new Error([
+    'Could not read OpenCode session rows from SQLite.',
+    ...errors,
+    'History requires working SQLite support in Obsidian, Node.js 22.13+ (or a newer supported release), or sqlite3.',
+  ].join('\n'));
 }
 
 function requireSqliteModule(): SqliteModule | null {
-  try {
-    if (typeof module === 'undefined' || typeof module.require !== 'function') {
-      return null;
-    }
-
-    const sqlite = module.require('node:sqlite') as unknown;
-    return isSqliteModule(sqlite) ? sqlite : null;
-  } catch {
-    return null;
-  }
+  // Obsidian supplies require separately from its plain { exports } module object.
+  const sqliteModuleName = 'node:sqlite';
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- Load optional SQLite lazily through Obsidian's injected require.
+  const sqlite = require(sqliteModuleName) as unknown;
+  return isSqliteModule(sqlite) ? sqlite : null;
 }
 
 function isSqliteModule(value: unknown): value is SqliteModule {
@@ -107,108 +131,74 @@ function isSqliteModule(value: unknown): value is SqliteModule {
   );
 }
 
-function loadSessionRowsWithCurrentProcessSqlite(
-  databasePath: string,
-  sessionId: string,
-  requireSqlite: () => SqliteModule | null,
-): StoredSessionRows | null {
-  const sqlite = requireSqlite();
-  if (!sqlite) {
-    return null;
-  }
-
-  let db: InstanceType<SqliteModule['DatabaseSync']> | null = null;
-  try {
-    db = new sqlite.DatabaseSync(databasePath, { readonly: true });
-    const messageRows = db.prepare(OPENCODE_MESSAGE_ROW_SQL).all(sessionId);
-    const partRows = db.prepare(OPENCODE_PART_ROW_SQL).all(sessionId);
-    return { messageRows, partRows };
-  } catch {
-    return null;
-  } finally {
-    db?.close();
-  }
-}
-
-async function loadSessionRowsWithNodeProcess(
-  databasePath: string,
-  sessionId: string,
-  findNode: () => string | null,
-  spawn: typeof defaultSpawn,
-): Promise<StoredSessionRows | null> {
-  const nodePath = findNode();
-  if (!nodePath) {
-    return null;
-  }
-
-  const stdout = await runBufferedChild(
-    nodePath,
-    [
-      '-e',
-      OPENCODE_SQLITE_CHILD_SCRIPT,
-      databasePath,
-      sessionId,
-      OPENCODE_MESSAGE_ROW_SQL,
-      OPENCODE_PART_ROW_SQL,
-    ],
-    spawn,
-  );
-  return stdout === null ? null : parseStoredSessionRows(stdout);
-}
-
-async function loadSessionRowsWithSqliteCli(
-  databasePath: string,
-  sessionId: string,
-  spawn: typeof defaultSpawn,
-): Promise<StoredSessionRows | null> {
-  const escapedSessionId = escapeSqlLiteral(sessionId);
-  const messageRows = await runSqlite3JsonQuery(
-    databasePath,
-    buildOpencodeMessageRowsSql(`'${escapedSessionId}'`),
-    spawn,
-  );
-  const partRows = await runSqlite3JsonQuery(
-    databasePath,
-    buildOpencodePartRowsSql(`'${escapedSessionId}'`),
-    spawn,
-  );
-
-  if (!messageRows || !partRows) {
-    return null;
-  }
-
-  return { messageRows, partRows };
-}
-
 async function runSqlite3JsonQuery(
   databasePath: string,
   sql: string,
-  spawn: typeof defaultSpawn,
-): Promise<StoredRow[] | null> {
+  spawn: SpawnSqliteProcess,
+  environment: NodeJS.ProcessEnv,
+): Promise<StoredRow[]> {
   const stdout = await runBufferedChild(
     'sqlite3',
-    ['-json', databasePath, sql],
+    ['-readonly', '-json', databasePath, sql],
     spawn,
+    environment,
   );
-  return stdout === null ? null : parseStoredRows(stdout);
+  const rows = parseStoredRows(stdout);
+  if (!rows) throw new Error('Invalid SQLite query output.');
+  return rows;
 }
 
 function runBufferedChild(
   command: string,
   args: string[],
-  spawn: typeof defaultSpawn,
-): Promise<string | null> {
-  return new ManagedCommandRunner().run({
-    args,
-    command,
-    cwd: process.cwd(),
-    env: process.env,
-    spawn,
-    stdoutLimitBytes: OPENCODE_SQLITE_QUERY_MAX_BUFFER,
-    timeoutMs: 10_000,
-  }).then(result => (
-    result.termination || result.exitCode !== 0 ? null : result.stdout
-  ));
+  spawn: SpawnSqliteProcess,
+  environment: NodeJS.ProcessEnv,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let size = 0;
+    let timer: number | null = null;
+    const chunks: Buffer[] = [];
+    let stderr = '';
+    const child = spawn(command, args, {
+      env: environment,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    const finish = (error?: Error): void => {
+      if (settled) return;
+      settled = true;
+      if (timer !== null) window.clearTimeout(timer);
+      if (error) reject(error);
+      else resolve(Buffer.concat(chunks).toString('utf8'));
+    };
+
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      size += buffer.length;
+      if (size > OPENCODE_SQLITE_QUERY_MAX_BUFFER) {
+        child.kill('SIGKILL');
+        finish(new Error('SQLite query output exceeded the size limit.'));
+        return;
+      }
+      chunks.push(buffer);
+    });
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      stderr = (stderr + chunk.toString()).slice(0, 2_000);
+    });
+    child.once('error', (error) => finish(error));
+    child.once('close', (code) => {
+      finish(code === 0 ? undefined : new Error(stderr.trim() || `Process exited with code ${code}.`));
+    });
+    timer = window.setTimeout(() => {
+      child.kill('SIGKILL');
+      finish(new Error('SQLite query timed out after 10 seconds.'));
+    }, 10_000);
+  });
+}
+
+function formatError(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error)).slice(0, 2_000);
 }
 
 function parseStoredSessionRows(value: string): StoredSessionRows | null {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -185,7 +185,8 @@ function getExtraBinaryPaths(): string[] {
   }
 }
 
-export function findNodeDirectory(additionalPaths?: string): string | null {
+function* findNodeDirectories(additionalPaths?: string): Generator<string, undefined> {
+  const executables = new Set<string>();
   const searchPaths = getExtraBinaryPaths();
 
   const currentPath = process.env.PATH || '';
@@ -199,8 +200,9 @@ export function findNodeDirectory(additionalPaths?: string): string | null {
       const nodePath = path.join(dir, NODE_EXECUTABLE);
       if (fs.existsSync(nodePath)) {
         const stat = fs.statSync(nodePath);
-        if (stat.isFile()) {
-          return dir;
+        if (stat.isFile() && !executables.has(nodePath)) {
+          executables.add(nodePath);
+          yield dir;
         }
       }
     } catch {
@@ -208,15 +210,19 @@ export function findNodeDirectory(additionalPaths?: string): string | null {
     }
   }
 
-  return null;
+}
+
+export function findNodeExecutables(additionalPaths?: string): string[] {
+  return [...findNodeDirectories(additionalPaths)].map(dir => path.join(dir, NODE_EXECUTABLE));
+}
+
+export function findNodeDirectory(additionalPaths?: string): string | null {
+  return findNodeDirectories(additionalPaths).next().value ?? null;
 }
 
 export function findNodeExecutable(additionalPaths?: string): string | null {
   const nodeDir = findNodeDirectory(additionalPaths);
-  if (nodeDir) {
-    return path.join(nodeDir, NODE_EXECUTABLE);
-  }
-  return null;
+  return nodeDir ? path.join(nodeDir, NODE_EXECUTABLE) : null;
 }
 
 export function cliPathRequiresNode(cliPath: string): boolean {

--- a/tests/unit/providers/opencode/OpencodeHistoryStore.test.ts
+++ b/tests/unit/providers/opencode/OpencodeHistoryStore.test.ts
@@ -5,11 +5,29 @@ import { DatabaseSync } from 'node:sqlite';
 
 import {
   loadOpencodeSessionMessages,
+  loadOpencodeSessionModel,
   mapOpencodeMessages,
   OPENCODE_MESSAGE_ROW_SQL,
 } from '../../../../src/providers/opencode/history/OpencodeHistoryStore';
 
 describe('mapOpencodeMessages', () => {
+  it('preserves Windows paths as literal code in hydration diagnostics', () => {
+    const [message] = mapOpencodeMessages(
+      [{ info: { id: 'msg-bad', data_valid: 0 }, parts: [] }],
+      { databasePath: String.raw`C:\Users\cylix\.local\share\opencode\opencode.db` },
+    );
+
+    expect(message.content).toBe([
+      '```text',
+      'Failed to hydrate OpenCode session.',
+      'provider: OpenCode',
+      String.raw`databasePath: C:\Users\cylix\.local\share\opencode\opencode.db`,
+      'messageId: msg-bad',
+      'reason: OpenCode message metadata is not valid JSON.',
+      '```',
+    ].join('\n'));
+  });
+
   it('maps stored OpenCode messages into Claudian chat messages', () => {
     const messages = mapOpencodeMessages([
       {
@@ -375,10 +393,12 @@ describe('mapOpencodeMessages', () => {
     expect(messages).toEqual([
       expect.objectContaining({
         content: [
+          '```text',
           'Failed to hydrate OpenCode session.',
           'provider: OpenCode',
           'messageId: msg-bad',
           'reason: OpenCode message metadata is not valid JSON.',
+          '```',
         ].join('\n'),
         id: 'opencode-hydration-error-message-msg-bad',
         role: 'assistant',
@@ -405,6 +425,18 @@ describe('loadOpencodeSessionMessages', () => {
 
   afterEach(() => {
     rmSync(tmpRoot, { force: true, recursive: true });
+  });
+
+  it('shows underlying SQLite failure as a history diagnostic', async () => {
+    const dbPath = path.join(tmpRoot, 'empty.db');
+    new DatabaseSync(dbPath).close();
+
+    const messages = await loadOpencodeSessionMessages('ses-empty', { databasePath: dbPath });
+    expect(messages).toEqual([expect.objectContaining({
+      id: 'opencode-hydration-error-session-ses-empty',
+      content: expect.stringContaining('no such table: message'),
+    })]);
+    await expect(loadOpencodeSessionModel('ses-empty', { databasePath: dbPath })).resolves.toBeNull();
   });
 
   it('loads conversation content without selecting raw message metadata', async () => {

--- a/tests/unit/providers/opencode/OpencodeSqliteReader.test.ts
+++ b/tests/unit/providers/opencode/OpencodeSqliteReader.test.ts
@@ -1,4 +1,5 @@
-import type { spawn as nodeSpawn } from 'node:child_process';
+import { spawn as nodeSpawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { mkdtempSync, rmSync } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -9,9 +10,10 @@ import { createMockChildProcess } from '@test/helpers/MockChildProcess';
 import {
   loadOpencodeSessionRows,
   OPENCODE_MESSAGE_ROW_SQL,
+  type OpencodeSqliteReaderDependencies,
 } from '../../../../src/providers/opencode/history/OpencodeSqliteReader';
 
-type Spawn = typeof nodeSpawn;
+type Spawn = NonNullable<OpencodeSqliteReaderDependencies['spawn']>;
 
 describe('loadOpencodeSessionRows', () => {
   let tmpRoot: string;
@@ -25,11 +27,66 @@ describe('loadOpencodeSessionRows', () => {
     jest.restoreAllMocks();
   });
 
+  it('never creates a missing history database through in-process SQLite', async () => {
+    const dbPath = path.join(tmpRoot, 'missing.db');
+    await loadOpencodeSessionRows(dbPath, 'ses-missing', {
+      requireSqliteModule: () => ({ DatabaseSync } as any),
+      findNodeExecutables: () => [],
+      spawn: createSpawnMock([]),
+    }).catch(() => undefined);
+    expect(existsSync(dbPath)).toBe(false);
+  });
+
+  it('tries a compatible Node after an installed Node fails', async () => {
+    const dbPath = createFixtureDatabase(tmpRoot);
+    const nodeWithoutSqlite = path.join(tmpRoot, 'old-node');
+    const spawn: Spawn = (command, args, options) => nodeSpawn(
+      process.execPath,
+      command === process.execPath ? args : ['--no-experimental-sqlite', ...args],
+      options,
+    );
+    await expect(loadOpencodeSessionRows(dbPath, 'ses-child', {
+      requireSqliteModule: () => null,
+      findNodeExecutables: () => [nodeWithoutSqlite, process.execPath],
+      spawn,
+    })).resolves.toMatchObject({ partRows: [{ id: 'part-user' }] });
+  });
+
+  it('reports backend errors when SQLite cannot read the database', async () => {
+    const dbPath = path.join(tmpRoot, 'empty.db');
+    new DatabaseSync(dbPath).close();
+    const spawn: Spawn = (command, args, options) => nodeSpawn(
+      command === 'sqlite3' ? path.join(tmpRoot, 'missing-sqlite3') : command,
+      args,
+      options,
+    );
+    await expect(loadOpencodeSessionRows(dbPath, 'ses-missing', {
+      requireSqliteModule: () => null,
+      findNodeExecutables: () => [process.execPath],
+      spawn,
+    })).rejects.toThrow('no such table: message');
+  });
+
+  it('uses the supplied environment for external SQLite readers', async () => {
+    const dbPath = createFixtureDatabase(tmpRoot);
+    const spawn: Spawn = (command, args, options) => nodeSpawn(
+      command === 'sqlite3' ? path.join(tmpRoot, 'missing-sqlite3') : command,
+      args,
+      options,
+    );
+    await expect(loadOpencodeSessionRows(dbPath, 'ses-child', {
+      environment: { ...process.env, NODE_OPTIONS: '--no-experimental-sqlite' },
+      requireSqliteModule: () => null,
+      findNodeExecutables: () => [process.execPath],
+      spawn,
+    })).rejects.toThrow('No such built-in module: node:sqlite');
+  });
+
   it('loads rows through a Node child process when in-process SQLite is unavailable', async () => {
     const dbPath = createFixtureDatabase(tmpRoot);
 
     await expect(loadOpencodeSessionRows(dbPath, 'ses-child', {
-      findNodeExecutable: () => process.execPath,
+      findNodeExecutables: () => [process.execPath],
       requireSqliteModule: () => null,
     })).resolves.toEqual({
       messageRows: [{
@@ -50,6 +107,59 @@ describe('loadOpencodeSessionRows', () => {
     });
   });
 
+  it('opens an in-process SQLite database in read-only mode', async () => {
+    const database = {
+      close: jest.fn(),
+      prepare: jest.fn(() => ({ all: jest.fn(() => []) })),
+    };
+    const DatabaseSync = jest.fn(() => database);
+
+    await expect(loadOpencodeSessionRows('/tmp/opencode.db', 'ses-read-only', {
+      requireSqliteModule: () => ({ DatabaseSync } as any),
+    })).resolves.toEqual({ messageRows: [], partRows: [] });
+
+    expect(DatabaseSync).toHaveBeenCalledWith('/tmp/opencode.db', { readOnly: true });
+    expect(database.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('tries each discovered Node executable with the configured environment', async () => {
+    const spawn = createSpawnMock([
+      { status: 1, stdout: '' },
+      {
+        status: 0,
+        stdout: JSON.stringify({
+          messageRows: [{ id: 'msg-user' }],
+          partRows: [{ id: 'part-user' }],
+        }),
+      },
+    ]);
+    const environment = { PATH: 'C:\\custom\\node;C:\\Windows\\System32' };
+
+    await expect(loadOpencodeSessionRows('/tmp/opencode.db', 'ses-node-fallback', {
+      environment,
+      findNodeExecutables: () => ['C:\\broken\\node.exe', 'C:\\working\\node.exe'],
+      requireSqliteModule: () => null,
+      spawn,
+    })).resolves.toEqual({
+      messageRows: [{ id: 'msg-user' }],
+      partRows: [{ id: 'part-user' }],
+    });
+
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(spawn).toHaveBeenNthCalledWith(
+      1,
+      'C:\\broken\\node.exe',
+      expect.any(Array),
+      expect.objectContaining({ env: environment }),
+    );
+    expect(spawn).toHaveBeenNthCalledWith(
+      2,
+      'C:\\working\\node.exe',
+      expect.any(Array),
+      expect.objectContaining({ env: environment }),
+    );
+  });
+
   it('uses a discovered Node executable before the system sqlite3 fallback', async () => {
     const spawn = createSpawnMock([{
       status: 0,
@@ -60,7 +170,7 @@ describe('loadOpencodeSessionRows', () => {
     }]);
 
     await expect(loadOpencodeSessionRows('/tmp/opencode.db', 'ses-node', {
-      findNodeExecutable: () => '/usr/local/bin/node',
+      findNodeExecutables: () => ['/usr/local/bin/node'],
       requireSqliteModule: () => null,
       spawn,
     })).resolves.toEqual({
@@ -80,7 +190,7 @@ describe('loadOpencodeSessionRows', () => {
         expect.stringContaining('from part'),
       ],
       expect.objectContaining({
-        stdio: ['ignore', 'pipe', 'ignore'],
+        stdio: ['ignore', 'pipe', 'pipe'],
         windowsHide: true,
       }),
     );
@@ -99,7 +209,7 @@ describe('loadOpencodeSessionRows', () => {
     ]);
 
     await expect(loadOpencodeSessionRows('/tmp/opencode.db', 'ses-with-quote\'s', {
-      findNodeExecutable: () => null,
+      findNodeExecutables: () => [],
       requireSqliteModule: () => null,
       spawn,
     })).resolves.toEqual({
@@ -112,12 +222,13 @@ describe('loadOpencodeSessionRows', () => {
       1,
       'sqlite3',
       [
+        '-readonly',
         '-json',
         '/tmp/opencode.db',
         expect.stringContaining("where session_id = 'ses-with-quote''s'"),
       ],
       expect.objectContaining({
-        stdio: ['ignore', 'pipe', 'ignore'],
+        stdio: ['ignore', 'pipe', 'pipe'],
         windowsHide: true,
       }),
     );
@@ -125,12 +236,13 @@ describe('loadOpencodeSessionRows', () => {
       2,
       'sqlite3',
       [
+        '-readonly',
         '-json',
         '/tmp/opencode.db',
         expect.stringContaining("where session_id = 'ses-with-quote''s'"),
       ],
       expect.objectContaining({
-        stdio: ['ignore', 'pipe', 'ignore'],
+        stdio: ['ignore', 'pipe', 'pipe'],
         windowsHide: true,
       }),
     );


### PR DESCRIPTION
## Summary
- restore OpenCode history when Obsidian injects a plain require object
- open SQLite databases with the correct read-only option and preserve backend diagnostics
- try all discovered Node executables with the configured environment before sqlite3 fallback
- pass provider history environment through model recovery and hydration

Adapted from upstream Claudian PR #1314 within the existing OpenCode history boundary.

## Verification
- pnpm exec jest tests/unit/providers/opencode --runInBand
- pnpm run typecheck
- pnpm run lint
- pnpm run test
- pnpm run build