### PR TITLE
refactor: extract message action row

### DIFF
--- a/src/features/chat/rendering/MessageActionRow.ts
+++ b/src/features/chat/rendering/MessageActionRow.ts
@@ -1,0 +1,19 @@
+const MESSAGE_ACTION_ROW_CLASS = 'claudian-message-action-row';
+const MESSAGE_ACTION_VISIBILITY_CLASS = 'claudian-message-actions';
+
+/**
+ * Returns the single action row owned by a message shell.
+ *
+ * Keeping the row as a direct child prevents action controls from becoming
+ * part of the content bubble's sizing or Markdown layout.
+ */
+export function getOrCreateMessageActionRow(messageEl: HTMLElement): HTMLElement {
+  const existing = Array.from(messageEl.children).find((child) => (
+    child.classList.contains(MESSAGE_ACTION_ROW_CLASS)
+  ));
+  if (existing) return existing as HTMLElement;
+
+  return messageEl.createDiv({
+    cls: `${MESSAGE_ACTION_ROW_CLASS} ${MESSAGE_ACTION_VISIBILITY_CLASS}`,
+  });
+}

--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -46,6 +46,7 @@ import {
   restoreDisplayOnlyCodeFences,
 } from './DisplayOnlyCodeFences';
 import { renderMermaidDiagram } from './MermaidRenderer';
+import { getOrCreateMessageActionRow } from './MessageActionRow';
 import { resolveSubagentAdapter } from './subagentAdapterResolution';
 import {
   renderStoredAsyncSubagent,
@@ -241,7 +242,7 @@ export class MessageRenderer {
       msgEl.removeAttribute('data-toc-title');
     }
 
-    const toolbar = msgEl.querySelector<HTMLElement>('.claudian-user-msg-actions');
+    const toolbar = msgEl.querySelector<HTMLElement>('.claudian-message-action-row');
     if (toolbar) {
       toolbar.querySelectorAll('.claudian-user-msg-copy-btn').forEach((el) => el.remove());
     }
@@ -1242,9 +1243,7 @@ export class MessageRenderer {
   }
 
   private getOrCreateActionsToolbar(msgEl: HTMLElement): HTMLElement {
-    const existing = msgEl.querySelector<HTMLElement>('.claudian-user-msg-actions');
-    if (existing) return existing;
-    return msgEl.createDiv({ cls: 'claudian-user-msg-actions claudian-message-actions' });
+    return getOrCreateMessageActionRow(msgEl);
   }
 
   private addUserCopyButton(msgEl: HTMLElement, content: string): void {

--- a/src/style/components/messages.css
+++ b/src/style/components/messages.css
@@ -376,7 +376,7 @@ button.claudian-completed-work-header:focus-visible {
 }
 
 /* Message actions share one hover-revealed row below the content bubble. */
-.claudian-user-msg-actions {
+.claudian-message-action-row {
   display: flex;
   align-items: center;
   gap: 12px;
@@ -385,7 +385,7 @@ button.claudian-completed-work-header:focus-visible {
   transition: opacity 0.15s;
 }
 
-.claudian-message-user > .claudian-user-msg-actions {
+.claudian-message-user > .claudian-message-action-row {
   justify-content: flex-end;
 }
 
@@ -432,7 +432,7 @@ button.claudian-completed-work-header:focus-visible {
   z-index: auto;
 }
 
-.claudian-user-msg-actions button {
+.claudian-message-action-row button {
   appearance: none;
   width: auto;
   min-width: 0;
@@ -451,14 +451,14 @@ button.claudian-completed-work-header:focus-visible {
   transition: color 0.15s;
 }
 
-.claudian-user-msg-actions button svg {
+.claudian-message-action-row button svg {
   width: 16px;
   height: 16px;
 }
 
-.claudian-user-msg-actions button:hover,
-.claudian-user-msg-actions button:focus-visible,
-.claudian-user-msg-actions button:active {
+.claudian-message-action-row button:hover,
+.claudian-message-action-row button:focus-visible,
+.claudian-message-action-row button:active {
   padding: 0;
   border: 0;
   background: transparent;
@@ -466,12 +466,12 @@ button.claudian-completed-work-header:focus-visible {
   color: var(--text-normal);
 }
 
-.claudian-user-msg-actions button:focus-visible {
+.claudian-message-action-row button:focus-visible {
   outline: 2px solid var(--interactive-accent);
   outline-offset: 2px;
 }
 
-.claudian-user-msg-actions button:disabled {
+.claudian-message-action-row button:disabled {
   padding: 0;
   border: 0;
   background: transparent;
@@ -480,7 +480,7 @@ button.claudian-completed-work-header:focus-visible {
   cursor: default;
 }
 
-.claudian-user-msg-actions button.copied {
+.claudian-message-action-row button.copied {
   color: var(--text-accent);
   font-size: 11px;
   font-family: var(--font-monospace);

--- a/tests/unit/features/chat/rendering/MessageActionRow.test.ts
+++ b/tests/unit/features/chat/rendering/MessageActionRow.test.ts
@@ -1,0 +1,23 @@
+import { createMockEl } from '@test/helpers/MockElement';
+
+import { getOrCreateMessageActionRow } from '@/features/chat/rendering/MessageActionRow';
+
+describe('getOrCreateMessageActionRow', () => {
+  it('creates one direct child action row with the shared message-action classes', () => {
+    const messageEl = createMockEl();
+
+    const row = getOrCreateMessageActionRow(messageEl);
+
+    expect(row.hasClass('claudian-message-action-row')).toBe(true);
+    expect(row.hasClass('claudian-message-actions')).toBe(true);
+    expect(messageEl.children).toContain(row);
+  });
+
+  it('reuses the direct child row instead of creating duplicate action areas', () => {
+    const messageEl = createMockEl();
+    const existing = messageEl.createDiv({ cls: 'claudian-message-action-row claudian-message-actions' });
+
+    expect(getOrCreateMessageActionRow(messageEl)).toBe(existing);
+    expect(messageEl.children).toHaveLength(1);
+  });
+});

--- a/tests/unit/style/components/messages.test.ts
+++ b/tests/unit/style/components/messages.test.ts
@@ -45,7 +45,7 @@ describe('Message styles', () => {
 
     expect(css).toMatch(/\.claudian-message-user\s*{[^}]*padding:\s*0;/);
     expect(css).toMatch(/\.claudian-message-user > \.claudian-message-content\s*{[^}]*padding:\s*10px 14px;/);
-    expect(css).toMatch(/\.claudian-user-msg-actions\s*{[^}]*display:\s*flex;[^}]*margin-top:\s*8px;/);
+    expect(css).toMatch(/\.claudian-message-action-row\s*{[^}]*display:\s*flex;[^}]*margin-top:\s*8px;/);
     expect(css).toMatch(/\.claudian-message-user > \.claudian-message-actions\s*{[^}]*position:\s*absolute;[^}]*inset-inline-end:\s*0;/);
     expect(css).toMatch(/\.claudian-message-user::after\s*{[^}]*height:\s*8px;/);
     expect(css).toMatch(/\.claudian-message-actions\s*{[^}]*pointer-events:\s*none;/);


### PR DESCRIPTION
## Summary
- centralize message action-row creation in a dedicated rendering component
- keep action controls as direct message children so they cannot affect bubble or Markdown layout
- extend style contracts and unit coverage for action-row ownership, branded bubbles, hover bridging, and focus visibility

## Verification
- pnpm run typecheck
- pnpm run lint (warnings only)
- pnpm run test