### PR TITLE
feat: describe active provider capabilities

### DIFF
--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -207,6 +207,8 @@ export interface ProviderUIOption {
   value: string;
   label: string;
   description?: string;
+  /** Provider that owns this option when options from multiple providers are mixed. */
+  providerId?: ProviderId;
   /** Optional group label for visual separators in dropdowns. */
   group?: string;
   /** Per-option icon override (e.g. when mixing providers in a single dropdown). */

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -28,7 +28,11 @@ import {
 } from '../OpenSubagentTranscriptEvent';
 import type { MessageRenderer } from '../rendering/MessageRenderer';
 import { cleanupThinkingBlock } from '../rendering/ThinkingBlockRenderer';
-import { createWelcomeElement, renderWelcomeContent } from '../rendering/WelcomeRenderer';
+import {
+  createWelcomeElement,
+  renderWelcomeContent,
+  type WelcomeProviderSummary,
+} from '../rendering/WelcomeRenderer';
 import { findRewindContext } from '../rewind';
 import type { SubagentManager } from '../services/SubagentManager';
 import { projectHistory } from '../session-manager/HistoryProjection';
@@ -102,6 +106,7 @@ export interface ConversationControllerDeps {
   getExecutionCoordinator: () => ChatExecutionCoordinator | null;
   ensureExecutionInitialized?: () => Promise<boolean>;
   getProviderId?: () => ProviderId;
+  getWelcomeProviderSummary?: () => WelcomeProviderSummary;
   getSelectedModel?: () => string | null;
   getInitialUsage?: (providerId: ProviderId, model: string) => UsageInfo | null;
   ensureExecutionForConversation?: (conversation: Conversation | null) => Promise<void>;
@@ -507,7 +512,11 @@ export class ConversationController {
       messagesEl.empty();
 
       // Recreate welcome element first (before StatusPanel for consistent ordering)
-      const welcomeEl = createWelcomeElement(messagesEl, this.getGreeting());
+      const welcomeEl = createWelcomeElement(
+        messagesEl,
+        this.getGreeting(),
+        this.deps.getWelcomeProviderSummary?.(),
+      );
       this.deps.setWelcomeEl(welcomeEl);
 
       // Remount StatusPanel to restore state for new conversation
@@ -2383,9 +2392,11 @@ export class ConversationController {
     fileCtx?.resetForNewConversation();
     fileCtx?.autoAttachActiveFile();
 
-    // Only add greeting if not already present
-    if (!welcomeEl.querySelector('.claudian-welcome-greeting')) {
-      renderWelcomeContent(welcomeEl, this.getGreeting());
+    const providerSummary = this.deps.getWelcomeProviderSummary?.();
+    // A blank tab can change providers without replacing its DOM. In that case
+    // the existing summary is stale and must be replaced, not merely detected.
+    if (!welcomeEl.querySelector('.claudian-welcome-greeting') || providerSummary) {
+      renderWelcomeContent(welcomeEl, this.getGreeting(), providerSummary);
     }
 
     this.updateWelcomeVisibility();

--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -2,6 +2,7 @@ import type { App, Component } from 'obsidian';
 import { MarkdownRenderer, Menu, Notice, setIcon } from 'obsidian';
 
 import type { ChatRewindMode } from '../../../core/execution';
+import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
 import {
   DEFAULT_CHAT_PROVIDER_ID,
   type ProviderCapabilities,
@@ -54,7 +55,7 @@ import {
 } from './SubagentRenderer';
 import { renderStoredThinkingBlock } from './ThinkingBlockRenderer';
 import { renderStoredToolCall } from './ToolCallRenderer';
-import { createWelcomeElement } from './WelcomeRenderer';
+import { createWelcomeElement, type WelcomeProviderSummary } from './WelcomeRenderer';
 import { renderStoredWriteEdit } from './WriteEditRenderer';
 
 export interface RenderContentOptions {
@@ -141,6 +142,14 @@ export class MessageRenderer {
 
   private getSubagentAdapter(toolName?: string) {
     return resolveSubagentAdapter(this.getCapabilities().providerId, toolName);
+  }
+
+  private getWelcomeProviderSummary(): WelcomeProviderSummary {
+    const capabilities = this.getCapabilities();
+    return {
+      displayName: ProviderRegistry.getProviderDisplayName(capabilities.providerId),
+      capabilities,
+    };
   }
 
   private shouldExpandFileEditsByDefault(): boolean {
@@ -287,7 +296,11 @@ export class MessageRenderer {
     this.liveMessageEls.clear();
 
     // Recreate welcome element after clearing
-    const newWelcomeEl = createWelcomeElement(this.messagesEl, getGreeting());
+    const newWelcomeEl = createWelcomeElement(
+      this.messagesEl,
+      getGreeting(),
+      this.getWelcomeProviderSummary(),
+    );
 
     for (let i = 0; i < messages.length; i++) {
       this.renderStoredMessage(messages[i], messages, i);

--- a/src/features/chat/rendering/WelcomeRenderer.ts
+++ b/src/features/chat/rendering/WelcomeRenderer.ts
@@ -1,8 +1,76 @@
+import type { ProviderCapabilities } from '../../../core/providers/types';
+import { t } from '../../../i18n/i18n';
+
 const WELCOME_BRAND_NAME = 'Oh My Claudian';
+
+type WelcomeCapabilityKey = keyof Pick<
+  ProviderCapabilities,
+  | 'supportsPlanMode'
+  | 'supportsRewind'
+  | 'supportsFork'
+  | 'supportsProviderCommands'
+  | 'supportsImageAttachments'
+  | 'supportsMcpTools'
+  | 'supportsTurnSteer'
+>;
+
+const WELCOME_CAPABILITIES: ReadonlyArray<{
+  key: WelcomeCapabilityKey;
+  label: 'settings.capabilityMatrix.rows.planMode'
+    | 'settings.capabilityMatrix.rows.rewind'
+    | 'settings.capabilityMatrix.rows.fork'
+    | 'settings.capabilityMatrix.rows.providerCommands'
+    | 'settings.capabilityMatrix.rows.imageAttachments'
+    | 'settings.capabilityMatrix.rows.mcpTools'
+    | 'settings.capabilityMatrix.rows.turnSteer';
+}> = [
+  { key: 'supportsPlanMode', label: 'settings.capabilityMatrix.rows.planMode' },
+  { key: 'supportsRewind', label: 'settings.capabilityMatrix.rows.rewind' },
+  { key: 'supportsFork', label: 'settings.capabilityMatrix.rows.fork' },
+  { key: 'supportsProviderCommands', label: 'settings.capabilityMatrix.rows.providerCommands' },
+  { key: 'supportsImageAttachments', label: 'settings.capabilityMatrix.rows.imageAttachments' },
+  { key: 'supportsMcpTools', label: 'settings.capabilityMatrix.rows.mcpTools' },
+  { key: 'supportsTurnSteer', label: 'settings.capabilityMatrix.rows.turnSteer' },
+];
+
+export interface WelcomeProviderSummary {
+  displayName: string;
+  capabilities: ProviderCapabilities;
+}
+
+function renderCapabilitySummary(
+  welcomeEl: HTMLElement,
+  providerSummary: WelcomeProviderSummary,
+): void {
+  const supported = WELCOME_CAPABILITIES
+    .filter(({ key }) => providerSummary.capabilities[key])
+    .map(({ label }) => t(label));
+  const unsupported = WELCOME_CAPABILITIES
+    .filter(({ key }) => !providerSummary.capabilities[key])
+    .map(({ label }) => t(label));
+
+  const summaryEl = welcomeEl.createDiv({ cls: 'claudian-welcome-capability-summary' });
+  summaryEl.createDiv({
+    cls: 'claudian-welcome-provider-name',
+    text: providerSummary.displayName,
+  });
+  summaryEl.createDiv({
+    cls: 'claudian-welcome-capability-line claudian-welcome-capability-line--supported',
+    text: t('chat.welcome.availableCapabilities', { capabilities: supported.join(' · ') }),
+  });
+
+  if (unsupported.length > 0) {
+    summaryEl.createDiv({
+      cls: 'claudian-welcome-capability-line claudian-welcome-capability-line--unsupported',
+      text: t('chat.welcome.unavailableCapabilities', { capabilities: unsupported.join(' · ') }),
+    });
+  }
+}
 
 export function renderWelcomeContent(
   welcomeEl: HTMLElement,
   greeting?: string,
+  providerSummary?: WelcomeProviderSummary,
 ): void {
   welcomeEl.empty();
   welcomeEl.createDiv({
@@ -16,13 +84,18 @@ export function renderWelcomeContent(
       text: greeting,
     });
   }
+
+  if (providerSummary) {
+    renderCapabilitySummary(welcomeEl, providerSummary);
+  }
 }
 
 export function createWelcomeElement(
   parentEl: HTMLElement,
   greeting?: string,
+  providerSummary?: WelcomeProviderSummary,
 ): HTMLElement {
   const welcomeEl = parentEl.createDiv({ cls: 'claudian-welcome' });
-  renderWelcomeContent(welcomeEl, greeting);
+  renderWelcomeContent(welcomeEl, greeting, providerSummary);
   return welcomeEl;
 }

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -17,7 +17,9 @@ import {
   resolveNewConversationModel,
 } from '../../../core/providers/conversationModel';
 import { getEnabledProviderForModel, getProviderForModel } from '../../../core/providers/modelRouting';
-import { resolveProviderCustomContextLimit } from '../../../core/providers/modelSelection';
+import {
+  resolveProviderCustomContextLimit,
+} from '../../../core/providers/modelSelection';
 import {
   createProviderDiagnosticError,
   createProviderDiagnosticReport,
@@ -132,7 +134,12 @@ export function getBlankTabModelOptions(
     const group = ProviderRegistry.getProviderDisplayName(providerId);
 
     return uiConfig.getModelOptions(settings)
-      .map(model => ({ ...model, group, providerIcon }));
+      .map(model => ({
+        ...model,
+        group,
+        providerIcon,
+        providerId,
+      }));
   });
 }
 
@@ -1246,6 +1253,7 @@ function initializeInputToolbar(
       tab.providerId = providerId;
       syncTabProviderServices(tab, plugin);
       tab.ui.slashCommandDropdown?.clearProviderCatalog?.();
+      tab.controllers.conversationController?.initializeWelcome();
     },
     restoreDraft: ({ providerId, model }) => {
       tab.draftModel = model;
@@ -1270,15 +1278,12 @@ function initializeInputToolbar(
     getCapabilities: () => getTabCapabilities(tab, plugin),
     getSettings: () => getTabSettingsSnapshot(tab, plugin),
     getEnvironmentVariables: () => plugin.getActiveEnvironmentVariables(),
-    onModelChange: async (model: string) => {
+    onModelChange: async (model: string, selectedProviderId?: ProviderId) => {
       // For blank tabs, update draft model and derive provider
       if (tab.conversationId === null) {
         const selectionIntent = plugin.chatModelSelection.beginIntent();
         const request = modelSelection.beginRequest();
-        const newProvider = getEnabledProviderForModel(
-          model,
-          plugin.settings,
-        );
+        const newProvider = selectedProviderId ?? getEnabledProviderForModel(model, plugin.settings);
         const result = await modelSelection.selectBlank(request, {
           providerId: newProvider,
           model,

--- a/src/features/chat/tabs/TabConversationControllerFactory.ts
+++ b/src/features/chat/tabs/TabConversationControllerFactory.ts
@@ -83,6 +83,13 @@ export function createTabConversationController(
       getExecutionCoordinator: () => tab.executionCoordinator,
       ensureExecutionInitialized: options.ensureExecutionInitialized,
       getProviderId: options.getProviderId,
+      getWelcomeProviderSummary: () => {
+        const providerId = getTabProviderId(tab, plugin);
+        return {
+          displayName: ProviderRegistry.getProviderDisplayName(providerId),
+          capabilities: ProviderRegistry.getCapabilities(providerId),
+        };
+      },
       getSelectedModel: options.getSelectedModel,
       getInitialUsage: (providerId: ProviderId, model: string) => ProviderRegistry
         .getChatUIConfig(providerId)

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -6,6 +6,7 @@ import type { McpServerManager } from '../../../core/mcp/McpServerManager';
 import type {
   ProviderCapabilities,
   ProviderChatUIConfig,
+  ProviderId,
   ProviderModeSelectorConfig,
   ProviderPermissionModeToggleConfig,
   ProviderReasoningOption,
@@ -53,7 +54,7 @@ export interface ToolbarSettings {
 }
 
 export interface ToolbarCallbacks {
-  onModelChange: (model: string) => Promise<void>;
+  onModelChange: (model: string, providerId?: ProviderId) => Promise<void>;
   onModeChange: (mode: string) => Promise<void>;
   onThinkingBudgetChange: (budget: string) => Promise<void>;
   onEffortLevelChange: (effort: string) => Promise<void>;
@@ -161,7 +162,11 @@ export class ModelSelector {
       option.addEventListener('click', (e) => {
         e.stopPropagation();
         runToolbarAction(async () => {
-          await this.callbacks.onModelChange(model.value);
+          if (model.providerId) {
+            await this.callbacks.onModelChange(model.value, model.providerId);
+          } else {
+            await this.callbacks.onModelChange(model.value);
+          }
           this.updateDisplay();
           this.renderOptions();
         }, 'Failed to change model');

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -88,6 +88,10 @@
       "label": "Abgeschlossen",
       "seconds": "Dauer: {seconds} Sek.",
       "minutes": "Dauer: {minutes} Min. {seconds} Sek."
+    },
+    "welcome": {
+      "availableCapabilities": "Verfügbar: {capabilities}",
+      "unavailableCapabilities": "Nicht verfügbar: {capabilities}"
     }
   },
   "settings": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -88,6 +88,10 @@
       "label": "Completed",
       "seconds": "Took {seconds}s",
       "minutes": "Took {minutes}m {seconds}s"
+    },
+    "welcome": {
+      "availableCapabilities": "Available: {capabilities}",
+      "unavailableCapabilities": "Not available: {capabilities}"
     }
   },
   "settings": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -88,6 +88,10 @@
       "label": "Completado",
       "seconds": "Duró {seconds} s",
       "minutes": "Duró {minutes} min {seconds} s"
+    },
+    "welcome": {
+      "availableCapabilities": "Disponible: {capabilities}",
+      "unavailableCapabilities": "No disponible: {capabilities}"
     }
   },
   "settings": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -88,6 +88,10 @@
       "label": "Terminé",
       "seconds": "Durée : {seconds} s",
       "minutes": "Durée : {minutes} min {seconds} s"
+    },
+    "welcome": {
+      "availableCapabilities": "Disponible : {capabilities}",
+      "unavailableCapabilities": "Indisponible : {capabilities}"
     }
   },
   "settings": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -88,6 +88,10 @@
       "label": "完了",
       "seconds": "所要時間 {seconds} 秒",
       "minutes": "所要時間 {minutes} 分 {seconds} 秒"
+    },
+    "welcome": {
+      "availableCapabilities": "利用可能: {capabilities}",
+      "unavailableCapabilities": "利用不可: {capabilities}"
     }
   },
   "settings": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -88,6 +88,10 @@
       "label": "완료됨",
       "seconds": "{seconds}초 소요",
       "minutes": "{minutes}분 {seconds}초 소요"
+    },
+    "welcome": {
+      "availableCapabilities": "사용 가능: {capabilities}",
+      "unavailableCapabilities": "사용할 수 없음: {capabilities}"
     }
   },
   "settings": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -88,6 +88,10 @@
       "label": "Concluído",
       "seconds": "Levou {seconds} s",
       "minutes": "Levou {minutes} min {seconds} s"
+    },
+    "welcome": {
+      "availableCapabilities": "Disponível: {capabilities}",
+      "unavailableCapabilities": "Indisponível: {capabilities}"
     }
   },
   "settings": {

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -88,6 +88,10 @@
       "label": "Завершено",
       "seconds": "Заняло {seconds} с",
       "minutes": "Заняло {minutes} мин {seconds} с"
+    },
+    "welcome": {
+      "availableCapabilities": "Доступно: {capabilities}",
+      "unavailableCapabilities": "Недоступно: {capabilities}"
     }
   },
   "settings": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -88,6 +88,10 @@
       "label": "已完成",
       "seconds": "用时 {seconds} 秒",
       "minutes": "用时 {minutes} 分 {seconds} 秒"
+    },
+    "welcome": {
+      "availableCapabilities": "可用：{capabilities}",
+      "unavailableCapabilities": "暂不可用：{capabilities}"
     }
   },
   "settings": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -88,6 +88,10 @@
       "label": "已完成",
       "seconds": "耗時 {seconds} 秒",
       "minutes": "耗時 {minutes} 分 {seconds} 秒"
+    },
+    "welcome": {
+      "availableCapabilities": "可用：{capabilities}",
+      "unavailableCapabilities": "暫不可用：{capabilities}"
     }
   },
   "settings": {

--- a/src/style/components/messages.css
+++ b/src/style/components/messages.css
@@ -43,6 +43,40 @@
   letter-spacing: -0.01em;
 }
 
+.claudian-welcome-capability-summary {
+  box-sizing: border-box;
+  display: grid;
+  gap: 3px;
+  width: fit-content;
+  max-width: min(100%, 34rem);
+  margin-top: 4px;
+  padding: 10px 12px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 10px;
+  background: var(--background-secondary);
+  color: var(--text-muted);
+  font-size: var(--font-ui-small);
+  line-height: 1.5;
+  text-align: left;
+}
+
+.claudian-welcome-provider-name {
+  color: var(--text-normal);
+  font-weight: var(--font-semibold);
+  font-size: var(--font-ui-medium);
+  letter-spacing: 0.01em;
+}
+
+.claudian-welcome-capability-line--supported {
+  color: var(--text-muted);
+}
+
+.claudian-welcome-capability-line--unsupported {
+  padding-top: 3px;
+  border-top: 1px solid var(--background-modifier-border);
+  color: var(--text-faint);
+}
+
 .claudian-message {
   position: relative;
   padding: 10px 14px;

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -351,6 +351,34 @@ describe('ConversationController', () => {
       controller.initializeWelcome();
       expect(createDivSpy).toHaveBeenCalledTimes(initialCallCount);
     });
+
+    it('refreshes an existing summary after the blank tab changes provider', () => {
+      let providerName = 'Pi';
+      const capabilities = {
+        providerId: 'pi' as const,
+        supportsNativeHistory: false,
+        supportsPlanMode: false,
+        supportsRewind: false,
+        supportsFork: false,
+        supportsProviderCommands: false,
+        supportsImageAttachments: false,
+        supportsInstructionMode: false,
+        supportsMcpTools: false,
+        supportsTurnSteer: false,
+        reasoningControl: 'none' as const,
+      };
+      deps = createMockDeps({
+        getWelcomeProviderSummary: () => ({ displayName: providerName, capabilities }),
+      });
+      controller = new ConversationController(deps);
+
+      controller.initializeWelcome();
+      providerName = 'OMP';
+      controller.initializeWelcome();
+
+      expect(deps.getWelcomeEl()?.querySelector('.claudian-welcome-provider-name')?.textContent)
+        .toBe('OMP');
+    });
   });
 
   describe('formatDate', () => {

--- a/tests/unit/features/chat/rendering/WelcomeRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/WelcomeRenderer.test.ts
@@ -5,6 +5,23 @@ import {
   renderWelcomeContent,
 } from '@/features/chat/rendering/WelcomeRenderer';
 
+const PROVIDER_SUMMARY = {
+  displayName: 'Codex',
+  capabilities: {
+    providerId: 'codex' as const,
+    supportsNativeHistory: false,
+    supportsPlanMode: true,
+    supportsRewind: false,
+    supportsFork: true,
+    supportsProviderCommands: false,
+    supportsImageAttachments: true,
+    supportsInstructionMode: false,
+    supportsMcpTools: false,
+    supportsTurnSteer: false,
+    reasoningControl: 'none' as const,
+  },
+};
+
 describe('Welcome', () => {
   it('renders Oh My Claudian branding before the dynamic greeting', () => {
     const parentEl = createMockEl();
@@ -40,5 +57,17 @@ describe('Welcome', () => {
 
     expect(welcomeEl.children).toHaveLength(1);
     expect(welcomeEl.children[0].textContent).toBe('Oh My Claudian');
+  });
+
+  it('explains the current provider capabilities on an empty conversation', () => {
+    const parentEl = createMockEl();
+
+    const welcomeEl = createWelcomeElement(parentEl, undefined, PROVIDER_SUMMARY);
+
+    expect(welcomeEl.querySelector('.claudian-welcome-provider-name')?.textContent).toBe('Codex');
+    expect(welcomeEl.querySelector('.claudian-welcome-capability-line--supported')?.textContent)
+      .toContain('Plan mode · Fork · Image attachments');
+    expect(welcomeEl.querySelector('.claudian-welcome-capability-line--unsupported')?.textContent)
+      .toContain('Rewind · Provider commands · MCP tools · Turn steering');
   });
 });

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -364,7 +364,7 @@ describe('Tab provider execution ownership', () => {
     ));
     getEnabledProviderIds.mockReturnValue(['claude', 'codex']);
     resolveProviderForModel.mockImplementation((model: string) => (
-      model.startsWith('codex-') ? 'codex' : 'claude'
+      model.startsWith('codex-') ? 'pi' : 'claude'
     ));
     let rejectCodexSwitch!: (error: Error) => void;
     const codexSwitch = new Promise<void>((_resolve, reject) => {
@@ -374,6 +374,8 @@ describe('Tab provider execution ownership', () => {
     try {
       const plugin = createPlugin();
       const tab = createTab({ plugin, containerEl: createMockEl() as any });
+      const initializeWelcome = jest.fn();
+      tab.controllers.conversationController = { initializeWelcome } as any;
       initializeTabUI(tab, plugin, {
         onProviderChanged: () => codexSwitch,
       });
@@ -393,6 +395,7 @@ describe('Tab provider execution ownership', () => {
 
       expect(tab.providerId).toBe('codex');
       expect(tab.draftModel).toBe('codex-latest');
+      expect(initializeWelcome).toHaveBeenCalledTimes(1);
 
       rejectCodexSwitch(new Error('Codex initialization failed'));
       await new Promise<void>(resolve => setImmediate(resolve));


### PR DESCRIPTION
## Summary
- show the active provider's available and unavailable chat capabilities on blank conversations
- preserve provider identity through mixed model selection so similarly named models cannot switch to the wrong provider
- refresh the summary whenever a blank tab changes provider, with a theme-adaptive compact layout

## Validation
- pnpm run typecheck
- pnpm exec jest tests/unit/features/chat/controllers/ConversationController.test.ts tests/unit/features/chat/tabs/Tab.test.ts tests/unit/features/chat/ui/InputToolbar.test.ts tests/unit/features/chat/rendering/WelcomeRenderer.test.ts --runInBand
- pnpm run build