### PR TITLE
Fix repeated completed disclosures in subagent transcripts

### DIFF
--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -327,7 +327,12 @@ export class ConversationController {
     if (typeof renderer.renderMessagesInto !== 'function') return;
 
     panel.setMessageRenderer((containerEl, messages) => {
-      renderer.renderMessagesInto(containerEl, messages);
+      renderer.renderMessagesInto(containerEl, messages, {
+        // A subagent transcript often contains many short tool-only turns.
+        // Collapsing each one produces a wall of indistinguishable
+        // "Completed" disclosures instead of the actual running history.
+        collapseCompletedWork: false,
+      });
     });
   }
 

--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -306,7 +306,11 @@ export class MessageRenderer {
   renderMessagesInto(
     containerEl: HTMLElement,
     messages: ChatMessage[],
-    options?: { suppressConversationActions?: boolean },
+    options?: {
+      suppressConversationActions?: boolean;
+      /** Keep transcript steps visible instead of wrapping every turn in a completed disclosure. */
+      collapseCompletedWork?: boolean;
+    },
   ): void {
     const mainMessagesEl = this.messagesEl;
     const previousSuppress = this.suppressConversationActions;
@@ -315,7 +319,9 @@ export class MessageRenderer {
     try {
       containerEl.empty();
       for (let index = 0; index < messages.length; index++) {
-        this.renderStoredMessage(messages[index], messages, index);
+        this.renderStoredMessage(messages[index], messages, index, {
+          collapseCompletedWork: options?.collapseCompletedWork ?? true,
+        });
       }
     } finally {
       this.messagesEl = mainMessagesEl;
@@ -323,7 +329,12 @@ export class MessageRenderer {
     }
   }
 
-  renderStoredMessage(msg: ChatMessage, allMessages?: ChatMessage[], index?: number): void {
+  renderStoredMessage(
+    msg: ChatMessage,
+    allMessages?: ChatMessage[],
+    index?: number,
+    options?: { collapseCompletedWork?: boolean },
+  ): void {
     // Bare interrupt marker: user-role interrupts (Claude bracket markers) always render
     // as a standalone indicator. Assistant-role interrupts (Codex partial responses)
     // only use the bare marker when there's no content to preserve.
@@ -392,7 +403,7 @@ export class MessageRenderer {
     if (shouldRenderTimestamp) {
       this.renderMessageTimestamp(msgEl, msg.timestamp);
     }
-    if (msg.role === 'assistant') {
+    if (msg.role === 'assistant' && options?.collapseCompletedWork !== false) {
       this.finalizeCompletedWork(msg);
     }
   }

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -4691,6 +4691,7 @@ describe('ConversationController rich transcript rendering', () => {
     expect(renderMessagesInto).toHaveBeenCalledWith(
       expect.anything(),
       expect.arrayContaining([expect.objectContaining({ content: '**bold** result' })]),
+      { collapseCompletedWork: false },
     );
     const root = messagesEl.querySelector('.claudian-subagent-transcript');
     expect(root).toBeTruthy();

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -2600,5 +2600,41 @@ describe('MessageRenderer', () => {
       renderer.renderStoredMessage(eligibleMessages()[0], eligibleMessages(), 0);
       expect(messagesEl.querySelector('.claudian-message-rewind-btn')).not.toBeNull();
     });
+
+    it('keeps completed work expanded when rendering a subagent transcript', () => {
+      const messagesEl = createMockEl();
+      const renderer = new MessageRenderer(
+        { app: {}, settings: { mediaFolder: '' } } as any,
+        createMockComponent() as any,
+        messagesEl,
+        jest.fn(),
+        jest.fn(),
+        mockCapabilities(),
+      );
+      jest.spyOn(renderer, 'renderContent').mockResolvedValue(undefined);
+      const finalizeCompletedWork = jest.spyOn(renderer, 'finalizeCompletedWork');
+
+      const container = createMockEl();
+      renderer.renderMessagesInto(container, [{
+        id: 'subagent-turn-1',
+        role: 'assistant',
+        content: 'The search is complete.',
+        timestamp: 1,
+        contentBlocks: [
+          { type: 'tool_use', toolId: 'tool-1' },
+          { type: 'text', content: 'The search is complete.' },
+        ],
+        toolCalls: [{
+          id: 'tool-1',
+          name: 'Bash',
+          input: { command: 'rg --files' },
+          status: 'completed',
+          result: 'note.md',
+          isExpanded: false,
+        }],
+      }] as ChatMessage[], { collapseCompletedWork: false });
+
+      expect(finalizeCompletedWork).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- keep completed work expanded in read-only subagent transcripts
- preserve completed-work collapsing for normal conversation rendering
- add regression coverage for the transcript renderer