### PR TITLE
feat(chat): navigate input history with arrow keys

### DIFF
--- a/src/features/chat/tabs/InputHistoryController.ts
+++ b/src/features/chat/tabs/InputHistoryController.ts
@@ -1,0 +1,111 @@
+import type { ChatMessage } from '../../../core/types';
+import { isCanonicalUserMessage } from '../../../core/types';
+import { extractUserDisplayContent } from '../../../utils/context';
+import { dispatchComposerInputEvent } from '../ui/ComposerInputEvents';
+
+export interface InputHistoryControllerDeps {
+  getMessages: () => readonly ChatMessage[];
+  getConversationId: () => string | null;
+}
+
+type InputHistoryDirection = 'up' | 'down';
+
+function isHistoryNavigationKey(event: KeyboardEvent): boolean {
+  return (event.key === 'ArrowUp' || event.key === 'ArrowDown')
+    && !event.isComposing
+    && !event.altKey
+    && !event.ctrlKey
+    && !event.metaKey
+    && !event.shiftKey;
+}
+
+function isAtInputBoundary(input: HTMLTextAreaElement, direction: InputHistoryDirection): boolean {
+  const selectionStart = input.selectionStart;
+  const selectionEnd = input.selectionEnd;
+  if (selectionStart === null || selectionEnd === null || selectionStart !== selectionEnd) {
+    return false;
+  }
+
+  // A single-line composer has no useful vertical caret navigation, so both
+  // arrows should be available regardless of the horizontal caret position.
+  if (!input.value.includes('\n')) return true;
+
+  return direction === 'up'
+    ? selectionStart === 0
+    : selectionEnd === input.value.length;
+}
+
+function getInputHistory(messages: readonly ChatMessage[]): string[] {
+  return messages
+    .filter(isCanonicalUserMessage)
+    .map(message => message.displayContent
+      ?? extractUserDisplayContent(message.content)
+      ?? message.content)
+    .filter(content => content.trim().length > 0);
+}
+
+/** Navigates canonical user prompts while preserving the current composer draft. */
+export class InputHistoryController {
+  private readonly deps: InputHistoryControllerDeps;
+  private inputHistoryIndex: number | null = null;
+  private inputHistoryDraft = '';
+  private inputHistoryConversationId: string | null;
+  private restoringInputHistory = false;
+
+  constructor(deps: InputHistoryControllerDeps) {
+    this.deps = deps;
+    this.inputHistoryConversationId = deps.getConversationId();
+  }
+
+  handleKeydown(event: KeyboardEvent, input: HTMLTextAreaElement): boolean {
+    if (!isHistoryNavigationKey(event)) return false;
+
+    const direction = event.key === 'ArrowUp' ? 'up' : 'down';
+    if (!isAtInputBoundary(input, direction)) return false;
+
+    if (this.inputHistoryConversationId !== this.deps.getConversationId()) {
+      this.reset();
+    }
+
+    const history = getInputHistory(this.deps.getMessages());
+    if (history.length === 0) return false;
+
+    let nextIndex: number | null;
+    if (direction === 'up') {
+      if (this.inputHistoryIndex === null) {
+        this.inputHistoryDraft = input.value;
+        nextIndex = history.length - 1;
+      } else {
+        nextIndex = this.inputHistoryIndex - 1;
+        if (nextIndex < 0) return false;
+      }
+    } else {
+      if (this.inputHistoryIndex === null) return false;
+      nextIndex = this.inputHistoryIndex + 1;
+      if (nextIndex >= history.length) {
+        nextIndex = null;
+      }
+    }
+
+    this.inputHistoryIndex = nextIndex;
+    const nextValue = nextIndex === null ? this.inputHistoryDraft : history[nextIndex];
+    this.restoringInputHistory = true;
+    input.value = nextValue;
+    input.setSelectionRange?.(nextValue.length, nextValue.length);
+    dispatchComposerInputEvent(input);
+    this.restoringInputHistory = false;
+    event.preventDefault();
+    return true;
+  }
+
+  handleInput(): void {
+    if (this.restoringInputHistory) return;
+    this.reset();
+  }
+
+  reset(): void {
+    this.inputHistoryIndex = null;
+    this.inputHistoryDraft = '';
+    this.inputHistoryConversationId = this.deps.getConversationId();
+  }
+}

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -74,6 +74,7 @@ import { ScopePreview } from '../ui/ScopePreview';
 import { StatusPanel } from '../ui/StatusPanel';
 import { installTextareaSizing } from '../ui/textareaSizing';
 import { recalculateUsageForModel } from '../utils/usageInfo';
+import { InputHistoryController } from './InputHistoryController';
 import { getTabProviderId } from './providerResolution';
 import { initializeTabPresentationControllers } from './TabControllerFactory';
 import { createTabConversationController } from './TabConversationControllerFactory';
@@ -1953,6 +1954,10 @@ export const initializeTabControllers = initializeTabRuntimeControllers;
  */
 export function wireTabInputEvents(tab: TabData, plugin: FeatureHost): void {
   const { dom, ui, state, controllers } = tab;
+  const inputHistoryController = new InputHistoryController({
+    getMessages: () => state.messages,
+    getConversationId: () => state.currentConversationId,
+  });
 
   let wasBangBashActive = ui.bangBashModeManager?.isActive() ?? false;
   const syncBangBashSuppression = (): void => {
@@ -2002,6 +2007,10 @@ export function wireTabInputEvents(tab: TabData, plugin: FeatureHost): void {
       return;
     }
 
+    if (inputHistoryController.handleKeydown(e, dom.inputEl)) {
+      return;
+    }
+
     // Check !e.isComposing for IME support (Chinese, Japanese, Korean, etc.)
     if (e.key === 'Escape' && !e.isComposing && state.isStreaming) {
       e.preventDefault();
@@ -2027,6 +2036,7 @@ export function wireTabInputEvents(tab: TabData, plugin: FeatureHost): void {
   dom.eventCleanups.push(() => dom.inputEl.removeEventListener('keydown', keydownHandler));
 
   const inputHandler = () => {
+    inputHistoryController.handleInput();
     commitProvisionalTab(tab);
     if (!ui.bangBashModeManager?.isActive()) {
       ui.fileContextManager?.handleInputChange();

--- a/tests/unit/features/chat/tabs/InputHistoryController.test.ts
+++ b/tests/unit/features/chat/tabs/InputHistoryController.test.ts
@@ -1,0 +1,127 @@
+import { createMockEl } from '@test/helpers/MockElement';
+
+import type { ChatMessage } from '@/core/types';
+import { InputHistoryController } from '@/features/chat/tabs/InputHistoryController';
+
+function createKeyEvent(
+  key: string,
+  modifiers: Partial<Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>> = {},
+): KeyboardEvent & { preventDefault: jest.Mock } {
+  return {
+    altKey: false,
+    ctrlKey: false,
+    isComposing: false,
+    key,
+    metaKey: false,
+    preventDefault: jest.fn(),
+    shiftKey: false,
+    ...modifiers,
+  } as unknown as KeyboardEvent & { preventDefault: jest.Mock };
+}
+
+function createInput(): HTMLTextAreaElement {
+  const input = createMockEl('textarea') as unknown as HTMLTextAreaElement;
+  input.selectionStart = 0;
+  input.selectionEnd = 0;
+  input.setSelectionRange = jest.fn((start: number, end: number) => {
+    input.selectionStart = start;
+    input.selectionEnd = end;
+  });
+  return input;
+}
+
+function createMessage(
+  id: string,
+  content: string,
+  overrides: Partial<ChatMessage> = {},
+): ChatMessage {
+  return {
+    content,
+    id,
+    role: 'user',
+    timestamp: 1,
+    ...overrides,
+  };
+}
+
+describe('InputHistoryController', () => {
+  it('navigates sent user messages and restores the composer draft', () => {
+    const input = createInput();
+    const messages = [
+      createMessage('user-1', 'first request'),
+      createMessage('assistant-1', 'first response', { role: 'assistant' }),
+      createMessage('user-2', 'latest request'),
+    ];
+    const controller = new InputHistoryController({
+      getConversationId: () => 'conversation-1',
+      getMessages: () => messages,
+    });
+    input.value = 'unsent draft';
+    input.selectionStart = input.value.length;
+    input.selectionEnd = input.value.length;
+
+    const up = createKeyEvent('ArrowUp');
+    expect(controller.handleKeydown(up, input)).toBe(true);
+    expect(input.value).toBe('latest request');
+    expect(up.preventDefault).toHaveBeenCalled();
+
+    input.selectionStart = 0;
+    input.selectionEnd = 0;
+    controller.handleKeydown(createKeyEvent('ArrowUp'), input);
+    expect(input.value).toBe('first request');
+
+    input.selectionStart = input.value.length;
+    input.selectionEnd = input.value.length;
+    controller.handleKeydown(createKeyEvent('ArrowDown'), input);
+    expect(input.value).toBe('latest request');
+
+    input.selectionStart = input.value.length;
+    input.selectionEnd = input.value.length;
+    controller.handleKeydown(createKeyEvent('ArrowDown'), input);
+    expect(input.value).toBe('unsent draft');
+  });
+
+  it('resets navigation after manual input and ignores non-boundary or modified keys', () => {
+    const input = createInput();
+    const messages = [createMessage('user-1', 'previous request')];
+    const controller = new InputHistoryController({
+      getConversationId: () => 'conversation-1',
+      getMessages: () => messages,
+    });
+    input.value = 'current multiline\ntext';
+    input.selectionStart = 1;
+    input.selectionEnd = 1;
+
+    const middleUp = createKeyEvent('ArrowUp');
+    expect(controller.handleKeydown(middleUp, input)).toBe(false);
+    expect(middleUp.preventDefault).not.toHaveBeenCalled();
+
+    const modifiedUp = createKeyEvent('ArrowUp', { ctrlKey: true });
+    expect(controller.handleKeydown(modifiedUp, input)).toBe(false);
+
+    input.value = 'manual edit';
+    controller.handleInput();
+    input.selectionStart = 0;
+    input.selectionEnd = 0;
+    controller.handleKeydown(createKeyEvent('ArrowUp'), input);
+    expect(input.value).toBe('previous request');
+  });
+
+  it('skips interrupt and rebuilt-context user messages', () => {
+    const input = createInput();
+    const messages = [
+      createMessage('interrupt', 'interrupt', { isInterrupt: true }),
+      createMessage('rebuilt', 'rebuilt', { isRebuiltContext: true }),
+      createMessage('canonical', 'canonical request'),
+    ];
+    const controller = new InputHistoryController({
+      getConversationId: () => 'conversation-1',
+      getMessages: () => messages,
+    });
+    input.selectionStart = 0;
+    input.selectionEnd = 0;
+
+    controller.handleKeydown(createKeyEvent('ArrowUp'), input);
+    expect(input.value).toBe('canonical request');
+  });
+});


### PR DESCRIPTION
## What changed

- Add Up/Down arrow navigation for previously sent user prompts.
- Preserve and restore the unsent composer draft.
- Ignore IME composition, modified shortcuts, interrupt messages, and rebuilt context messages.
- Keep multiline caret navigation working away from input boundaries.

## Validation

- Typecheck passed
- Lint passed with 9 pre-existing warnings
- Full test suite passed: 7259 passed, 5 skipped
- Build passed